### PR TITLE
Update recurring payments copy on payment gateways page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234
 * Fix: Update the Automatic Recurring Payments column on the Payment Methods table to only show which payment methods are supported by Subscriptions Core. PR#55
 * Tweak: Update deprecation message when calling WC_Subscriptions_Coupon::cart_contains_limited_recurring_coupon() to mention the correct replacement function. PR#53
+* Tweak: Update recurring payments copy on payment gateways page.
 
 2021-11-23 - version 1.2.0
 * Fix: Update tooltip wording when deleting product variation. PR#46

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1742,7 +1742,7 @@ class WC_Subscriptions_Admin {
 					'type' => 'informational',
 				),
 			),
-			WC_Subscriptions_Admin::$option_prefix,
+			self::$option_prefix
 		);
 
 		$insert_index = array_search(

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1711,9 +1711,8 @@ class WC_Subscriptions_Admin {
 	}
 
 	/**
-	 * Add recurring payment gateway information after the Settings->Checkout->Payment Gateways table.
-	 * This includes links to find additional gateways, information about manual renewals
-	 * and a warning if no payment gateway which supports automatic recurring payments is enabled/setup correctly.
+	 * Add recurring payment gateway information after the Settings->Payments->Payment Methods table.
+	 * This includes information about manual renewals and a warning if no payment gateway which supports automatic recurring payments is enabled/setup correctly.
 	 *
 	 * @since 2.1
 	 */

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1726,27 +1726,24 @@ class WC_Subscriptions_Admin {
 			$available_gateways_description = sprintf( __( 'No payment gateways capable of processing automatic subscription payments are enabled. If you would like to process automatic payments, we recommend the %1$sfree Stripe extension%2$s.', 'woocommerce-subscriptions' ), '<strong><a href="https://www.woocommerce.com/products/stripe/">', '</a></strong>' );
 		}
 
-		$recurring_payment_settings = array(
+		$recurring_payment_settings = apply_filters(
+			'woocommerce_subscriptions_admin_recurring_payment_information',
 			array(
-				'name' => __( 'Recurring Payments', 'woocommerce-subscriptions' ),
-				'desc' => $available_gateways_description,
-				'id'   => WC_Subscriptions_Admin::$option_prefix . '_payment_gateways_available',
-				'type' => 'informational',
-			),
+				array(
+					'name' => __( 'Recurring Payments', 'woocommerce-subscriptions' ),
+					'desc' => $available_gateways_description,
+					'id'   => WC_Subscriptions_Admin::$option_prefix . '_payment_gateways_available',
+					'type' => 'informational',
+				),
 
-			array(
-				// translators: placeholders are opening and closing link tags
-				'desc' => sprintf( __( 'Payment gateways which don\'t support automatic recurring payments can be used to process %1$smanual subscription renewal payments%2$s.', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/renewal-process/">', '</a>' ),
-				'id'   => WC_Subscriptions_Admin::$option_prefix . '_payment_gateways_additional',
-				'type' => 'informational',
+				array(
+					// translators: placeholders are opening and closing link tags
+					'desc' => sprintf( __( 'Payment gateways which don\'t support automatic recurring payments can be used to process %1$smanual subscription renewal payments%2$s.', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/renewal-process/">', '</a>' ),
+					'id'   => WC_Subscriptions_Admin::$option_prefix . '_payment_gateways_additional',
+					'type' => 'informational',
+				),
 			),
-
-			array(
-				// translators: $1-$2: opening and closing tags. Link to documents->payment gateways, 3$-4$: opening and closing tags. Link to WooCommerce extensions shop page
-				'desc' => sprintf( __( 'Find new gateways that %1$ssupport automatic subscription payments%2$s in the official %3$sWooCommerce Marketplace%4$s.', 'woocommerce-subscriptions' ), '<a href="' . esc_url( 'http://docs.woocommerce.com/document/subscriptions/payment-gateways/' ) . '">', '</a>', '<a href="' . esc_url( 'http://www.woocommerce.com/product-category/woocommerce-extensions/' ) . '">', '</a>' ),
-				'id'   => WC_Subscriptions_Admin::$option_prefix . '_payment_gateways_additional',
-				'type' => 'informational',
-			),
+			WC_Subscriptions_Admin::$option_prefix,
 		);
 
 		$insert_index = array_search(


### PR DESCRIPTION
Fixes #52
Related: https://github.com/Automattic/woocommerce-payments/issues/3402

## Description

Currently, subscriptions-core makes reference to finding "new gateways that support automatic subscription payments" on the payment gateways page. This message should only be shown for WooCommerce Subscriptions and not in WCPay Subscriptions (where WCPay is the required gateway).

This PR removes that line from subscriptions-core and passes it through a new filter. A separate PR (https://github.com/woocommerce/woocommerce-subscriptions/pull/4283) in WooCommerce Subscriptions will use the filter to add the line back for WooCommerce Subscriptions only.

## How to test this PR

Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout` and verify that you no longer see the "Find new gateways that support automatic subscription payments" text.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
