### PR TITLE
Limit period intervals when creating a product to "1" when the period is set to "year" 

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -373,6 +373,18 @@ jQuery( function( $ ) {
 
 			$( '#_subscription_one_time_shipping' ).prop( 'disabled', is_synced_or_has_trial );
 		},
+		// Sets the interval to 1 and disables its select when the selected period is yearly.
+		// Stripe doesn't allow greater intervals for yearly subscriptions.
+		limitYearlyPeriodInterval: function( $periodSelect ) {
+			const $intervalSelect = $periodSelect.closest( '._subscription_price_field').find( '.wc_input_subscription_period_interval' );
+
+			if ( 'year' === $periodSelect.val() ) {
+				$intervalSelect.val( 1 );
+				$intervalSelect.prop( 'disabled', true );
+			} else {
+				$intervalSelect.prop( 'disabled', false );
+			}
+		},
 		showHideSubscriptionsPanels: function() {
 			var tab = $( 'div.panel-wrap' ).find( 'ul.wc-tabs li' ).eq( 0 ).find( 'a' );
 			var panel = tab.attr( 'href' );
@@ -443,6 +455,11 @@ jQuery( function( $ ) {
 
 	$('#woocommerce-product-data').on('propertychange keyup input paste change','[name^="_subscription_trial_length"], [name^="variable_subscription_trial_length"]',function(){
 		$.setTrialPeriods();
+	});
+
+	// Limit the period interval to 1 when using yearly periods.
+	$('#woocommerce-product-data').on('change','[name^="_subscription_period"], [name^="variable_subscription_period"]',function(){
+		$.limitYearlyPeriodInterval( $(this) );
 	});
 
 	// Handles changes to sync date select/input for yearly subscription products.

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -310,7 +310,7 @@ class WC_Subscriptions_Admin {
 			<span class="wrap">
 				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php echo esc_attr_x( 'e.g. 5.90', 'example price', 'woocommerce-subscriptions' ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
-				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval">
+				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval" <?php disabled( 'year', $chosen_period, true ); ?>>
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>
 					<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $chosen_interval, true ) ?>><?php echo esc_html( $label ); ?></option>
 				<?php } ?>

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -539,6 +539,11 @@ class WC_Subscriptions_Admin {
 			}
 		}
 
+		// Force the interval to '1' when the period is yearly.
+		if ( isset( $_REQUEST['_subscription_period'] ) && 'year' === $_REQUEST['_subscription_period'] ) {
+			update_post_meta( $post_id, '_subscription_period_interval', '1' );
+		}
+
 		// To prevent running this function on multiple save_post triggered events per update. Similar to WC_Admin_Meta_Boxes:$saved_meta_boxes implementation.
 		self::$saved_product_meta = true;
 	}
@@ -753,6 +758,11 @@ class WC_Subscriptions_Admin {
 			if ( isset( $_POST[ 'variable' . $field_name ][ $index ] ) ) {
 				update_post_meta( $variation_id, $field_name, wc_clean( $_POST[ 'variable' . $field_name ][ $index ] ) );
 			}
+		}
+
+		// Force the interval to '1' when the period is yearly.
+		if ( isset( $_POST['variable_subscription_period'][ $index ] ) && 'year' === $_POST['variable_subscription_period'][ $index ] ) {
+			update_post_meta( $variation_id, '_subscription_period_interval', '1' );
 		}
 	}
 

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -47,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ); ?>">
 
 		<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
-		<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval">
+		<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval" <?php disabled( 'year', $billing_period, true ); ?>>
 		<?php foreach ( wcs_get_subscription_period_interval_strings() as $key => $value ) : ?>
 			<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, WC_Subscriptions_Product::get_interval( $variation_product ) ); ?>><?php echo esc_html( $value ); ?></option>
 		<?php endforeach; ?>


### PR DESCRIPTION
Fixes WCPay's [#3255](https://github.com/Automattic/woocommerce-payments/issues/3255)

#### Changes proposed in this Pull Request

On client-side, when changing the product's period to "year":
* Change the selected period interval value to "1"
* Disable the select for the period interval

On server-side:
* Force the period interval to "1" when the period is set to "year" when saving

These, for both simple and variable products.

Not adding the testing instructions since we won't go this way.