### PR TITLE
Prevent fatal errors caused by orders without a created date.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-x-x - version 1.0.4
+* Fix: Fatal error due to order with no created date in order row template. PR#40
+
 2021-10-29 - version 1.0.3
 * Fix: Errors when attempting to get the plugin version during PayPal requests. PR#27
 

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -8,14 +8,10 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
-
-// WC 3.0+ compatibility
-$order_post = wcs_get_objects_property( $order, 'post' );
-
 ?>
 <tr>
 	<td>
-		<a href="<?php echo esc_url( get_edit_post_link( wcs_get_objects_property( $order, 'id' ) ) ); ?>">
+		<a href="<?php echo esc_url( get_edit_post_link( $order->get_id() ) ); ?>">
 			<?php
 			// translators: placeholder is an order number.
 			echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) );
@@ -23,20 +19,24 @@ $order_post = wcs_get_objects_property( $order, 'post' );
 		</a>
 	</td>
 	<td>
-		<?php echo esc_html( wcs_get_objects_property( $order, 'relationship' ) ); ?>
+		<?php echo esc_html( $order->get_meta( '_relationship' ) ); ?>
 	</td>
 	<td>
 		<?php
-		$timestamp_gmt = wcs_get_objects_property( $order, 'date_created' )->getTimestamp();
-		if ( $timestamp_gmt > 0 ) {
-			// translators: php date format
-			$t_time          = get_the_time( _x( 'Y/m/d g:i:s A', 'post date', 'woocommerce-subscriptions' ), $order_post );
-			$date_to_display = ucfirst( wcs_get_human_time_diff( $timestamp_gmt ) );
+		$date_created = $order->get_date_created();
+
+		if ( $date_created ) {
+			$t_time          = $order->get_date_created()->date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) );
+			$date_to_display = ucfirst( wcs_get_human_time_diff( $date_created->getTimestamp() ) );
 		} else {
 			$t_time = $date_to_display = __( 'Unpublished', 'woocommerce-subscriptions' );
-		} ?>
+		}
+
+		// Backwards compatibility for third-parties using the generic WP post time filter.
+		$date_to_display = apply_filters( 'post_date_column_time', $date_to_display, get_post( $order->get_id() ) );
+		?>
 		<abbr title="<?php echo esc_attr( $t_time ); ?>">
-			<?php echo esc_html( apply_filters( 'post_date_column_time', $date_to_display, $order_post ) ); ?>
+			<?php echo esc_html( apply_filters( 'wc_subscriptions_related_order_date_column', $date_to_display, $order ) ); ?>
 		</abbr>
 	</td>
 	<td>


### PR DESCRIPTION
Fixes 3939-gh-woocommerce/woocommerce-subscriptions

#### Changes proposed in this Pull Request

Copied from 4132-gh-woocommerce/woocommerce-subscriptions:

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR fixes a fairly obscure issue that can occur when an order doesn't have a date created. Because we got the created date's timestamp on a single line with `wcs_get_objects_property( $order, 'date_created' )->getTimestamp();`, if the date didn't exist, a fatal error would occur (see below). This PR fixes that error.

```
An error of type E_ERROR was caused in line 30 of the file html-related-orders-row.php. 
Error message: Uncaught Error: Call to a member function getTimestamp() on null in .
```

While editing the file I also removed all uses of `wcs_get_objects_property()` in the file.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
<!-- Please include screenshots. -->
I wasn't able to replicate a scenario when the order has no created date. This PR is just rearranging things, to be more defensive so test and review the changes. 

1. View the edit admin screen for a subscription or a subscription-related order.
1. In the related orders tables, the content should remain unchanged.

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->