### PR TITLE
Deleted Product causes fatal error when customer views renewal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2021-xx-xx - version 1.1.0
 * Fix: Add consistent margins to the recurring taxes totals row on the Checkout and Cart block. PR#39
 * Fix: Fatal error due to order with no created date in order row template. PR#40
+* Fix: Fatal error on the customer payment page for renewal orders with deleted products. PR#42
 
 2021-10-29 - version 1.0.3
 * Fix: Errors when attempting to get the plugin version during PayPal requests. PR#27

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -850,7 +850,7 @@ function wcs_set_payment_meta( $subscription, $payment_meta ) {
 }
 
 /**
- * Get total quantity of a product on a subscription or order, even across multiple line items.
+ * Get total quantity of a product on a subscription or order, even across multiple line items. So we can determine if product has stock available.
  *
  * @since 2.6.0
  *
@@ -877,7 +877,13 @@ function wcs_get_total_line_item_product_quantity( $order, $product, $product_ma
 				$product_id           = $product->get_id(); // The variation ID for variations or product ID.
 				break;
 			default:
-				$line_item_product_id = $line_item->get_product()->get_stock_managed_by_id();
+				$line_item_product = $line_item->get_product();
+				if ( false === $line_item_product ) {
+					// Skip processing here if line item product doesn't exist.
+					// NB: Product not found generates a notice later in the flow in \WCS_Cart_Renewal::setup_cart
+					continue 2;
+				}
+				$line_item_product_id = $line_item_product->get_stock_managed_by_id();
 				$product_id           = $product->get_stock_managed_by_id();
 				break;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Deleted Product causes fatal error when customer views renewal page.

If an admin adds a simple product to a renewal order and the is deleted. When the customer views the renewal page they will get a fatal error.


#### Testing instructions

1. Create a simple product.
2. Purchase a subscription of a subscription product.
3. Create a pending renewal order for the subscription.
4. Edit the pending renewal order and add the simple product that was created.
5. Delete the simple product and permanently remove it from the trash.
6. View the customer payment page for the order.

Before this fix this generates a fatal error. 
With this fix in place we instead get the following error that is more user-friendly.

![image](https://user-images.githubusercontent.com/57298/141227311-5ea21cdd-33e9-43b8-89eb-ec873b43fcac.png)

Originally it appears that this code worked as intended until out of stock checks were added before the check to see if the product exists. If the product is not found during the out of stock check we skip it for that product.

fixes 4224-gh-woocommerce/woocommerce-subscriptions