### PR TITLE
add explicit prompts to templates for product impact & tracking issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-### Describe the bug
-<!-- A clear and concise description of what the bug is. Please be as descriptive as possible. -->
+## Describe the bug
+<!-- A clear and concise description of what the bug is. Please be as descriptive as possible, and include screenshots to illustrate. -->
 
-### To Reproduce
+## To Reproduce
 <!-- Describe the steps to reproduce the behavior. -->
 
 1. Go to '…'
@@ -18,28 +18,26 @@ assignees: ''
 3. Scroll down to …'
 4. See error
 
-### Actual behavior
-<!-- A clear and concise description of what actually happens. -->
-
-### Screenshots
-<!-- If applicable, add screenshots to help explain your problem. -->
-
 ### Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-### Desktop (please complete the following information):
+### Actual behavior
+<!-- A clear and concise description of what actually happens. -->
 
-* OS: [e.g. iOS]
-* Browser [e.g. chrome, safari]
-* Version [e.g. 22]
+## Product impact
+<!-- What products does this issue affect? -->
 
-### Smartphone (please complete the following information):
+- [ ] Does this issue affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
+- [ ] Does this issue affect WooCommerce Payments? yes/no/tbc, add issue ref
 
-* Device: [e.g. iPhone6]
-* OS: [e.g. iOS8.1]
-* Browser [e.g. stock browser, safari]
-* Version [e.g. 22]
-
-### Additional context
+## Additional context
 <!-- Any additional context or details you think might be helpful. -->
 <!-- Ticket numbers/links, plugin versions, system statuses etc. -->
+
+<!-- Collapse lengthy logs or status reports with a <details> tag -->
+<!--
+<details>
+```
+```
+</details>
+-->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,5 +1,5 @@
 ---
-name: Feature
+name: Enhancement
 about: A new feature or improvement
 title: ''
 labels: ''
@@ -7,19 +7,12 @@ assignees: ''
 
 ---
 
-### Description
-<!-- A clear and concise description of what the new feature or improvement is. -->
-
-### Acceptance criteria
-<!-- A list of predefined requirements that must be met in order to mark the issue as complete. -->
-
-* First requirement
-* Second requirement
-* Third requirement
-* etc.
-
-### Designs
-<!-- If applicable, add screenshots or links to the UI design for this feature. -->
+## Description
+<!-- 
+ A clear and concise description of what the new feature or improvement is. 
+ Include images or screenshots to clarify the context.
+ What are you trying to do – what's the wider flow?
+ -->
 
 ### Testing instructions
 <!-- If applicable, a list of instructions that will aid in confirming that the new feature or improvement is working as expected. -->
@@ -29,9 +22,16 @@ assignees: ''
 3. Scroll down to '…'
 4. Observe expected behaviour
 
-### Dev notes
+
+## Product impact
+<!-- What product(s) is this feature intended for? -->
+
+- [ ] Does this feature affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
+- [ ] Does this feature affect WooCommerce Payments? yes/no/tbc, add issue ref
+
+## Dev notes
 <!-- If applicable, additional technical or implementation details that will help when developing this feature or improvement. -->
 
-### Additional context
+## Additional context
 <!-- Any additional context or details you think might be helpful. -->
 <!-- Ticket numbers/links, P2s, project threads, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,5 +39,6 @@ Add as many details as possible to help others reproduce the issue and test the 
 ## Product impact
 <!-- What products will this PR ship in? -->
 
+- [ ] Added changelog entry (or does not apply)
 - [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
 - [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,14 @@
 Fixes #
 
-#### Changes proposed in this Pull Request
+## Description
 
 <!--
-Title: A descriptive, yet concise, title.
--->
-
-<!--
-Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
+Write a brief summary about this PR. 
+- Why is this change needed? 
+- What does this change do? 
+- Were there other solutions you considered? 
+- Why did you choose to pursue this solution? 
+- Describe any trade-offs you might have had to make.
 -->
 
 <!--
@@ -17,13 +18,14 @@ Questions for PR author:
 -->
 
 <!--
-Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
+Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
 -->
 
-#### Testing instructions
+## How to test this PR
 
 <!--
 Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
+Use the testing instructions from the linked issue as a starting point.
 -->
 
 <!--
@@ -31,18 +33,11 @@ Add as many details as possible to help others reproduce the issue and test the 
 "Before / After" screenshots can also be very helpful when the change is visual.
 -->
 
-*
+1. Go to …
+2. Click on …
 
--------------------
+## Product impact
+<!-- What products will this PR ship in? -->
 
-- [ ] Added changelog entry (or does not apply)
-- [ ] Covered with tests (or have a good reason not to test in description ☝️)
-- [ ] Tested on mobile (or does not apply)
-
-**Post merge**
-
-<!--
-Make sure you edit the page for the current release when adding testing instructions.
-We often create a blank page ahead of time for the next release.
--->
-
+- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
+- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref


### PR DESCRIPTION
This PR adjusts the templates for issues and PRs to add prompts to explictly consider what products are impacted.

The goal is to help get in the habit of considering the following, as part of any change:

- Which products need the fix or feature (e.g. WC Pay, WC Subscriptions, or both).
- How to reproduce the issue in each affected product.
- How to verify the fix in each affected product.
- Who has the ball for releasing the fix, when it will go out to customers (etc).

Ideally we'd consider this whenever we log an issue, and especially important when we start work on a PR. 