### PR TITLE
show only valid payment methods when creating/editing a subscription on wp-admin

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -954,6 +954,14 @@ jQuery( function( $ ) {
 					option.text = cards[i];
 					cardsSelect.appendChild( option );
 				}
+
+				if ("createEvent" in document) {
+					var evt = document.createEvent("HTMLEvents");
+					evt.initEvent("change", false, true);
+					cardsSelect.dispatchEvent(evt);
+				}
+				else
+					cardsSelect.fireEvent("onchange");
 			} );
 	} );
 });

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -921,4 +921,39 @@ jQuery( function( $ ) {
 	};
 	wcs_accounts_and_privacy_settings.init();
 
+	//Loads the saved credit cards after customer is selected
+	//when editing/creating a subscription
+	$( '#woocommerce-subscription-data #customer_user' ).change( function () {
+		const data = new FormData();
+
+		data.append( 'action', 'wcs_get_allowed_payment_gateways' );
+		data.append( 'customer', this.options[ this.selectedIndex ].value );
+		data.append( 'subscription_id', document.getElementById('post_ID').value );
+		data.append( 'nonce', WCSubscriptions.getValidPaymentGatewaysNonce );
+
+		fetch( woocommerce_admin.ajax_url, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: data,
+		} )
+			.then( ( response ) => response.json() )
+			.then( ( cards ) => {
+				const cardsSelect = document.querySelector(
+					'#_payment_method'
+				);
+
+				cardsSelect.innerHTML = '';
+
+				for ( var i in cards ) {
+					if (!cards.hasOwnProperty(i)) {
+						continue;
+					}
+
+					const option = document.createElement( 'option' );
+					option.value = i;
+					option.text = cards[i];
+					cardsSelect.appendChild( option );
+				}
+			} );
+	} );
 });

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -882,7 +882,7 @@ class WC_Subscriptions_Admin {
 			$script_params['ajaxLoaderImage']              = WC()->plugin_url() . '/assets/images/ajax-loader.gif';
 			$script_params['ajaxUrl']                      = admin_url( 'admin-ajax.php' );
 			$script_params['isWCPre24']                    = var_export( wcs_is_woocommerce_pre( '2.4' ), true );
-			$script_params['getValidPaymentGatewaysNonce'] = wp_create_nonce('get_valid_payment_gateways_nonce');
+			$script_params['getValidPaymentGatewaysNonce'] = wp_create_nonce( 'get_valid_payment_gateways_nonce' );
 
 			wp_enqueue_script( 'woocommerce_subscriptions_admin', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/admin.js' ), $dependencies, filemtime( WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'assets/js/admin/admin.js' ) ) );
 			wp_localize_script( 'woocommerce_subscriptions_admin', 'WCSubscriptions', apply_filters( 'woocommerce_subscriptions_admin_script_parameters', $script_params ) );

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -879,9 +879,10 @@ class WC_Subscriptions_Admin {
 				);
 			}
 
-			$script_params['ajaxLoaderImage'] = WC()->plugin_url() . '/assets/images/ajax-loader.gif';
-			$script_params['ajaxUrl']         = admin_url( 'admin-ajax.php' );
-			$script_params['isWCPre24']       = var_export( wcs_is_woocommerce_pre( '2.4' ), true );
+			$script_params['ajaxLoaderImage']              = WC()->plugin_url() . '/assets/images/ajax-loader.gif';
+			$script_params['ajaxUrl']                      = admin_url( 'admin-ajax.php' );
+			$script_params['isWCPre24']                    = var_export( wcs_is_woocommerce_pre( '2.4' ), true );
+			$script_params['getValidPaymentGatewaysNonce'] = wp_create_nonce();
 
 			wp_enqueue_script( 'woocommerce_subscriptions_admin', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/admin.js' ), $dependencies, filemtime( WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'assets/js/admin/admin.js' ) ) );
 			wp_localize_script( 'woocommerce_subscriptions_admin', 'WCSubscriptions', apply_filters( 'woocommerce_subscriptions_admin_script_parameters', $script_params ) );

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -882,7 +882,7 @@ class WC_Subscriptions_Admin {
 			$script_params['ajaxLoaderImage']              = WC()->plugin_url() . '/assets/images/ajax-loader.gif';
 			$script_params['ajaxUrl']                      = admin_url( 'admin-ajax.php' );
 			$script_params['isWCPre24']                    = var_export( wcs_is_woocommerce_pre( '2.4' ), true );
-			$script_params['getValidPaymentGatewaysNonce'] = wp_create_nonce();
+			$script_params['getValidPaymentGatewaysNonce'] = wp_create_nonce('get_valid_payment_gateways_nonce');
 
 			wp_enqueue_script( 'woocommerce_subscriptions_admin', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/admin.js' ), $dependencies, filemtime( WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'assets/js/admin/admin.js' ) ) );
 			wp_localize_script( 'woocommerce_subscriptions_admin', 'WCSubscriptions', apply_filters( 'woocommerce_subscriptions_admin_script_parameters', $script_params ) );

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -131,6 +131,7 @@ class WC_Subscriptions_Core_Plugin {
 		WCS_Dependent_Hook_Manager::init();
 		WCS_Admin_Product_Import_Export_Manager::init();
 		WC_Subscriptions_Frontend_Scripts::init();
+		WCS_Change_Payment_Method_Admin::init();
 
 		add_action( 'init', array( 'WC_Subscriptions_Synchroniser', 'init' ) );
 		add_action( 'after_setup_theme', array( 'WC_Subscriptions_Upgrader', 'init' ), 11 );

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -16,8 +16,14 @@ class WCS_Change_Payment_Method_Admin {
 		add_action( 'wp_ajax_wcs_get_allowed_payment_gateways', __CLASS__ . '::get_allowed_payment_gateways' );
 	}
 
+	/**
+	 * Get payment gateways that can be used
+	 * on a subscription on wp-admin for a given user
+	 *
+	 * @since 1.1.0
+	 */
 	public static function get_allowed_payment_gateways() {
-		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( wc_clean( wp_unslash( $_POST['nonce'] ) ), 'get_cards_tokens_nonce' ) ) {
+		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( wc_clean( wp_unslash( $_POST['nonce'] ) ), 'get_valid_payment_gateways_nonce' ) ) {
 			return;
 		}
 

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -70,7 +70,7 @@ class WCS_Change_Payment_Method_Admin {
 
 		echo '</p>';
 
-		$payment_method_table = apply_filters( 'woocommerce_subscription_payment_meta', [], $subscription );
+		$payment_method_table = apply_filters( 'woocommerce_subscription_payment_meta', array(), $subscription );
 
 		if ( is_array( $payment_method_table ) ) {
 
@@ -127,8 +127,8 @@ class WCS_Change_Payment_Method_Admin {
 
 		$payment_gateways    = WC()->payment_gateways->payment_gateways();
 		$payment_method      = isset( $_POST['_payment_method'] ) ? wc_clean( $_POST['_payment_method'] ) : '';
-		$payment_method_meta = apply_filters( 'woocommerce_subscription_payment_meta', [], $subscription );
-		$payment_method_meta = ( ! empty( $payment_method_meta[ $payment_method ] ) ) ? $payment_method_meta[ $payment_method ] : [];
+		$payment_method_meta = apply_filters( 'woocommerce_subscription_payment_meta', array(), $subscription );
+		$payment_method_meta = ( ! empty( $payment_method_meta[ $payment_method ] ) ) ? $payment_method_meta[ $payment_method ] : array();
 
 		$valid_payment_methods = self::get_valid_payment_methods( $subscription );
 

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -203,6 +203,11 @@ class WCS_Change_Payment_Method_Admin {
 			$valid = $valid && count( $tokens );
 
 			if ( $valid ) {
+				// Only non manual gateways should be available when WC Subscriptions pro is not active.
+				if ( isset( $valid_gateways['manual'] ) && ! class_exists( 'WC_Subscriptions' ) ) {
+					unset( $valid_gateways['manual'] );
+				}
+
 				$valid_gateways[ $gateway_id ] = $gateway->get_title();
 			}
 		}

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -169,9 +169,11 @@ class WCS_Change_Payment_Method_Admin {
 
 	/**
 	 * Get a list of possible gateways that a subscription could be changed to by admins.
+	 * If a user id is passed it will take precedence over the customer inside the subscription
 	 *
 	 * @since 2.0
 	 * @param $subscription int | WC_Subscription
+	 * @param $user int
 	 * @return
 	 */
 	public static function get_valid_payment_methods( $subscription, $user = null ) {

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -182,7 +182,7 @@ class WCS_Change_Payment_Method_Admin {
 			$subscription = wcs_get_subscription( $subscription );
 		}
 
-		$valid_gateways = [ 'manual' => __( 'Manual Renewal', 'woocommerce-subscriptions' ) ];
+		$valid_gateways = array( 'manual' => __( 'Manual Renewal', 'woocommerce-subscriptions' ) );
 
 		if ( ! $user ) {
 			$user = $subscription->get_customer_id();

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -176,8 +176,16 @@ class WCS_Change_Payment_Method_Admin {
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		foreach ( $available_gateways as $gateway_id => $gateway ) {
+			$tokens = WC_Payment_Tokens::get_customer_tokens(
+				$subscription->get_customer_id(),
+				$gateway_id
+			);
 
-			if ( $gateway->supports( 'subscription_payment_method_change_admin' ) && ! wcs_is_manual_renewal_required() || ( ! $subscription->is_manual() && $gateway_id == $subscription->get_payment_method() ) ) {
+			$valid = $gateway->supports( 'subscription_payment_method_change_admin' ) && ! wcs_is_manual_renewal_required();
+			$valid = $valid || ( ! $subscription->is_manual() && $gateway_id === $subscription->get_payment_method() );
+			$valid = $valid && count( $tokens );
+
+			if ( $valid ) {
 				$valid_gateways[ $gateway_id ] = $gateway->get_title();
 			}
 		}

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -114,8 +114,8 @@ class WCS_Change_Payment_Method_Admin {
 
 		$payment_gateways    = WC()->payment_gateways->payment_gateways();
 		$payment_method      = isset( $_POST['_payment_method'] ) ? wc_clean( $_POST['_payment_method'] ) : '';
-		$payment_method_meta = apply_filters( 'woocommerce_subscription_payment_meta', array(), $subscription );
-		$payment_method_meta = ( ! empty( $payment_method_meta[ $payment_method ] ) ) ? $payment_method_meta[ $payment_method ] : array();
+		$payment_method_meta = apply_filters( 'woocommerce_subscription_payment_meta', [], $subscription );
+		$payment_method_meta = ( ! empty( $payment_method_meta[ $payment_method ] ) ) ? $payment_method_meta[ $payment_method ] : [];
 
 		$valid_payment_methods = self::get_valid_payment_methods( $subscription );
 
@@ -167,7 +167,11 @@ class WCS_Change_Payment_Method_Admin {
 			$subscription = wcs_get_subscription( $subscription );
 		}
 
-		$valid_gateways = array( 'manual' => __( 'Manual Renewal', 'woocommerce-subscriptions' ) );
+		$valid_gateways = [ 'manual' => __( 'Manual Renewal', 'woocommerce-subscriptions' ) ];
+
+		if ( ! $subscription->get_customer_id() ) {
+			return $valid_gateways;
+		}
 
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 


### PR DESCRIPTION
This is a partial fix to https://github.com/Automattic/woocommerce-payments/issues/2962 and 
fix #29 


#### Changes proposed in this Pull Request
This PR adds an ajax request to load which payment gateways are available for a selected customer when creating a new subscription/editing a subscription.

#### Testing instructions
Case 1
- With WC Payments plugin **active** and WC Subscription **inactive**
- Go to **WooCommerce > Subscriptions > Add new**
- Choose a customer **with** a saved credit card on WCPayments 
- Click the pencil icon in the billing fields section. 
- It should show **only WC Payments**

Case 2
- With WC Payments plugin **active** and WC Subscription **inactive**
- Go to **WooCommerce > Subscriptions > Add new**
- Choose a customer **without** a saved credit card on WCPayments 
- Click the pencil icon in the billing fields section. 
- It should show **only Manual Renewal**

Case 3
- With WC Payments plugin **active** and WC Subscription **active**
- Go to **WooCommerce > Subscriptions > Add new**
- Choose a customer **with** a saved credit card on WCPayments 
- Click the pencil icon in the billing fields section. 
- It should show **Manual Renewal and WC Payments**