### PR TITLE
don't initialise WCS_PayPal - PayPal gateway is not supported

### DIFF
--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -16,8 +16,6 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	 */
 	public static function init() {
 
-		add_action( 'init', array( get_called_class(), 'init_paypal' ), 5 ); // run before default priority 10 in case the site is using ALTERNATE_WP_CRON to avoid https://core.trac.wordpress.org/ticket/24160.
-
 		add_filter( 'woocommerce_available_payment_gateways', array( get_called_class(), 'get_available_payment_gateways' ) );
 
 		add_filter( 'woocommerce_no_available_payment_methods_message', array( get_called_class(), 'no_available_payment_methods_message' ) );
@@ -26,15 +24,6 @@ class WC_Subscriptions_Core_Payment_Gateways {
 
 		// Create a gateway specific hooks for subscription events.
 		add_action( 'woocommerce_subscription_status_updated', array( get_called_class(), 'trigger_gateway_status_updated_hook' ), 10, 2 );
-	}
-
-	/**
-	 * Instantiate our custom PayPal class
-	 *
-	 * @since 2.0
-	 */
-	public static function init_paypal() {
-		WCS_PayPal::init();
 	}
 
 	/**


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-payments/issues/3245

This PR removes code to initialise PayPal specific functionality. 

WC Pay Subscriptions only supports WooCommerce Payments gateway. So PayPal is not supported and PayPal related code should not be loaded by default. 

In this PR I've simply removed the call to `WCS_PayPal::init();`. We may need to add this back in WC Subscriptions repo, or alternatively add a filter to allow it to be disabled in WC Pay. 
