### PR TITLE
Deprecator handler and non static function call fixes to core

### DIFF
--- a/includes/abstracts/abstract-wcs-deprecated-functions-handler.php
+++ b/includes/abstracts/abstract-wcs-deprecated-functions-handler.php
@@ -74,7 +74,7 @@ abstract class WCS_Deprecated_Functions_Handler {
 				if ( is_array( $replacement[0] ) ) {
 					$instance = call_user_func( $replacement[0] );
 
-					return call_user_func( array( $instance, $replacement[1] ), $arguments );
+					return call_user_func_array( array( $instance, $replacement[1] ), $arguments );
 				} elseif ( get_class( $this ) === $replacement[0] ) {
 					return $this->{$replacement[1]}( ...$arguments );
 				}

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -224,7 +224,7 @@ class WC_Subscriptions_Core_Plugin {
 
 		// Add the "Settings | Documentation" links on the Plugins administration screen
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->get_plugin_file() ), array( $this, 'add_plugin_action_links' ) );
-		add_action( 'in_plugin_update_message-' . plugin_basename( $this->get_plugin_file() ), array( __CLASS__, 'update_notice' ), 10, 2 );
+		add_action( 'in_plugin_update_message-' . plugin_basename( $this->get_plugin_file() ), array( $this, 'update_notice' ), 10, 2 );
 
 		add_action( 'init', array( $this, 'activate_plugin' ) );
 

--- a/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
+++ b/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
@@ -33,10 +33,6 @@ class WC_Subscriptions_Deprecation_Handler extends WCS_Deprecated_Functions_Hand
 			'replacement' => array( __CLASS__, '_is_large_site' ),
 			'version'     => '2.0.0',
 		),
-		'get_total_subscription_count' => array(
-			'replacement' => array( __CLASS__, '_get_total_subscription_count' ),
-			'version'     => '2.0.0',
-		),
 		'get_subscription_status_counts' => array(
 			'replacement' => array( __CLASS__, '_get_subscription_status_counts' ),
 			'version'     => '2.0.0',
@@ -227,23 +223,6 @@ class WC_Subscriptions_Deprecation_Handler extends WCS_Deprecated_Functions_Hand
 	 */
 	protected function _is_large_site() {
 		return apply_filters( 'woocommerce_subscriptions_is_large_site', false );
-	}
-
-	/**
-	 * Deprecation handling of the original WC_Subscriptions::get_total_subscription_count() function.
-	 *
-	 * Not to be called directly.
-	 *
-	 * @deprecated
-	 */
-	protected function _get_total_subscription_count() {
-		static $total_subscription_count = null;
-
-		if ( null === $total_subscription_count ) {
-			$total_subscription_count = WC_Subscriptions::get_subscription_count();
-		}
-
-		return apply_filters( 'woocommerce_get_total_subscription_count', $total_subscription_count );
 	}
 
 	/**

--- a/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
+++ b/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
@@ -166,50 +166,50 @@ class WC_Subscriptions_Deprecation_Handler extends WCS_Deprecated_Functions_Hand
 			'version'     => '4.0.0',
 		),
 		'load_dependant_classes' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'init_version_dependant_classes' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'init_version_dependant_classes' ),
 			'version'     => '4.0.0',
 		),
 		'attach_dependant_hooks' => array(
 			'version' => '4.0.0',
 		),
 		'register_order_types' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'register_order_types' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'register_order_types' ),
 			'version'     => '4.0.0',
 		),
 		'add_data_stores' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'add_data_stores' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'add_data_stores' ),
 			'version'     => '4.0.0',
 		),
 		'register_post_status' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'register_post_statuses' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'register_post_statuses' ),
 			'version'     => '4.0.0',
 		),
 		'deactivate_woocommerce_subscriptions' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'deactivate_plugin' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'deactivate_plugin' ),
 			'version'     => '4.0.0',
 		),
 		'load_plugin_textdomain' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'load_plugin_textdomain' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'load_plugin_textdomain' ),
 			'version'     => '4.0.0',
 		),
 		'action_links' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'add_plugin_action_links' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'add_plugin_action_links' ),
 			'version'     => '4.0.0',
 		),
 		'update_notice' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'update_notice' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'update_notice' ),
 			'version'     => '4.0.0',
 		),
 		'setup_blocks_integration' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'setup_blocks_integration' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'setup_blocks_integration' ),
 			'version'     => '4.0.0',
 		),
 		'maybe_activate_woocommerce_subscriptions' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'activate_plugin' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'activate_plugin' ),
 			'version'     => '4.0.0',
 		),
 		'action_scheduler_multisite_batch_size' => array(
-			'replacement' => array( array( 'WC_Subscriptions_Plugin', 'instance' ), 'reduce_multisite_action_scheduler_batch_size' ),
+			'replacement' => array( array( 'WC_Subscriptions_Core_Plugin', 'instance' ), 'reduce_multisite_action_scheduler_batch_size' ),
 			'version'     => '4.0.0',
 		),
 	);


### PR DESCRIPTION
### Description

This PR is fixing a few things in WCS Core that I noticed today while browsing around my store and sifting through the code. I'll go through them one-by-one:

### 1. Update Subscriptions Plugin Notice

![](https://d.pr/i/W0vGKH+)

Since Subscriptions 3.1.5 was been released this week, the "Please update subscriptions plugin" notice on the plugins page is now being displayed with a PHP notice.

This issue is caused by a copy/paste error when we moved this functionality from the main Subscriptions extension to the core plugin file.

I've fixed this in 9a3ac3a.

#### Testing Instructions

1. Activate the Subscriptions extension and checkout `4-0-bleeding` branch
2. If you have WCS Core also activated, make sure you're on `trunk`
3. Visit the WP Admin > Plugins page and notice the above error.
4. Checkout this branch in core and refresh the page

### 2. Deprecated Handler Fixes

While looking through some code, I noticed a few issues with the deprecator handler in core:

- `deprecation-handlers/class-wc-subscriptions-deprecation-handler.php` was referencing `WC_Subscriptions_Plugin` which doesn't exist in WCS Core
  - While this is very unlikely to cause issues, referencing `WC_Subscriptions_Plugin` inside WCS Core should be avoided.
- `WC_Subscriptions_Deprecation_Handler::_get_total_subscription_count()` was referencing `WC_Subscriptions::get_subscription_count()` which doesn't exist
  - This function has been deprecated since 2.0.0 so it was removed entirely in 4.0.0 and therefore we can remove all deprecation handling for this function.
- The deprecator function (`call_replacement()`) isn't able to  properly handle calling `WC_Subscriptions_Core_Plugin::instance()->{called_function}() with multiple arguments.
   - This was caused by using `call_user_func` and passing an array of arguments.

#### Testing Instructions

1. Activate the Subscriptions extension and checkout 4-0-bleeding
2. Checkout WCS Core `trunk` (doesn't need to be installed to reproduce the bug)
2. Add the following test code to trigger the deprecation handler class to fire off
```
add_action( 'admin_footer', function() {
	WC_Subscriptions::update_notice( [ 'new_version' => '1.5.30' ], 'yoohoo' );
} );
```
3. Load any admin page and you should see the following fatal error:
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function WC_Subscriptions_Core_Plugin::update_notice(),
```
4. Checkout this branch of WCS core and try reproduce.