### PR TITLE
Filter the available payment methods when paying for a renewal and WCPay is active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-xx-xx - version x.x.x
+* Fix: Correctly show the available payment methods when paying for a subscription renewal order. PR#9
+
 2021-09-22 - version 0.1.0
 * New: Subscriptions Core first release

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -69,7 +69,11 @@ class WC_Subscriptions_Core_Payment_Gateways {
 			return $available_gateways;
 		}
 
-		if ( ! WC_Subscriptions_Cart::cart_contains_subscription() && ( ! isset( $_GET['order_id'] ) || ! wcs_order_contains_subscription( $_GET['order_id'] ) ) ) {
+		if (
+			! wcs_cart_contains_renewal() &&
+			! WC_Subscriptions_Cart::cart_contains_subscription() &&
+			( ! isset( $_GET['order_id'] ) || ! wcs_order_contains_subscription( $_GET['order_id'] ) )
+		) {
 			return $available_gateways;
 		}
 


### PR DESCRIPTION
Fixes WCPay's [#3102](https://github.com/Automattic/woocommerce-payments/issues/3102)

#### Changes proposed in this Pull Request

When WCPay is enabled, make sure the cart doesn't contain a renewal before returning the unfiltered payment methods.

All payment methods were being displayed when manually paying for a renewal. When WCPay is active, only WCPay methods should be displayed instead.

#### Testing instructions

1. Deactivate the **WC Subscriptions plugin**.
2. Activate another payment gateway like Stripe, PayPal or Square.
3. [Create a subscription manually via the admin](https://docs.woocommerce.com/document/subscriptions/add-or-modify-a-subscription/#section-1). It should automatically be a manual subscription.
4. [Create a pending parent order](https://docs.woocommerce.com/document/subscriptions/add-or-modify-a-subscription/#section-1) from the actions dropdown.
5. [Create a pending renewal order](https://docs.woocommerce.com/document/subscriptions/add-or-modify-a-subscription/#section-1) from the actions dropdown.
6. Attempt to pay for the renewal order.
7. WC Payments should be the only payment method option.

---

Closes https://github.com/Automattic/woocommerce-payments/issues/3102