### PR TITLE
Remove tooltip mentioning WC Subscriptions in WCPay

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -563,7 +563,8 @@ table.wp-list-table .subscription_renewal_order:after {
     color: #a46497;
 }
 
-table.wc_gateways .renewals .tips{
+table.wc_gateways .renewals .tips,
+table.wc_gateways .renewals .status-enabled {
     margin: 0 0.2em;
     display: inline-block;
 }

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1599,7 +1599,13 @@ class WC_Subscriptions_Admin {
 	public static function payment_gateways_renewal_support( $gateway ) {
 		echo '<td class="renewals">';
 		if ( ( is_array( $gateway->supports ) && in_array( 'subscriptions', $gateway->supports ) ) || $gateway->id == 'paypal' ) {
-			$status_html = '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Supports automatic renewal payments with the WooCommerce Subscriptions extension.', 'woocommerce-subscriptions' ) . '">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
+
+			// Don't display the tooltip when Subscriptions are powered by WCPay instead of WC Subscriptions.
+			if ( class_exists( 'WC_Subscriptions' ) ) {
+				$status_html = '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Supports automatic renewal payments with the WooCommerce Subscriptions extension.', 'woocommerce-subscriptions' ) . '">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
+			} else {
+				$status_html = '<span class="status-enabled">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
+			}
 		} else {
 			$status_html = '-';
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/3234

#### Changes proposed in this Pull Request

* Remove the "tips" class and the tooltip data-attribute from the "enabled" span when Subscriptions is powered by WCPay instead of WC Subscriptions
* Update the CSS rule targeting this span so it doesn't look off when it doesn't have a tooltip

#### Testing instructions

**Scenario 1 - WooCommerce Subscriptions not installed**

* Ensure WooCommerce Subscriptions is not installed.
* Navigate to WooCommerce → Settings → Payments.
* Hover the checkmark icon in the "Automatic Recurring Payments" column next to WooCommerce Payments.
Observe no tooltip is shown.

**Scenario 2 - WooCommerce Subscriptions installed and active**

* Ensure WooCommerce Subscriptions is installed and active.
* Navigate to WooCommerce → Settings → Payments.
* Hover the checkmark icon in the "Automatic Recurring Payments" column next to WooCommerce Payments.
* Observe a tooltip is visible and reads "Supports automatic renewal payments with the WooCommerce Subscriptions extension."

Regarding this scenario, WC Subscriptions would supersede the woocommerce-subscriptions-core plugin, from what I've understood. So activating WC Subscriptions won't really put this change into test if you're testing using the woocommerce-subscriptions-core as a plugin. I'd dig on how to integrate this change into WC Subscriptions to actually test it having the plugin enabled, but I reckon the reviewer from Helix probably knows. I'd be glad to check that out and include it in the instructions either way!