### PR TITLE
Add: Minimum subscription order value

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2021-xx-xx - version 1.x.x
 * Fix: Update tooltip wording when deleting product variation. PR#46
+* Add: Minimum subscription order value. PR#48  wcpay#3311
 
 2021-11-12 - version 1.1.0
 * Fix: Add consistent margins to the recurring taxes totals row on the Checkout and Cart block. PR#39


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/3311

#### Changes proposed in this Pull Request

Prevent admin from creating subscriptions with below a minimum value.

When an admin creates or updates a subscription that is below the minimum order value we add a minimum order fee to the order to make up the difference. 
By default this minimum order value is set to $1. So if the subscription comes to $0.75, then a fee will be added at $0.25 with a note added.

Other options considered included client-side notices / blocking and backend validation. These were discarded due to various reasons. - (see pdjTHR-k2-p2)

![image](https://user-images.githubusercontent.com/57298/142779333-58e1c644-baaf-456f-ae6c-af91488fe6f8.png)

#### Testing instructions

1. Create a new subscription for a customer.
2. Add a subscription product
3. Manually discount the subscription to be below $1
4. Save.  

NB: no unit tests added due to current test state in subscriptions-core.
-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in description ☝️)
- [x] Tested on mobile (or does not apply)

**Post merge**

Will need to update subscriptions extension to accept different minimum values in that project.