### PR TITLE
Update tooltips used on the Payment Methods page to remove references to the Subscriptions Extension

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2021-xx-xx - version 1.3.0
-* Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55
+* Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234
 * Fix: Update the Automatic Recurring Payments column on the Payment Methods table to only show which payment methods are supported by Subscriptions Core. PR#55
 * Tweak: Update deprecation message when calling WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon() to mention the correct replacement function. PR#53
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2021-xx-xx - version 1.3.0
-* Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#
-* Fix: Update the Automatic Recurring Payments column on the Payment Methods table to only show which payment methods are supported by Subscriptions Core. PR#
+* Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55
+* Fix: Update the Automatic Recurring Payments column on the Payment Methods table to only show which payment methods are supported by Subscriptions Core. PR#55
 * Tweak: Update deprecation message when calling WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon() to mention the correct replacement function. PR#53
 
 2021-11-23 - version 1.2.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2021-xx-xx - version 1.3.0
+* Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#
+* Fix: Update the Automatic Recurring Payments column on the Payment Methods table to only show which payment methods are supported by Subscriptions Core. PR#
 * Tweak: Update deprecation message when calling WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon() to mention the correct replacement function. PR#53
 
 2021-11-23 - version 1.2.0

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1597,8 +1597,10 @@ class WC_Subscriptions_Admin {
 	 * @since 2.5.3
 	 */
 	public static function payment_gateways_renewal_support( $gateway ) {
+		$payment_gateways_handler = WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class();
+
 		echo '<td class="renewals">';
-		if ( ( is_array( $gateway->supports ) && in_array( 'subscriptions', $gateway->supports ) ) || $gateway->id == 'paypal' ) {
+		if ( $payment_gateways_handler::gateway_supports_subscriptions( $gateway ) ) {
 			$status_html = '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Supports automatic renewal payments.', 'woocommerce-subscriptions' ) . '">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
 		} else {
 			$status_html = '-';

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1599,7 +1599,7 @@ class WC_Subscriptions_Admin {
 	public static function payment_gateways_renewal_support( $gateway ) {
 		echo '<td class="renewals">';
 		if ( ( is_array( $gateway->supports ) && in_array( 'subscriptions', $gateway->supports ) ) || $gateway->id == 'paypal' ) {
-			$status_html = '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Supports automatic renewal payments with the WooCommerce Subscriptions extension.', 'woocommerce-subscriptions' ) . '">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
+			$status_html = '<span class="status-enabled tips" data-tip="' . esc_attr__( 'Supports automatic renewal payments.', 'woocommerce-subscriptions' ) . '">' . esc_html__( 'Yes', 'woocommerce-subscriptions' ) . '</span>';
 		} else {
 			$status_html = '-';
 		}

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -200,7 +200,7 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	 */
 	public static function payment_gateways_support_tooltip( $status_html, $gateway ) {
 
-		if ( ( ! is_array( $gateway->supports ) || ! in_array( 'subscriptions', $gateway->supports ) ) && 'paypal' !== $gateway->id ) {
+		if ( ! static::gateway_supports_subscriptions( $gateway ) ) {
 			return $status_html;
 		}
 
@@ -269,6 +269,17 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	 */
 	public static function has_available_payment_method( $subscription ) {
 		return 'woocommerce_payments' === $subscription->get_payment_method() && method_exists( WC_Payments_Subscription_Service::class, 'is_wcpay_subscription' ) && WC_Payments_Subscription_Service::is_wcpay_subscription( $subscription ) ? true : false;
+	}
+
+	/**
+	 * Returns whether the gateway supports subscriptions and automatic renewals.
+	 *
+	 * @since 1.3.0
+	 * @param WC_Gateway $gateway Gateway to check if it supports subscriptions.
+	 * @return bool
+	 */
+	public static function gateway_supports_subscriptions( $gateway ) {
+		return ! empty( $gateway->id ) && 'woocommerce_payments' === $gateway->id;
 	}
 
 	/**


### PR DESCRIPTION
Issues: Automattic/woocommerce-payments#3234

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

This PR is making some minor improvements to the **WooCommerce > Settings > Payment Methods** table to clear up some confusion when store managers are using WCPay Subscriptions versus WC Subscriptions extension. The changes in this PR include:

1. Update tooltips to remove mentions of the Subscriptions extension
2. Don't show a ✔️  in the "supports automatic recurring payments" column when the gateway isn't supported by Subscriptions Core

On `trunk`, when you hover over a tooltip next to a payment method, the tooltip mentions that this gateway supports recurring payments with the WooCommerce Subscriptions extension.

This tooltip doesn't make sense for stores that don't have this extension and are using Subscriptions Core bundled in WC Payments. In https://github.com/Automattic/woocommerce-payments/issues/3234#issuecomment-955839975, my suggestion was to remove the mention of the extension which I've done in this PR.

The other thing I noticed is when you don't have WC Subscriptions activated, and you're using WCPay Subscriptions, when you view the Payment Methods table, you shouldn't see that PayPal Standard also supports automatic recurring payments.

When WCPay Subscriptions is being used, only WooCommerce Payments is supported so I made a change to make it so only WooCommerce Payments will show up as supports Automatic Recurring Payments.

![image](https://user-images.githubusercontent.com/2275145/144517752-857dba4e-7cc7-4a6e-80bd-376953cf2815.png)

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Deactivate Subscriptions extension
2. Activate WC Payments and make sure WCPay Subscriptions feature is enabled
3. Activate the WooCommerce Subscriptions Core extension and checkout `trunk`
5. Go into **WooCommerce > Settings > Payments > All payment methods**
6. Notice that WooCommerce Payments and PayPal Standard say they support automatic recurring payments :x:
7. Notice hovering over the tooltip says it's supported with the WooCommerce Subscriptions extension :x:
8. Checkout `fix/recurring-payment-gateway-support-tooltip` and refresh the page
9. Notice only WooCommerce Payments says it supports automatic recurring payments ✅ 
10. Hover over the tooltip and confirm it no longer says it's supported with the extension ✅ 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref

**WooCommerce Subscriptions** will need to be patched to override Subscriptions Core introduced with this PR. See: https://github.com/woocommerce/woocommerce-subscriptions/pull/4279
