### PR TITLE
Fixes minor deprecation issues in Subscriptions Core

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2021-xx-xx - version 1.3.0
+* Tweak: Update deprecation message when calling WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon() to mention the correct replacement function. PR#53
+
 2021-11-23 - version 1.2.0
 * Fix: Update tooltip wording when deleting product variation. PR#46
 * Fix: Don't show an admin error notice when a store downgrades to a previous minor version of Subscriptions. WCS#4271

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -1175,7 +1175,7 @@ class WC_Subscriptions_Coupon {
 	 * @deprecated 4.0.0
 	 */
 	public static function cart_contains_limited_recurring_coupon() {
-		wcs_deprecated_function( __METHOD__, '4.0.0', 'WCS_Limited_Recurring_Coupon_Manager::coupon_is_limited() if available' );
+		wcs_deprecated_function( __METHOD__, '4.0.0', 'WCS_Limited_Recurring_Coupon_Manager::cart_contains_limited_recurring_coupon() if available' );
 		if ( class_exists( 'WCS_Limited_Recurring_Coupon_Manager' ) ) {
 			return WCS_Limited_Recurring_Coupon_Manager::cart_contains_limited_recurring_coupon();
 		}

--- a/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
+++ b/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
@@ -86,10 +86,6 @@ class WC_Subscriptions_Deprecation_Handler extends WCS_Deprecated_Functions_Hand
 			'version'     => '4.0.0',
 		),
 		'redirect_to_cart' => array(
-			'replacement' => array( 'WCS_Template_Loader', 'get_my_subscriptions' ),
-			'version'     => '4.0.0',
-		),
-		'redirect_to_cart' => array(
 			'replacement' => array( __CLASS__, '_redirect_to_cart' ),
 			'version'     => '4.0.0',
 		),


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

While writing out a list of deprecated functions in Subscriptions 4.0.0, I noticed a few small wording/non-critical issues with some of our deprecation handling. These are caused by simple copy-paste mistakes.

Issues:

1. The deprecated message in `WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon()` was a copy-paste from the above deprecated function and mentioned the wrong replacement function.
2. Inside `WC_Subscriptions_Deprecation_Handler`, the `redirect_to_cart` was listed twice in the array of `$deprecated_functions` and had the wrong replacement function (was copy-pasted from the above line). This doesn't break anything and isn't a big issue because the next line has the same array key and will override this incorrect value.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

No testing should be needed for this PR as the only testable thing is just changing wording 😅 
If you wanted to, you could confirm that calling `WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon()` threw a deprecated notice with the incorrect replacement function listed.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Affects WC Subscriptions?
   - It does affect WC Subscriptions but deprecation notices haven't been released in WC Subscriptions yet so no changelog needed
- [x] Affects WooCommerce Payments?

While this technically does affect WC Payments, it's very unlikely anyone was calling this deprecated function. To give some background, this function was deprecated because it was moved in the upcoming Subscriptions 4.0 release to its own class. If any custom code was using this function with only WC Pay Subscriptions + Subscriptions Core, the function would return false since `WCS_Limited_Recurring_Coupon_Manager` is only available in Subscriptions 4.0.