### PR TITLE
Fix incorrect text when filtering subscriptions with no results

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234
 * Fix: Update the Automatic Recurring Payments column on the Payment Methods table to only show which payment methods are supported by Subscriptions Core. PR#55
 * Tweak: Update deprecation message when calling WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon() to mention the correct replacement function. PR#53
+* Fix: Incorrect text when filtering subscriptions to no results.
 
 2021-11-23 - version 1.2.0
 * Fix: Update tooltip wording when deleting product variation. PR#46

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -312,7 +312,7 @@ class WC_Subscriptions_Core_Plugin {
 	public function register_order_types() {
 		$subscriptions_exist = $this->cache->cache_and_get( 'wcs_do_subscriptions_exist', 'wcs_do_subscriptions_exist' );
 
-		if ( true === apply_filters( 'woocommerce_subscriptions_not_empty', $subscriptions_exist ) ) {
+		if ( true === (bool) apply_filters( 'woocommerce_subscriptions_not_empty', $subscriptions_exist ) ) {
 			$not_found_text = __( 'No Subscriptions found', 'woocommerce-subscriptions' );
 		} else {
 			$not_found_text = '<p>' . __( 'Subscriptions will appear here for you to view and manage once purchased by a customer.', 'woocommerce-subscriptions' ) . '</p>';


### PR DESCRIPTION
Fixes #51

## Description

Currently, if you filter your WooCommerce > Subscriptions table so that no results are returned (e.g. by searching for a string that doesn't exist in any of your subscriptions), you'll see the message "Subscriptions will appear here for you to view and manage..." instead of the no results found message "No Subscriptions found."

@james-allan identified in #51 that this is because the transient `_transient_wcs_do_subscriptions_exist` is stored as an int, but we compare it to `true`. This PR casts the transient to a bool before performing the comparison, so that the correct text appears.

## How to test this PR

Test the following with both WCPay Subscriptions and WooCommerce Subscriptions:

1. Go to **WooCommerce > Subscriptions**.
2. In the search field, type a random string and click "Search Subscriptions."
3. Verify that you see the message "No Subscriptions found".

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref: https://github.com/Automattic/woocommerce-payments/issues/3412
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref: https://github.com/woocommerce/woocommerce-subscriptions/issues/4274
