### PR TITLE
Move checkout blocks loading to init rather than 'plugins_loaded'

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix: Remove the "Welcome to Subscriptions" notice that is displayed upon upgrading from previous minor versions. PR#14
 * Fix: Don't display a "Welcome to Subscriptions 2.1" for stores that have upgraded from really old version of Subscriptions. PR#16
 * Fix: Errors during the upgrade process for stores that are upgrading from very old versions of Subscriptions (1.5.0). PR#16
+* Fix: Show subscription billing information (recurring cart totals, sign up fees etc) on the WooCommerce Checkout block. PR#18
 
 2021-09-22 - version 1.0.0
 * New: Subscriptions Core first release

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -150,6 +150,12 @@ class WC_Subscriptions_Core_Plugin {
 
 		// Initialise the cache.
 		$this->cache = WCS_Cache_Manager::get_instance();
+
+		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '4.4.0', '>' ) ) {
+			// When WooCommerceBlocks is loaded, set up the Integration class.
+			add_action( 'woocommerce_blocks_loaded', array( $this, 'setup_blocks_integration' ) );
+			add_action( 'woocommerce_blocks_loaded', array( 'WC_Subscriptions_Extend_Store_Endpoint', 'init' ) );
+		}
 	}
 
 	/**
@@ -190,12 +196,6 @@ class WC_Subscriptions_Core_Plugin {
 		// Only load privacy handling on WC applicable versions.
 		if ( class_exists( 'WC_Abstract_Privacy' ) ) {
 			new WCS_Privacy();
-		}
-
-		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '4.4.0', '>' ) ) {
-			// When WooCommerceBlocks is loaded, set up the Integration class.
-			add_action( 'woocommerce_blocks_loaded', array( $this, 'setup_blocks_integration' ) );
-			add_action( 'woocommerce_blocks_loaded', array( 'WC_Subscriptions_Extend_Store_Endpoint', 'init' ) );
 		}
 	}
 


### PR DESCRIPTION
WC Subscriptions previously used to have the blocks integration code loaded at the top of the plugin file (here). When we split the main plugin file into the two plugin classes for `core`, however, it incorrectly got moved into the function that runs on plugin loaded, which is too late for the blocks hook as it has already run.

This commit fixes that issue by making sure we attach the block hooks on init.

### Testing instructions:

1. Checkout the latest `trunk` of subscriptions-core
2. Add the [WooCommerce blocks plugin](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
3. Create a checkout and cart block.
   - **WP > Pages > New**
   -  Add the `/checkout` block 
   - Save
4. Add a subscription product to the cart.
5. View the checkout block. 
6. On `trunk` you should see no recurring information. See screenshots below.
7. Checkout this branch. 
8. The recurring information should reappear. 

**Before -> After**
<img width="938" alt="Screen Shot 2021-10-25 at 9 47 51 am" src="https://user-images.githubusercontent.com/8490476/138617681-a3f34eed-52b5-413c-8bf3-5412d4730b59.png">

Closes https://github.com/Automattic/woocommerce-payments/issues/3174

