### PR TITLE
Fix the error caused by getting plugin version during PayPal request 

### DIFF
--- a/includes/gateways/paypal/class-wcs-paypal.php
+++ b/includes/gateways/paypal/class-wcs-paypal.php
@@ -627,7 +627,7 @@ class WCS_PayPal {
 	}
 
 	public function get_version() {
-		return WC_Subscriptions::$version;
+		return WC_Subscriptions_Core_Plugin::instance()->get_plugin_version();
 	}
 
 	public function get_id() {


### PR DESCRIPTION
### Description

Fixes https://github.com/Automattic/woocommerce-payments/issues/3245 
Closes #24 
^ alternative PR

See this comment https://github.com/Automattic/woocommerce-subscriptions-core/pull/24#issuecomment-954276478 about the two possible approaches to fix this error.

When sending PayPal related requests we get the subscriptions plugin version in `WCS_PayPal::get_version()`. That function was using `WC_Subscriptions::$version` though and that class doesn't exist on WC Pay Subscription installs. That would lead to the following error:

```
PHP Fatal error:  Uncaught Error: Class 'WC_Subscriptions' not found in /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce-payments/vendor/woocommerce/subscriptions-core/includes/gateways/paypal/class-wcs-paypal.php:630
Stack trace:
#0 /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce-payments/vendor/woocommerce/subscriptions-core/includes/gateways/paypal/includes/abstracts/abstract-wcs-sv-api-base.php(413): WCS_PayPal->get_version()
#1 /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce-payments/vendor/woocommerce/subscriptions-core/includes/gateways/paypal/includes/abstracts/abstract-wcs-sv-api-base.php(323): WCS_SV_API_Base->get_request_user_agent()
#2 /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce-payments/vendor/woocommerce/subscriptions-core/includes/gateways/paypal/includes/abstracts/abstract-wcs-sv-api-base.php(105): WCS_SV_API_Base->get_request_args()
#3 /Users/jamesallan/ in /Users/jamesallan/local-dev/wcsstripebilling/app/public/wp-content/plugins/woocommerce-payments/vendor/woocommerce/subscriptions-core/includes/gateways/paypal/class-wcs-paypal.php on line 630
```

This PR fixes that.

#### Steps to test:

1. Install this Subscriptions core library like a plugin on your store.
2. Deactivate the WC Subscriptions plugin.
3. Delete any `wcs_paypal_rt_enabled_accounts` option in your `wp_options` database table.
     - This is a cache of accounts we've previously confirmed the account status on. Deleting it will force the request to PayPal to be resent.
3. Install the latest version of WC Payments. 
4. Go to **WooCommerce > Settings > Payments > All payment methods**
5. Enable PayPal Standard. 
    - If PayPal Standard doesn't appear in the list of gateways, see the note below.
    - You will need to enter credentials in order to replicate the error. Find a set of credentials in Secret Store or _reach out if you want me to send you some._ 
6. Observe the error above.

**Note!** if you don't have PayPal Standard being shown in the Payment gateway list you may have a fresh site created after WooCommerce 5.5 when PayPal Standard stopped being loaded by default. You can use the snippet below to load PayPal Standard on your site.

```php
add_filter( 'woocommerce_should_load_paypal_standard', '__return_true' );
```
