### PR TITLE
Remove welcome notification after installing/activating subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2021-xx-xx - version x.x.x
 * Fix: Don't show a downgrade notice when activating the WC Subscriptions extension after installing WCS Core. PR#7
 * Fix: Correctly show the available payment methods when paying for a subscription renewal order. PR#9
+* Fix: Don't show the WC Subscriptions extension welcome/installation message after installing WCS Core. PR#11
 
-2021-09-22 - version 0.1.0
+2021-09-22 - version 1.0.0
 * New: Subscriptions Core first release

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2021-xx-xx - version x.x.x
+* Fix: Don't show a downgrade notice when activating the WC Subscriptions extension after installing WCS Core. PR#7
 * Fix: Correctly show the available payment methods when paying for a subscription renewal order. PR#9
 
 2021-09-22 - version 0.1.0

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -906,7 +906,7 @@ class WC_Subscriptions_Admin {
 			}
 		}
 
-		if ( $is_woocommerce_screen || $is_activation_screen || 'edit-product' == $screen->id || ( isset( $_GET['page'], $_GET['tab'] ) && 'wc-reports' === $_GET['page'] && 'subscriptions' === $_GET['tab'] ) ) {
+		if ( $is_woocommerce_screen || 'edit-product' == $screen->id || ( isset( $_GET['page'], $_GET['tab'] ) && 'wc-reports' === $_GET['page'] && 'subscriptions' === $_GET['tab'] ) ) {
 			wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() );
 			wp_enqueue_style( 'woocommerce_subscriptions_admin', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/css/admin.css' ), array( 'woocommerce_admin_styles' ), WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() );
 		}

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -816,7 +816,6 @@ class WC_Subscriptions_Admin {
 		$screen = get_current_screen();
 
 		$is_woocommerce_screen = in_array( $screen->id, array( 'product', 'edit-shop_order', 'shop_order', 'edit-shop_subscription', 'shop_subscription', 'users', 'woocommerce_page_wc-settings' ) );
-		$is_activation_screen  = (bool) get_transient( WC_Subscriptions_Core_Plugin::instance()->get_activation_transient() );
 
 		if ( $is_woocommerce_screen ) {
 
@@ -905,31 +904,6 @@ class WC_Subscriptions_Admin {
 
 				wp_enqueue_style( 'wp-pointer' );
 			}
-		}
-
-		// Maybe add the admin notice
-		if ( $is_activation_screen ) {
-
-			$woocommerce_plugin_dir_file = self::get_woocommerce_plugin_dir_file();
-
-			// check if subscription products exist in the store
-			$subscription_product = wc_get_products(
-				array(
-					'type'   => array( 'subscription', 'variable-subscription' ),
-					'limit'  => 1,
-					'return' => 'ids',
-				)
-			);
-
-			if ( ! empty( $woocommerce_plugin_dir_file ) && 0 == count( $subscription_product ) ) {
-
-				wp_enqueue_style( 'woocommerce-activation', plugins_url( '/assets/css/activation.css', $woocommerce_plugin_dir_file ), array(), WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() );
-
-				if ( ! isset( $_GET['page'] ) || 'wcs-about' != $_GET['page'] ) {
-					add_action( 'admin_notices', __CLASS__ . '::admin_installed_notice' );
-				}
-			}
-			delete_transient( WC_Subscriptions_Core_Plugin::instance()->get_activation_transient() );
 		}
 
 		if ( $is_woocommerce_screen || $is_activation_screen || 'edit-product' == $screen->id || ( isset( $_GET['page'], $_GET['tab'] ) && 'wc-reports' === $_GET['page'] && 'subscriptions' === $_GET['tab'] ) ) {
@@ -1255,48 +1229,6 @@ class WC_Subscriptions_Admin {
 		if ( isset( $field_details['desc'] ) && $field_details['desc'] ) {
 			echo wp_kses_post( wpautop( wptexturize( $field_details['desc'] ) ) );
 		}
-	}
-
-	/**
-	 * Outputs a welcome message. Called when the Subscriptions extension is activated.
-	 *
-	 * @since 1.0
-	 */
-	public static function admin_installed_notice() {
-		?>
-		<div id="message" class="updated woocommerce-message wc-connect woocommerce-subscriptions-activated">
-			<div class="squeezer">
-				<h4>
-					<?php
-					echo wp_kses(
-						sprintf(
-							// translators: $1-$2: opening and closing <strong> tags, $3-$4: opening and closing <em> tags
-							__(
-								'%1$sWooCommerce Subscriptions Installed%2$s &#8211; %3$sYou\'re ready to start selling subscriptions!%4$s',
-								'woocommerce-subscriptions'
-							),
-							'<strong>',
-							'</strong>',
-							'<em>',
-							'</em>'
-						),
-						array(
-							'strong' => true,
-							'em'     => true,
-						)
-					);
-					?>
-				</h4>
-
-				<p class="submit">
-					<a href="<?php echo esc_url( self::add_subscription_url() ); ?>" class="button button-primary"><?php esc_html_e( 'Add a Subscription Product', 'woocommerce-subscriptions' ); ?></a>
-					<a href="<?php echo esc_url( self::settings_tab_url() ); ?>" class="docs button button-primary"><?php esc_html_e( 'Settings', 'woocommerce-subscriptions' ); ?></a>
-					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://www.woocommerce.com/products/woocommerce-subscriptions/" data-text="Woot! I can sell subscriptions with #WooCommerce" data-via="WooCommerce" data-size="large">Tweet</a>
-					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-				</p>
-			</div>
-		</div>
-		<?php
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -287,6 +287,15 @@ class WC_Subscriptions_Core_Plugin {
 	}
 
 	/**
+	 * Gets the activation transient name.
+	 *
+	 * @return string The transient name used to record when the plugin was activated.
+	 */
+	public function get_activation_transient() {
+		return 'woocommerce_subscriptions_activated';
+	}
+
+	/**
 	 * Gets the core Payment Gateways handler class
 	 *
 	 * @since 4.0.0
@@ -468,6 +477,8 @@ class WC_Subscriptions_Core_Plugin {
 			}
 
 			update_option( WC_Subscriptions_Admin::$option_prefix . '_is_active', true );
+
+			set_transient( $this->get_activation_transient(), true, 60 * 60 );
 
 			flush_rewrite_rules();
 

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -17,7 +17,7 @@ class WC_Subscriptions_Core_Plugin {
 	 *
 	 * @var string
 	 */
-	protected $plugin_version = '4.0.0';
+	protected $plugin_version = '3.1.6';
 
 	/**
 	 * The subscription scheduler instance.

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -287,15 +287,6 @@ class WC_Subscriptions_Core_Plugin {
 	}
 
 	/**
-	 * Gets the activation transient name.
-	 *
-	 * @return string The transient name used to record when the plugin was activated.
-	 */
-	public function get_activation_transient() {
-		return 'woocommerce_subscriptions_activated';
-	}
-
-	/**
 	 * Gets the core Payment Gateways handler class
 	 *
 	 * @since 4.0.0
@@ -477,8 +468,6 @@ class WC_Subscriptions_Core_Plugin {
 			}
 
 			update_option( WC_Subscriptions_Admin::$option_prefix . '_is_active', true );
-
-			set_transient( $this->get_activation_transient(), true, 60 * 60 );
 
 			flush_rewrite_rules();
 

--- a/includes/gateways/paypal/includes/admin/class-wcs-paypal-admin.php
+++ b/includes/gateways/paypal/includes/admin/class-wcs-paypal-admin.php
@@ -95,7 +95,7 @@ class WCS_PayPal_Admin {
 
 		$valid_paypal_currency = in_array( get_woocommerce_currency(), apply_filters( 'woocommerce_paypal_supported_currencies', array( 'AUD', 'BRL', 'CAD', 'MXN', 'NZD', 'HKD', 'SGD', 'USD', 'EUR', 'JPY', 'TRY', 'NOK', 'CZK', 'DKK', 'HUF', 'ILS', 'MYR', 'PHP', 'PLN', 'SEK', 'CHF', 'TWD', 'THB', 'GBP', 'RMB' ) ) );
 
-		if ( ! $valid_paypal_currency || ! current_user_can( 'manage_options' ) || has_action( 'admin_notices', 'WC_Subscriptions_Admin::admin_installed_notice' ) || 'yes' !== WCS_PayPal::get_option( 'enabled' ) ) {
+		if ( ! $valid_paypal_currency || ! current_user_can( 'manage_options' ) || 'yes' !== WCS_PayPal::get_option( 'enabled' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #8

#### Changes proposed in this Pull Request
Completely remove the message that shows up right after installing/activating the subscription plugin 

#### Testing instructions
- Install a fresh Wordpress install with WC Payments plugin
- Install subscriptions-core
- Activate subscriptions using WC Pay Dev tools
- This message should **not** show

<img width="1183" alt="135557328-536501a7-73b2-4b1c-8d51-2ebaed860d3b" src="https://user-images.githubusercontent.com/6342964/137370065-54a6f09e-ba99-458c-993d-90c7c80a4006.png">

After merging this we will need to bump the Subscriptions core version at https://github.com/Automattic/woocommerce-payments/issues/3024