### PR TITLE
Don't redirect customers to a Welcome to Subscriptions 2.1 about us page... ever

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@
 * Fix: Correctly show the available payment methods when paying for a subscription renewal order. PR#9
 * Fix: Don't show the WC Subscriptions extension welcome/installation message after installing WCS Core. PR#11
 * Fix: Remove the "Welcome to Subscriptions" notice that is displayed upon upgrading from previous minor versions. PR#14
+* Fix: Don't display a "Welcome to Subscriptions 2.1" for stores that have upgraded from really old version of Subscriptions. PR#16
+* Fix: Errors during the upgrade process for stores that are upgrading from very old versions of Subscriptions (1.5.0). PR#16
 
 2021-09-22 - version 1.0.0
 * New: Subscriptions Core first release

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -46,7 +46,7 @@ class WC_Subscriptions_Upgrader {
 
 		self::$is_wc_version_2 = version_compare( get_option( 'woocommerce_db_version' ), '2.0', '>=' );
 
-		self::$about_page_url = admin_url( 'index.php?page=wcs-about&wcs-updated=true' );
+		self::$about_page_url = admin_url( 'admin.php?page=wc-admin' );
 
 		$version_out_of_date = version_compare( self::$active_version,  WC_Subscriptions_Core_Plugin::instance()->get_plugin_version(), '<' );
 

--- a/includes/upgrades/class-wcs-upgrade-1-2.php
+++ b/includes/upgrades/class-wcs-upgrade-1-2.php
@@ -67,7 +67,7 @@ class WCS_Upgrade_1_2 {
 			$cart_discount = $order->get_total_discount();
 			update_post_meta( $order_id, '_order_recurring_discount_cart', $cart_discount );
 
-			$order_discount = $order->get_order_discount();
+			$order_discount = $order->get_total_discount();
 			update_post_meta( $order_id, '_order_recurring_discount_total', $order_discount );
 
 			$order_shipping_tax = get_post_meta( $order_id, '_order_shipping_tax', true );

--- a/includes/upgrades/templates/wcs-upgrade.php
+++ b/includes/upgrades/templates/wcs-upgrade.php
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<h2><?php esc_html_e( 'Update in Progress', 'woocommerce-subscriptions' ); ?></h2>
 			<p><?php esc_html_e( 'This page will display the results of the process as each batch of subscriptions is updated.', 'woocommerce-subscriptions' ); ?></p>
 			<p><?php esc_html_e( 'Please keep this page open until the update process completes. No need to refresh or restart the process.', 'woocommerce-subscriptions' ); ?></p>
-			<?php if ( $estimated_duration > 20 ) : ?>
+			<?php if ( isset( $estimated_duration ) && $estimated_duration > 20 ) : ?>
 			<p><?php esc_html_e( 'Remember, although the update process may take a while, customers and other non-administrative users can browse and purchase from your store without interruption while the update is in progress.', 'woocommerce-subscriptions' ); ?></p>
 			<?php endif; ?>
 			<ol>


### PR DESCRIPTION
#### Description

If a store is using a really old version of Subscriptions (i.e. 1.5.0), or once had a very old version of subscriptions and then stopped using our extension, when they update to WC Payments 3.2 (which will come with Subscriptions 3.1.6) they'll see a "Welcome to Subscriptions 2.1" page 🙈 

![image](https://user-images.githubusercontent.com/2275145/138403096-fadbd5e0-715c-4d99-b9a8-748ad6e64218.png)

Now that we're in version 3.1.6, we never want to show this page to customers so in this PR I've change the upgrade process to redirect customers to the **WooCommerce > Home** page.

#### Testing Instructions

1. Make sure WC Subscriptions extension is deactivated and WC Payments is activated
2. With `woocommerce-subscriptions-core` plugin activated, checkout this branch
3. Set `woocommerce_subscriptions_previous_version` to `1.1.0` and `woocommerce_subscriptions_active_version` to `1.5.0` to trigger all the upgrade processes from running
4. Try to visit any WP Admin page and you'll see an upgrade database prompt
5. Continue through the upgrade process
6. Once complete, click `Continue`
7. You should be redirected to the WooCommerce Home page
8. On `trunk` you'll see some fatal errors (fixed in this PR) but once those are addressed you'll be redirected to the Subscriptions 2.1 landing page