### PR TITLE
Increase version to 1.4.0.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-2022-xx-x - version 1.4.0
+2022-01-03 - version 1.4.0
 * Fix: Simple subscription elements on the product edit page not shown/hidden when necessary. PR#80
 
 2021-12-21 - version 1.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-subscriptions-core",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-subscriptions-core",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -22225,7 +22225,7 @@
 			"version": "2.6.12",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
 			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-			"deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+			"deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
 			"dev": true,
 			"hasInstallScript": true
 		},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "WooCommerce Subscriptions Core",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
 	"main": "Gruntfile.js",

--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -6,5 +6,5 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Requires WP: 5.6
- * Version: 1.3.0
+ * Version: 1.4.0
  */


### PR DESCRIPTION
## Description

This PR:
- Updates changelog release date for `1.4.0`.
- Updates version in `package.json` and `woocommerce-subscriptions-core.php` to `1.4.0`.
- Updates `package-lock.json` as a result of running `npm install`.

## How to test this PR

- Make sure release date for `1.4.0` is correct.
- Make sure versions are updated in `package.json` and `woocommerce-subscriptions-core.php`.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes. 4290-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments? yes.