### PR TITLE
Improve WooCommerce Blocks Support: Wrap relevant totals lines in TotalsWrapper

### DIFF
--- a/assets/src/js/recurring-totals/index.js
+++ b/assets/src/js/recurring-totals/index.js
@@ -7,6 +7,7 @@ import {
 	Subtotal,
 	TotalsItem,
 	TotalsTaxes,
+	TotalsWrapper,
 } from '@woocommerce/blocks-checkout';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { getSetting } from '@woocommerce/settings';
@@ -252,24 +253,32 @@ const RecurringSubscription = ( {
 				initialOpen={ false }
 				title={ __( 'Details', 'woocommerce-subscriptions' ) }
 			>
-				<Subtotal currency={ currency } values={ totals } />
-				<DiscountTotals currency={ currency } values={ totals } />
-				<ShippingTotal
-					currency={ currency }
-					needsShipping={ needsShipping }
-					calculatedShipping={ calculatedShipping }
-					values={ totals }
-					selectedRate={ selectedRate }
-				/>
+				<TotalsWrapper>
+					<Subtotal currency={ currency } values={ totals } />
+					<DiscountTotals currency={ currency } values={ totals } />
+				</TotalsWrapper>
+				<TotalsWrapper>
+					<ShippingTotal
+						currency={ currency }
+						needsShipping={ needsShipping }
+						calculatedShipping={ calculatedShipping }
+						values={ totals }
+						selectedRate={ selectedRate }
+					/>
+				</TotalsWrapper>
 				{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (
-					<TotalsTaxes currency={ currency } values={ totals } />
+					<TotalsWrapper>
+						<TotalsTaxes currency={ currency } values={ totals } />
+					</TotalsWrapper>
 				) }
-				<TotalsItem
-					className="wcs-recurring-totals-panel__details-total"
-					currency={ currency }
-					label={ __( 'Total', 'woocommerce-subscriptions' ) }
-					value={ parseInt( totals.total_price, 10 ) }
-				/>
+				<TotalsWrapper>
+					<TotalsItem
+						className="wcs-recurring-totals-panel__details-total"
+						currency={ currency }
+						label={ __( 'Total', 'woocommerce-subscriptions' ) }
+						value={ parseInt( totals.total_price, 10 ) }
+					/>
+				</TotalsWrapper>
 			</Panel>
 		</div>
 	);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-xx-xx - version 1.1.0
+* Fix: Add consistent margins to the recurring taxes totals row on the Checkout and Cart block. PR#39
+
 2021-10-29 - version 1.0.3
 * Fix: Errors when attempting to get the plugin version during PayPal requests. PR#27
 


### PR DESCRIPTION
This PR is a migration of https://github.com/woocommerce/woocommerce-subscriptions/pull/4143 into Subscriptions Core.

---


#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->

- With Checkout/Cart blocks: Wrap subscriptions line item totals in TotalsWrapper

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

In WooCommerce Blocks woocommerce/woocommerce-gutenberg-products-block#4415 (released in blocks 5.5) they've added a TotalsWrapper component which can be used to separate elements of the checkout sidebar. In the recurring totals files we added in Subscriptions, we use the styling from Blocks, which has since been amended to remove padding and line breaks.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

|BEFORE|AFTER|
|:------:|:-----:|
|![image](https://user-images.githubusercontent.com/2275145/140847305-de6df8d6-579a-455d-bc1a-d3ae2b2fac80.png)|![image](https://user-images.githubusercontent.com/2275145/140847537-a387c175-e1dc-4b07-be03-2eaf2440f218.png)|

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure you're on the latest WooCommerce Subscriptions `trunk`
1. Clone `woocommerce-subscriptions-core` into your `/wp-plugins` directory
1. After checking WCS Core `wc_subscriptions/4143-pr` branch, make sure you run `npm run build:js` 
1. Activate both WooCommerce Subscriptions and WooCommerce Subscriptions Core plugins
1. Download and activate the latest version of the WooCommerce Blocks plugin (must be at least 5.5). Download from GH or WP.org plugin directory.
1. Set your store's tax setting "Display prices during cart and checkout" to "Excluding tax"
1. Create a cart and checkout block page if you don't have one yet
1. Add a subscription product to your cart. 
1. Go to the Cart and Checkout blocks and expand the recurring totals at the bottom of the sidebar.
1. Ensure that the Tax line has a margin above it and that all entries are spaced correctly.

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

