### PR TITLE
Set the WC Subscriptions plugin version in core to 3.1.6 to not show the downgrade notice

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-xx-xx - version x.x.x
+* Fix: Don't show a downgrade notice when activating the WC Subscriptions extension after installing WCS Core. PR#7
+
 2021-09-22 - version 0.1.0
 * New: Subscriptions Core first release

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -17,7 +17,7 @@ class WC_Subscriptions_Core_Plugin {
 	 *
 	 * @var string
 	 */
-	protected $plugin_version = '4.0.0';
+	protected $plugin_version = '3.1.6';
 
 	/**
 	 * The subscription scheduler instance.


### PR DESCRIPTION
Fixes #7

### Description

There's an issue where if you have been using Subscriptions Core inside WooCommerce Payments,
and then install/activate the latest WC Subscriptions version, you'll see a notice that displays a warning that you've downgraded to an older major version of Subscriptions.

While this is technically true, it's not actually an appropriate warning to show store managers that have purchased our WC Subscriptions, after using Subscriptions in WCPay.

As mentioned on the issue, this warning is outdated and is from the days when we were more worried about stores that
downgrade back to v1.5 after upgrading to 2.0 (which migrated subscriptions from an array in order meta to its own post type).

We could add a condition to only show this notice if stores have downgraded from 1.5, but this won't actually stop this notice from showing when stores download the WC Subscriptions extension because this new condition won't be in that codebase.

Therefore the best fix is to just updated the WC Subscriptions plugin version that we have stored.

### Testing Instructions

On `trunk`:

1. Make sure WC Subscriptions extension is deactivated
2. Download Subscriptions Core as a plugin and checkout `trunk`
3. Delete the `woocommerce_subscriptions_active_version` row from options table
3. Activate WC Payments and refresh the page (to make sure the subscriptions setup/upgrade process has finished)
4. Then activate the WC Subscriptions extension
5. You will see a warning to say you've downgraded

On `fix/issue-7`:
1. Make sure WC Subscriptions extension is deactivated
2. Download Subscriptions Core as a plugin and checkout `fix/issue-7`
3. Delete the `woocommerce_subscriptions_active_version` row from options table
3. Activate WC Payments and refresh the page (to make sure the subscriptions setup/upgrade process has finished)
4. Then activate the WC Subscriptions extension
5. No downgrade warning

---

Closes #7