### PR TITLE
Update tooltip wording when deleting product variation.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-xx-xx - version 1.x.x
+* Fix: Update tooltip wording when deleting product variation. PR#46
+
 2021-11-12 - version 1.1.0
 * Fix: Add consistent margins to the recurring taxes totals row on the Checkout and Cart block. PR#39
 * Fix: Fatal error due to order with no created date in order row template. PR#40

--- a/includes/class-wc-subscriptions-product.php
+++ b/includes/class-wc-subscriptions-product.php
@@ -974,7 +974,7 @@ class WC_Subscriptions_Product {
 		printf( '<input type="hidden" class="wcs-can-remove-variation" value="%d" />', intval( $can_remove ) );
 
 		if ( ! $can_remove ) {
-			$msg = __( 'This variation can not be removed because it is associated with active subscriptions. To remove this variation, please cancel and delete the subscriptions for it.', 'woocommerce-subscriptions' );
+			$msg = __( 'This variation can not be removed because it is associated with existing subscriptions. To remove this variation, please permanently delete any related subscriptions.', 'woocommerce-subscriptions' );
 			printf( '<a href="#" class="tips delete wcs-can-not-remove-variation-msg" data-tip="%s" rel="%s"></a>', wc_sanitize_tooltip( $msg ), absint( $variation->ID ) ); // XSS ok.
 		}
 	}


### PR DESCRIPTION
Issue: 4263-gh-woocommerce/woocommerce-subscriptions

#### Changes proposed in this Pull Request

Minor fix to update tooltip wording when deleting a variation. 


#### Testing instructions

View the tooltip when trying to delete a variation on a variable subscriptions product.

![image](https://user-images.githubusercontent.com/57298/141721538-6a964f80-b6d8-4a09-b03c-5c815522e9ff.png)


- [x] Added changelog entry (or does not apply)
