### PR TITLE
Deprecate the admin error notice when downgrading subscriptions to a previous minor version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2021-xx-xx - version 1.x.x
 * Fix: Update tooltip wording when deleting product variation. PR#46
+* Fix: Don't show an admin error notice when a store downgrades to a previous minor version of Subscriptions. WCS#4271
 
 2021-11-12 - version 1.1.0
 * Fix: Add consistent margins to the recurring taxes totals row on the Checkout and Cart block. PR#39

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -101,7 +101,6 @@ class WC_Subscriptions_Upgrader {
 		// When WC is updated from a version prior to 3.0 to a version after 3.0, add subscription address indexes. Must be hooked on before WC runs its updates, which occur on priority 5.
 		add_action( 'init', array( __CLASS__, 'maybe_add_subscription_address_indexes' ), 2 );
 
-		add_action( 'admin_notices', array( __CLASS__, 'maybe_add_downgrade_notice' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'maybe_display_external_object_cache_warning' ) );
 
 		add_action( 'init', array( __CLASS__, 'initialise_background_updaters' ), 0 );
@@ -815,31 +814,6 @@ class WC_Subscriptions_Upgrader {
 	}
 
 	/**
-	 * Display an admin notice if the database version is greater than the active version of the plugin by at least one minor release (eg 1.1 and 1.0).
-	 *
-	 * @since 2.3.0
-	 */
-	public static function maybe_add_downgrade_notice() {
-
-		// If there's no downgrade, exit early. self::$active_version is a bit of a misnomer here but in an upgrade context it refers to the database version of the plugin.
-		if ( ! version_compare( wcs_get_minor_version_string( self::$active_version ), wcs_get_minor_version_string(  WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() ), '>' ) ) {
-			return;
-		}
-
-		$admin_notice = new WCS_Admin_Notice( 'error' );
-		// translators: 1-2: opening/closing <strong> tags, 3: active version of Subscriptions, 4: current version of Subscriptions, 5-6: opening/closing tags linked to ticket form, 7-8: opening/closing tags linked to documentation.
-		$admin_notice->set_simple_content( sprintf( esc_html__( '%1$sWarning!%2$s It appears that you have downgraded %1$sWooCommerce Subscriptions%2$s from %3$s to %4$s. Downgrading the plugin in this way may cause issues. Please update to %3$s or higher, or %5$sopen a new support ticket%6$s for further assistance. %7$sLearn more &raquo;%8$s', 'woocommerce-subscriptions' ),
-			'<strong>', '</strong>',
-			'<code>' . self::$active_version . '</code>',
-			'<code>' .  WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() . '</code>',
-			'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">', '</a>',
-			'<a href="https://docs.woocommerce.com/document/subscriptions/upgrade-instructions/#section-12" target="_blank">', '</a>'
-		) );
-
-		$admin_notice->display();
-	}
-
-	/**
 	 * When updating WC to a version after 3.0 from a version prior to 3.0, schedule the repair script to add address indexes.
 	 *
 	 * @since 2.3.0
@@ -959,5 +933,32 @@ class WC_Subscriptions_Upgrader {
 	 */
 	public static function repair_subtracted_base_taxes( $item_id ) {
 		self::$background_updaters['3.1']['subtracted_base_tax_repair']->repair_item( $item_id );
+	}
+
+	/**
+	 * Display an admin notice if the database version is greater than the active version of the plugin by at least one minor release (eg 1.1 and 1.0).
+	 *
+	 * @since 2.3.0
+	 * @deprecated 4.0.0
+	 */
+	public static function maybe_add_downgrade_notice() {
+		wcs_deprecated_function( __METHOD__, '4.0.0' );
+
+		// If there's no downgrade, exit early. self::$active_version is a bit of a misnomer here but in an upgrade context it refers to the database version of the plugin.
+		if ( ! version_compare( wcs_get_minor_version_string( self::$active_version ), wcs_get_minor_version_string( WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() ), '>' ) ) {
+			return;
+		}
+
+		$admin_notice = new WCS_Admin_Notice( 'error' );
+		// translators: 1-2: opening/closing <strong> tags, 3: active version of Subscriptions, 4: current version of Subscriptions, 5-6: opening/closing tags linked to ticket form, 7-8: opening/closing tags linked to documentation.
+		$admin_notice->set_simple_content( sprintf( esc_html__( '%1$sWarning!%2$s It appears that you have downgraded %1$sWooCommerce Subscriptions%2$s from %3$s to %4$s. Downgrading the plugin in this way may cause issues. Please update to %3$s or higher, or %5$sopen a new support ticket%6$s for further assistance. %7$sLearn more &raquo;%8$s', 'woocommerce-subscriptions' ),
+			'<strong>', '</strong>',
+			'<code>' . self::$active_version . '</code>',
+			'<code>' .  WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() . '</code>',
+			'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">', '</a>',
+			'<a href="https://docs.woocommerce.com/document/subscriptions/upgrade-instructions/#section-12" target="_blank">', '</a>'
+		) );
+
+		$admin_notice->display();
 	}
 }

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -892,6 +892,18 @@ class WC_Subscriptions_Upgrader {
 	}
 
 	/**
+	 * Repair a single item's subtracted base tax meta.
+	 *
+	 * @since 3.1.0
+	 * @param int $item_id The ID of the item which needs repairing.
+	 */
+	public static function repair_subtracted_base_taxes( $item_id ) {
+		self::$background_updaters['3.1']['subtracted_base_tax_repair']->repair_item( $item_id );
+	}
+
+	/* Deprecated Functions */
+
+	/**
 	 * Handles the WC 3.5.0 upgrade routine that moves customer IDs from post metadata to the 'post_author' column.
 	 *
 	 * @since 2.4.0
@@ -923,16 +935,6 @@ class WC_Subscriptions_Upgrader {
 	public static function is_user_upgraded_to_1_4( $user_id ) {
 		_deprecated_function( __METHOD__, '2.0', 'WCS_Upgrade_1_4::is_user_upgraded( $user_id )' );
 		return WCS_Upgrade_1_4::is_user_upgraded( $user_id );
-	}
-
-	/**
-	 * Repair a single item's subtracted base tax meta.
-	 *
-	 * @since 3.1.0
-	 * @param int $item_id The ID of the item which needs repairing.
-	 */
-	public static function repair_subtracted_base_taxes( $item_id ) {
-		self::$background_updaters['3.1']['subtracted_base_tax_repair']->repair_item( $item_id );
 	}
 
 	/**

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -950,14 +950,20 @@ class WC_Subscriptions_Upgrader {
 		}
 
 		$admin_notice = new WCS_Admin_Notice( 'error' );
-		// translators: 1-2: opening/closing <strong> tags, 3: active version of Subscriptions, 4: current version of Subscriptions, 5-6: opening/closing tags linked to ticket form, 7-8: opening/closing tags linked to documentation.
-		$admin_notice->set_simple_content( sprintf( esc_html__( '%1$sWarning!%2$s It appears that you have downgraded %1$sWooCommerce Subscriptions%2$s from %3$s to %4$s. Downgrading the plugin in this way may cause issues. Please update to %3$s or higher, or %5$sopen a new support ticket%6$s for further assistance. %7$sLearn more &raquo;%8$s', 'woocommerce-subscriptions' ),
-			'<strong>', '</strong>',
-			'<code>' . self::$active_version . '</code>',
-			'<code>' .  WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() . '</code>',
-			'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">', '</a>',
-			'<a href="https://docs.woocommerce.com/document/subscriptions/upgrade-instructions/#section-12" target="_blank">', '</a>'
-		) );
+		$admin_notice->set_simple_content(
+			sprintf(
+				// translators: 1-2: opening/closing <strong> tags, 3: active version of Subscriptions, 4: current version of Subscriptions, 5-6: opening/closing tags linked to ticket form, 7-8: opening/closing tags linked to documentation.
+				esc_html__( '%1$sWarning!%2$s It appears that you have downgraded %1$sWooCommerce Subscriptions%2$s from %3$s to %4$s. Downgrading the plugin in this way may cause issues. Please update to %3$s or higher, or %5$sopen a new support ticket%6$s for further assistance. %7$sLearn more &raquo;%8$s', 'woocommerce-subscriptions' ),
+				'<strong>',
+				'</strong>',
+				'<code>' . self::$active_version . '</code>',
+				'<code>' . WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() . '</code>',
+				'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">',
+				'</a>',
+				'<a href="https://docs.woocommerce.com/document/subscriptions/upgrade-instructions/#section-12" target="_blank">',
+				'</a>'
+			)
+		);
 
 		$admin_notice->display();
 	}

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -939,10 +939,10 @@ class WC_Subscriptions_Upgrader {
 	 * Display an admin notice if the database version is greater than the active version of the plugin by at least one minor release (eg 1.1 and 1.0).
 	 *
 	 * @since 2.3.0
-	 * @deprecated 4.0.0
+	 * @deprecated 1.2.0
 	 */
 	public static function maybe_add_downgrade_notice() {
-		wcs_deprecated_function( __METHOD__, '4.0.0' );
+		wcs_deprecated_function( __METHOD__, '1.2.0' );
 
 		// If there's no downgrade, exit early. self::$active_version is a bit of a misnomer here but in an upgrade context it refers to the database version of the plugin.
 		if ( ! version_compare( wcs_get_minor_version_string( self::$active_version ), wcs_get_minor_version_string( WC_Subscriptions_Core_Plugin::instance()->get_plugin_version() ), '>' ) ) {


### PR DESCRIPTION
Fixes #12

#### Changes proposed in this Pull Request

<!--
Title: A descriptive, yet concise, title.
-->
 - Dont' show a downgrade notice whenever subscriptions has been downgraded by a minor version

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This admin notice was previously used to make store managers aware that downgrading Subscriptions to a previous version could have consequences however, this was really only the case for stores that downgraded to much older version of Subscriptions (like 1.5.0).

Because the subscriptions core library is being used in two extensions, there's now a much higher chance that stores will downgrade their subscriptions version but it's not a big deal anymore.

In this PR, I've deprecated this downgrade notice so that it's no longer shown.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

#### Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Clone this repo into `wp-content/plugins`
1. Activate the WooCommerce Subscriptions Core plugin so that these changes are loaded by WC Payments and WC Subscriptions
1. Activate the Woocommerce Subscriptions extension (trunk version)
1. While on `trunk`of this repo, go into `woocommerce-subscriptions.php` and change the `$version` static variable to something like: `'2.9.0'`
1. Load any admin page and you should see a "downgraded notice"
1. Checkout this branch 
1. No admin notice

-------------------

- [ ] Added changelog entry (or does not apply)
- [ ] Covered with tests (or have a good reason not to test in description ☝️)
- [ ] Tested on mobile (or does not apply)

**Post merge**

<!--
Make sure you edit the page for the current release when adding testing instructions.
We often create a blank page ahead of time for the next release.
-->

