### PR TITLE
Prevent fatal errors on subscriptions table screen 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2022-xx-x - version 1.4.0
 * Fix: Simple subscription elements on the product edit page not shown/hidden when necessary. PR#80
+* Fix: Prevent fatal errors on the admin subscriptions screen when a subscription fails to load. PR#84 wcpay#3596 wcs#4286
 
 2021-12-21 - version 1.3.0
 * Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -445,6 +445,23 @@ class WCS_Admin_Post_Types {
 			$the_subscription = wcs_get_subscription( $post->ID );
 		}
 
+		// If the subscription failed to load, only display the ID.
+		if ( empty( $the_subscription ) ) {
+			if ( 'order_title' === $column ) {
+				// translators: placeholder is an subscription ID.
+				echo '<strong>' . sprintf( esc_html_x( '#%s', 'hash before subscription number', 'woocommerce-subscriptions' ), esc_html( $post->ID ) ) . '</strong>';
+				?>
+				<div class="wcs-unknown-order-info-wrapper">
+					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18"><?php echo wcs_help_tip( sprintf( "This subscription couldn't be loaded from the database. %s Click to learn more.", '</br>' ) ); ?></a> <?php // @codingStandardsIgnoreLine ?>
+				</div>
+				<?php
+			} else {
+				echo '&mdash;';
+			}
+
+			return;
+		}
+
 		$column_content = '';
 
 		switch ( $column ) {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -452,7 +452,7 @@ class WCS_Admin_Post_Types {
 				echo '<strong>' . sprintf( esc_html_x( '#%s', 'hash before subscription number', 'woocommerce-subscriptions' ), esc_html( $post->ID ) ) . '</strong>';
 				?>
 				<div class="wcs-unknown-order-info-wrapper">
-					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18"><?php echo wcs_help_tip( sprintf( "This subscription couldn't be loaded from the database. %s Click to learn more.", '</br>' ) ); ?></a> <?php // @codingStandardsIgnoreLine ?>
+					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18"><?php echo wcs_help_tip( sprintf( "This subscription couldn't be loaded from the database. %s Click to learn more.", '</br>' ) ); ?></a><?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</div>
 				<?php
 			} else {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -452,8 +452,12 @@ class WCS_Admin_Post_Types {
 				echo '<strong>' . sprintf( esc_html_x( '#%s', 'hash before subscription number', 'woocommerce-subscriptions' ), esc_html( $post->ID ) ) . '</strong>';
 				?>
 				<div class="wcs-unknown-order-info-wrapper">
-					<?php // Translators: Placeholder is a <br> HTML tag. ?>
-					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18"><?php echo wcs_help_tip( sprintf( __( "This subscription couldn't be loaded from the database. %s Click to learn more.", 'woocommerce-subscriptions' ), '</br>' ) ); ?></a><?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18">
+						<?php
+						// Translators: Placeholder is a <br> HTML tag.
+						echo wcs_help_tip( sprintf( __( "This subscription couldn't be loaded from the database. %s Click to learn more.", 'woocommerce-subscriptions' ), '</br>' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
+					</a>
 				</div>
 				<?php
 			} else {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -452,7 +452,8 @@ class WCS_Admin_Post_Types {
 				echo '<strong>' . sprintf( esc_html_x( '#%s', 'hash before subscription number', 'woocommerce-subscriptions' ), esc_html( $post->ID ) ) . '</strong>';
 				?>
 				<div class="wcs-unknown-order-info-wrapper">
-					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18"><?php echo wcs_help_tip( sprintf( "This subscription couldn't be loaded from the database. %s Click to learn more.", '</br>' ) ); ?></a><?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php // Translators: Placeholder is a <br> HTML tag. ?>
+					<a href="https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18"><?php echo wcs_help_tip( sprintf( __( "This subscription couldn't be loaded from the database. %s Click to learn more.", 'woocommerce-subscriptions' ), '</br>' ) ); ?></a><?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</div>
 				<?php
 			} else {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -436,7 +436,7 @@ class WCS_Admin_Post_Types {
 
 	/**
 	 * Output custom columns for subscriptions
-	 * @param  string $column
+	 * @param string $column
 	 */
 	public function render_shop_subscription_columns( $column ) {
 		global $post, $the_subscription, $wp_list_table;
@@ -448,7 +448,7 @@ class WCS_Admin_Post_Types {
 		// If the subscription failed to load, only display the ID.
 		if ( empty( $the_subscription ) ) {
 			if ( 'order_title' === $column ) {
-				// translators: placeholder is an subscription ID.
+				// translators: placeholder is a subscription ID.
 				echo '<strong>' . sprintf( esc_html_x( '#%s', 'hash before subscription number', 'woocommerce-subscriptions' ), esc_html( $post->ID ) ) . '</strong>';
 				?>
 				<div class="wcs-unknown-order-info-wrapper">

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -18,7 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order_id ) );
 		?>
 		<div class="wcs-unknown-order-info-wrapper">
-			<a href="https://docs.woocommerce.com/document/subscriptions/orders/#section-8"><?php echo wcs_help_tip( sprintf( "This %s couldn't be loaded from the database. %s Click to learn more.", $relationship, '</br>' ) ); ?></a>
+			<?php // Translators: Placeholder is a <br> HTML tag. ?>
+			<a href="https://docs.woocommerce.com/document/subscriptions/orders/#section-8"><?php echo wcs_help_tip( sprintf( __( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ), $relationship, '</br>' ) ); ?></a> <?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 	</td>
 	<td><?php echo esc_html( $relationship ); ?></td>

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -18,8 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order_id ) );
 		?>
 		<div class="wcs-unknown-order-info-wrapper">
-			<?php // Translators: Placeholder is a <br> HTML tag. ?>
-			<a href="https://docs.woocommerce.com/document/subscriptions/orders/#section-8"><?php echo wcs_help_tip( sprintf( __( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ), $relationship, '</br>' ) ); ?></a> <?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<a href="https://docs.woocommerce.com/document/subscriptions/orders/#section-8">
+				<?php
+				// Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
+				echo wcs_help_tip( sprintf( __( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ), $relationship, '</br>' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
+			</a>
 		</div>
 	</td>
 	<td><?php echo esc_html( $relationship ); ?></td>


### PR DESCRIPTION
## Description

When a subscription fails to load on the admin subscriptions table, instead of causing a fatal error by trying to call functions (like `get_status()`) on that incomplete subscription object, display just the ID and a tooltip which links to documentation with an explainer and troubleshooting steps.

## How to test this PR

It'll be hard to replicate this issue in a legitimate way given you need to have a corrupt subscription. The easiest way to do this might be to just go into the database and mess with one of your subscription's post data. eg setting your next payment date meta to a dummy string.

<img width="530.4" alt="Screen Shot 2022-01-05 at 11 56 36 am" src="https://user-images.githubusercontent.com/8490476/148148478-30691cb0-e408-403c-98b4-4768dbe83623.png">

1. After corrupting one or more of your subscriptions visit the admin **WooCommerce > Subscriptions** table.
    - On subscriptions-core trunk you will get a [fatal error](https://user-images.githubusercontent.com/8490476/148149271-774357ca-fb62-4092-b88d-f933275b73e9.png). 
    - On this branch of subscriptions-core you will see the subscription's [Post ID and a tooltip](https://user-images.githubusercontent.com/8490476/148148758-e6f4d795-ddda-4ef1-b093-8089f7a43f2e.png).
2. Clicking on the (?) tooltip will send you to this [accompanying documentation](https://woocommerce.com/document/subscriptions/store-manager-guide/#section-18) 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions?
    - 4286-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments?
    - https://github.com/Automattic/woocommerce-payments/issues/3596