### PR TITLE
Fix payment method not updated in subscriptions via "Default payment method"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-xx-xx - version 1.x.x
+* Fix: Payment method not updated for all subscriptions when done via "Default payment method". PR#19
+
 2021-10-22 - version 1.0.1
 * Fix: Don't show a downgrade notice when activating the WC Subscriptions extension after installing WCS Core. PR#7
 * Fix: Correctly show the available payment methods when paying for a subscription renewal order. PR#9

--- a/includes/class-wcs-payment-tokens.php
+++ b/includes/class-wcs-payment-tokens.php
@@ -58,7 +58,13 @@ class WCS_Payment_Tokens extends WC_Payment_Tokens {
 			$payment_meta_table = self::get_subscription_payment_meta( $subscription, $new_token_payment_gateway );
 
 			if ( is_array( $payment_meta_table ) ) {
-				WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $subscription, $new_token->get_gateway_id(), $payment_meta_table );
+				if ( $new_token_payment_gateway === $token_payment_gateway ) {
+					// Update the token alone if both tokens belong to the same gateway.
+					$subscription->set_payment_method( $gateway_instance, $payment_meta_table );
+					$subscription->save();
+				} else {
+					WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $subscription, $new_token->get_gateway_id(), $payment_meta_table );
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes WCPay's [#3171](https://github.com/Automattic/woocommerce-payments/issues/3171)

#### Changes proposed in this Pull Request

When updating the payment method of all subscriptions as a shopper via My Account -> Payment methods -> Make default:

* Add the selected token to the token list of the subscription
* If both the old and new token belong to the same gateway, update the token in the subscription
* If the old and new token belongs to different gateways, update the subscription's payment method to the new one

#### Testing instructions

1. As a shopper, purchase a subscription with a test payment method
2. Purchase another subscription with a different payment method
3. Go to My Account -> Payment Methods and select "Make default" on a payment method
4. Click "Yes" in the "Would you like to update your subscriptions to use this new payment method - xxxx ending in xxxx (expires xx/xx)?"
5. Go to My Account -> Subscriptions
6. Opposite to step 6 on the related issue, notice that payment methods associated with the subscriptions are updated

To test that the payment for the subscription does use the updated payment method:
1. As a shopper, purchase a subscription with a test payment method
2. As an admin, enable Billing clocks in WCPay Dev Tools if not enabled already
3. As an admin, go to the newly added subscription (WooCommerce -> Subscription -> "Edit" on the latest subscription)  and enable Dev Testing Mode
4. Log in as incognito with the newly created user for the subscription to proceed as a shopper
5. Follow the testing steps mentioned before, starting from step 2
6. As an admin, go edit the subscription. Advance the billing clocks until you trigger the `invoice.paid` event
7. View the subscription in Stripe, and under "Invoices" go to the latest invoice (it should show up as "paid")
8. In the invoice's details, under "Payment method", check that the details match the payment method you selected in the store as a shopper
![image](https://user-images.githubusercontent.com/41606954/138750661-2a364429-07d7-4883-bf48-09afac448909.png)
