### PR TITLE
Remove trailing comma in function arguments.

### DIFF
--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1019,7 +1019,7 @@ class WC_Subscriptions_Cart {
 						'carts_with_multiple_payments' => $carts_with_multiple_payments,
 					),
 					'',
-					WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' ),
+					WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
 				);
 			}
 

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -288,7 +288,7 @@ class WC_Subscriptions_Email {
 				'order_items_table_args' => $order_items_table_args,
 			),
 			'',
-			WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' ),
+			WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
 		);
 	}
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -852,7 +852,7 @@ class WC_Subscriptions_Order {
 					'subscriptions' => $subscriptions,
 				),
 				'',
-				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' ),
+				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
 			);
 		}
 	}
@@ -874,7 +874,7 @@ class WC_Subscriptions_Order {
 					'subscription'        => $subscription,
 				),
 				'',
-				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' ),
+				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
 			);
 		}
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-payments/issues/3244

Remove trailing comma in function arguments to avoid PHP fatal error for sites with by PHP 7.2.

Testing instructions.

I can't think of other easy and sure way to confirm that I get all the trailing commas than this way:
1. Load this PR's subscription-core change from [woocommerce-payments](https://github.com/Automattic/woocommerce-payments).
Change this line in [woocommerce-payments' composer.json](https://github.com/Automattic/woocommerce-payments/blob/develop/composer.json):
```
"woocommerce/subscriptions-core": "1.0.1"
```
to
```
"woocommerce/subscriptions-core": "dev-fix/fatal-error-trailing-comma-function-args"
```
Then, run `composer update`.
Confirm that the changes from this PR present in the `vendor/woocommerce/subscriptions-core`, for example `vendor/woocommerce/subscriptions-core/includes/class-wc-subscriptions-cart.php` on line 1022 should not have trailing comma.

2. Change [woocommerce-payments' phpcs.xml.dist](https://github.com/Automattic/woocommerce-payments/blob/develop/phpcs.xml.dist) locally.
Remove
```
<exclude-pattern>./vendor/*</exclude-pattern>
```

3. Run `phpcs` on `vendor/woocommerce/subscriptions-core` files:
```
./vendor/bin/phpcs --standard=phpcs.xml.dist $(find ./vendor/woocommerce/subscriptions-core -name '*.php')
```
There will be a lot of errors and warnings. That's OK.

4. With base branch, expect there are 4 `PHPCompatibility.Syntax.NewFunctionCallTrailingComma.FoundInFunctionCall` errors.
With head branch, there shouldn't be that error at all.

To load subscriptions-core's trunk, change this line in [woocommerce-payments' composer.json](https://github.com/Automattic/woocommerce-payments/blob/develop/composer.json):
```
"woocommerce/subscriptions-core": "1.0.1"
```
to
```
"woocommerce/subscriptions-core": "dev-trunk"
```
to load this PR's head branch, change that line to:
```
"woocommerce/subscriptions-core": "dev-fix/fatal-error-trailing-comma-function-args"
```
Then, run `composer update`.