### PR TITLE
Display any non WCPay Subscriptions as manual renewal when the Subscriptions extension is deactivated

### DIFF
--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -621,7 +621,7 @@ class WC_Subscription extends WC_Order {
 	public function is_manual() {
 		$gateways_handler = WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class();
 
-		if ( WCS_Staging::is_duplicate_site() || true === $this->get_requires_manual_renewal() || false === $gateways_handler::get_subscription_payment_gateway( $this ) ) {
+		if ( WCS_Staging::is_duplicate_site() || true === $this->get_requires_manual_renewal() || false === $gateways_handler::has_available_payment_method( $this ) ) {
 			$is_manual = true;
 		} else {
 			$is_manual = false;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -619,8 +619,9 @@ class WC_Subscription extends WC_Order {
 	 * @return bool
 	 */
 	public function is_manual() {
+		$gateways_handler = WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class();
 
-		if ( WCS_Staging::is_duplicate_site() || true === $this->get_requires_manual_renewal() || false === wc_get_payment_gateway_by_order( $this ) ) {
+		if ( WCS_Staging::is_duplicate_site() || true === $this->get_requires_manual_renewal() || false === $gateways_handler::get_subscription_payment_gateway( $this ) ) {
 			$is_manual = true;
 		} else {
 			$is_manual = false;

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -257,10 +257,10 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	}
 
 	/**
-	 * Returns whether the subscription has an available payment gateway that's supported by `subscriptions-core1.
+	 * Returns whether the subscription has an available payment gateway that's supported by subscriptions-core.
 	 *
 	 * @since 1.0.0
-	 * @param WC_Subscription $subscription Subscription to get the gateway object from.
+	 * @param WC_Subscription $subscription Subscription to check if the gateway is available.
 	 * @return bool
 	 */
 	public static function has_available_payment_method( $subscription ) {

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -257,6 +257,19 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	}
 
 	/**
+	 * Returns the subscription payment gateway if it's supported by `subscriptions-core`
+	 * otherwise returns false.
+	 *
+	 * @since 1.0.0
+	 * @param WC_Subscription $subscription Subscription to get the gateway object from.
+	 * @return bool|WC_Payment_Gateway
+	 */
+	public static function get_subscription_payment_gateway( $subscription ) {
+		$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
+		return $payment_gateway && isset( $payment_gateway->id ) && 'woocommerce_payments' === $payment_gateway->id && method_exists( WC_Payments_Subscription_Service::class, 'is_wcpay_subscription' ) && WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ? $payment_gateway : false;
+	}
+
+	/**
 	 * Fire a gateway specific hook for when a subscription is activated.
 	 *
 	 * @since 1.0

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -257,16 +257,14 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	}
 
 	/**
-	 * Returns the subscription payment gateway if it's supported by `subscriptions-core`
-	 * otherwise returns false.
+	 * Returns whether the subscription has an available payment gateway that's supported by `subscriptions-core1.
 	 *
 	 * @since 1.0.0
 	 * @param WC_Subscription $subscription Subscription to get the gateway object from.
-	 * @return bool|WC_Payment_Gateway
+	 * @return bool
 	 */
-	public static function get_subscription_payment_gateway( $subscription ) {
-		$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
-		return $payment_gateway && isset( $payment_gateway->id ) && 'woocommerce_payments' === $payment_gateway->id && method_exists( WC_Payments_Subscription_Service::class, 'is_wcpay_subscription' ) && WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ? $payment_gateway : false;
+	public static function has_available_payment_method( $subscription ) {
+		return 'woocommerce_payments' === $subscription->get_payment_method() && method_exists( WC_Payments_Subscription_Service::class, 'is_wcpay_subscription' ) && WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ? true : false;
 	}
 
 	/**


### PR DESCRIPTION
Issue: #1
P2: pdjTHR-35-p2

### Description

When the Subscriptions extension is deactivated on a store and only core is loaded via WooCommerce Payments, tokenized Subscriptions will need to be displayed as manual renewal. This is because the payment processing triggered by the action scheduler is only part of the Subscriptions extension.

As part of the issue description (#1), James gave two options for implementing this and I decided to go with adding/overriding a condition within the `$subscriptions->is_manual()` function.

This new function in core (`WC_Subscriptions_Core_Payment_Gateways::get_subscription_payment_gateway()`) makes it so we only return a valid payment gateway if the gateway is WooCommerce Payments and it's a WCPay Subscription.

If it's not, the subscription will be Manual.

### Testing Instructions

The best way to test these changes is to simulate a store deactivating Subscriptions with active subscriptions (i.e. downgrading) and checking all tokenized subscriptions (non WCPay Subscriptions) appear as manual renewal:

1. Git clone `woocommerce-subscriptions-core` into wp-plugins and checkout this branch (this will make subscriptions 4.0+ and WC payments load `subscriptions-core` from this repo)
2. First activate the Subscriptions extension (this can be any subscriptions version, i.e. 3.1.4 (before core existence), trunk (before core), or `fix/core-issue-1` branch (has core changes), it doesn’t matter - any will work)
3. Activate and enable two payment gateways; WC Payments + Stripe
4. Purchase two subscriptions, one with each payment gateway
5. With the Subscriptions extension still activated, check both payments methods are displayed under the subscriptions on the table
6. Process renewals for both, confirm renewals are still created and processed
7. Deactivate Subscriptions extension and have WooCommerce Payments and Stripe enabled.
8. Visit the subscriptions table and notice both subscriptions will appear as manual renewal
9. Purchase a WCPay Subscription and make sure it appears as WooCommerce Payments
10. Reactivate Subscriptions extension, confirm the 3 subscriptions now have their payment methods displayed.

Closes #1 
