### PR TITLE
Fix: Misleading order note on payment method change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix: Add consistent margins to the recurring taxes totals row on the Checkout and Cart block. PR#39
 * Fix: Fatal error due to order with no created date in order row template. PR#40
 * Fix: Fatal error on the customer payment page for renewal orders with deleted products. PR#42
+* Fix: Misleading order note on payment method change. #PR41
 
 2021-10-29 - version 1.0.3
 * Fix: Errors when attempting to get the plugin version during PayPal requests. PR#27

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -533,8 +533,8 @@ class WC_Subscriptions_Change_Payment_Gateway {
 			$new_payment_method_title = (string) apply_filters( 'woocommerce_subscription_note_new_payment_method_title', $new_payment_method_title, $new_payment_method, $subscription );
 
 			// Log change on order
-			// translators: 1: old payment title (now unused, placement kept for backwards compatibility), 2: new payment title.
-			$subscription->add_order_note( sprintf( _x( 'Payment method changed to "%2$s" by the subscriber from their account page.', '%1$s: old payment title, %2$s: new payment title', 'woocommerce-subscriptions' ), $old_payment_method_title, $new_payment_method_title ) );
+			// translators: 1: old payment title, 2: new payment title.
+			$subscription->add_order_note( sprintf( _x( 'Payment method changed from "%1$s" to "%2$s" by the subscriber.', '%1$s: old payment title, %2$s: new payment title', 'woocommerce-subscriptions' ), $old_payment_method_title, $new_payment_method_title ) );
 
 			$subscription->save();
 

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -533,8 +533,8 @@ class WC_Subscriptions_Change_Payment_Gateway {
 			$new_payment_method_title = (string) apply_filters( 'woocommerce_subscription_note_new_payment_method_title', $new_payment_method_title, $new_payment_method, $subscription );
 
 			// Log change on order
-			// translators: 1: old payment title, 2: new payment title.
-			$subscription->add_order_note( sprintf( _x( 'Payment method changed from "%1$s" to "%2$s" by the subscriber from their account page.', '%1$s: old payment title, %2$s: new payment title', 'woocommerce-subscriptions' ), $old_payment_method_title, $new_payment_method_title ) );
+			// translators: 1: old payment title (now unused, placement kept for backwards compatibility), 2: new payment title.
+			$subscription->add_order_note( sprintf( _x( 'Payment method changed to "%2$s" by the subscriber from their account page.', '%1$s: old payment title, %2$s: new payment title', 'woocommerce-subscriptions' ), $old_payment_method_title, $new_payment_method_title ) );
 
 			$subscription->save();
 


### PR DESCRIPTION
Fixes 3268-gh-woocommerce/woocommerce-subscriptions 

#### Changes proposed in this Pull Request

Order note when payment method is changed can be misleading and confusing.

Previously the order note used to read `Payment method changed from “[OLD_METHOD]” to “[NEW_METHOD]” by the subscriber from their account page` however the change didn't always take place on the account page. This message was also triggered when the user updated the payment method when the payment failed.

This fix updates the order note to only mention the new payment method: `Payment method changed from "[OLD_METHOD] to “[NEW_METHOD]” by the subscriber.` removing any confusion.

**Before**
![image](https://user-images.githubusercontent.com/57298/141016399-ddf32100-771e-4e5b-8886-c7f86d4e58ae.png)

**After**
![image](https://user-images.githubusercontent.com/57298/141204622-9be63954-123a-4e4a-b48f-a7a65f1a30ca.png)

This change will affect both woocommerce-subscriptions and woocommerce-payments flows.