### PR TITLE
Show the subscription fields when the product type is simple subscription

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -74,6 +74,10 @@ jQuery( function ( $ ) {
 					$.showOrHideStockFields();
 				}
 
+				if ( 'subscription' === $( 'select#product-type' ).val() ) {
+					$( '.show_if_subscription' ).show();
+				}
+
 				// Restore the sale price row width to half
 				$( '.sale_price_dates_fields' )
 					.prev( '.form-row' )

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -76,6 +76,7 @@ jQuery( function ( $ ) {
 
 				if ( 'subscription' === $( 'select#product-type' ).val() ) {
 					$( '.show_if_subscription' ).show();
+					$( '.hide_if_subscription' ).hide();
 				}
 
 				// Restore the sale price row width to half

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2022-xx-x - version 1.4.0
+* Fix: Simple subscription elements on the product edit page not shown/hidden when necessary. PR#80
 
 2021-12-21 - version 1.3.0
 * Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234


### PR DESCRIPTION
Fixes #75
Fixes https://github.com/Automattic/woocommerce-payments/issues/3537

## Description

Fixes an issue introduced in da32cf1d9073b40ca32d34a9381a9a6d2288aeb3 when creating a Simple Subscription product:

- the "One time shipping" option under **Product Data > Shipping** and; 
- the "Limit Subscription" option under **Product Data > Advanced**, 
are hidden.

## How to test this PR

**Note:** these steps are largely copied from 4215-gh-woocommerce/woocommerce-subscriptions

<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
<!-- Please include screenshots. -->
1. Add the following code to your site somewhere (e.g. as a mu-plugin). 
1. Go to **Products > Add new**. 
1. Select the **New Variable**.
2. Go to the **Attributes** tab and add an attribute with attribute values.
3. Check the **'Used for variations'** checkbox.
4. Go to the **Variations** tab.
5. Click **go**. 
6. Expand the variation level settings.
7. Observe, there shouldn't be any subscription-related fields shown. https://d.pr/i/WIu1jH
8. Change the product type to **"Simple subscription"**.
9. Click the **"Shipping"** tab.
10. Observe, the **"One time shipping"** option is available https://d.pr/i/FaARPN
11. Click the **"Advanced"** tab.
12. Observe, the **"Limit subscription"** option is available https://d.pr/i/Ga30Bg
13. Change the product type to **"Variable subscription"**.
14. Click the **"Shipping"** tab.
15. Observe, the **"One time shipping"** option is available https://d.pr/i/z6jv9H
16. Click the **"Advanced"** tab.
17. Observe, the **"Limit subscription"** option is available https://d.pr/i/5vuRVE
18. Change the product type to **"Simple product"**.
19. Click the **"Shipping"** tab.
20. Observe, the **"One time shipping"** option is not available.
21. Click the **"Advanced"** tab.
22. Observe, the **"Limit subscription"** option is not available.

```php
/**
 * Add option to product type selector.
 */
function kia_new_variable_product_type( $product_types ){
    $product_types[ 'new-variable' ] = 'New Variable';
    return $product_types;
}
add_filter( 'product_type_selector', 'kia_new_variable_product_type' );

/**
 * Define new product class.
 */
function kia_create_new_product_class(){
    class WC_Product_New_Variable extends WC_Product_Variable {


        public function __construct( $product ) {

            $this->product_type = 'new-variable';
            parent::__construct( $product );

        }

        public function get_type() {
            return 'new-variable'; // so you can use $product = wc_get_product(); $product->get_type()
        }

    }
}
add_action( 'woocommerce_loaded', 'kia_create_new_product_class' );

/**
 * Custom JS for metaboxes.
 */
function kia_producttype_custom_js() {

	wp_add_inline_script( 'wc-admin-product-meta-boxes', '
		jQuery( function( $ ) {
				$( ".variations_tab" ).addClass( "show_if_new-variable" );

				$( document.body ).on( "woocommerce_added_attribute", function() {
					$( ".enable_variation" ).addClass( "show_if_new-variable" );

					if ( "new-variable" === $( "select#product-type" ).val() ) {
						$( ".enable_variation" ).show();
					}
				});
			} );
	', 'before' );
}
add_action( 'admin_enqueue_scripts', 'kia_producttype_custom_js', 99 );

/**
 * Use existing data store.
 */
function kia_new_variable_data_store( $stores ) {
    $stores['product-new-variable'] = 'WC_Product_Variable_Data_Store_CPT';
    return $stores;
}
add_filter( 'woocommerce_data_stores', 'kia_new_variable_data_store' );
```

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref