### PR TITLE
Handle relocated templates.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2022-01-03 - version 1.4.0
 * Fix: Simple subscription elements on the product edit page not shown/hidden when necessary. PR#80
 * Fix: Prevent fatal errors on the admin subscriptions screen when a subscription fails to load. PR#84 wcpay#3596 wcs#4286
+* Fix: Compatibility issue when loading subscriptions templates. PR#86 wcpay#3606 wcs#4291
 
 2021-12-21 - version 1.3.0
 * Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234

--- a/includes/class-wcs-template-loader.php
+++ b/includes/class-wcs-template-loader.php
@@ -384,7 +384,7 @@ class WCS_Template_Loader {
 			return $template;
 		}
 
-		return $subscriptions_core_path . 'templates/' . self::$relocated_templates[ $template_file ] . $template_file;
+		return $subscriptions_core_path . '/templates/' . self::$relocated_templates[ $template_file ] . $template_file;
 	}
 
 	/**

--- a/includes/class-wcs-template-loader.php
+++ b/includes/class-wcs-template-loader.php
@@ -10,67 +10,67 @@ class WCS_Template_Loader {
 	/**
 	 * Relocated templates from WooCommerce Subscriptions.
 	 *
-	 * @var array[]
+	 * @var array[] Array of file names and their directory found in templates/
 	 */
 	private static $relocated_templates = [
-		'admin/deprecated/html-variation-price.php',
-		'admin/deprecated/html-variation-synchronisation.php',
-		'admin/deprecated/order-shipping-html.php',
-		'admin/deprecated/order-tax-html.php',
-		'admin/html-admin-notice.php',
-		'admin/html-failed-scheduled-action-notice.php',
-		'admin/html-variation-price.php',
-		'admin/html-variation-synchronisation.php',
-		'admin/status.php',
-		'cart/cart-recurring-shipping.php',
-		'checkout/form-change-payment-method.php',
-		'checkout/recurring-coupon-totals.php',
-		'checkout/recurring-fee-totals.php',
-		'checkout/recurring-itemized-tax-totals.php',
-		'checkout/recurring-subscription-totals.php',
-		'checkout/recurring-subtotals.php',
-		'checkout/recurring-tax-totals.php',
-		'checkout/recurring-totals.php',
-		'checkout/subscription-receipt.php',
-		'emails/admin-new-renewal-order.php',
-		'emails/admin-new-switch-order.php',
-		'emails/admin-payment-retry.php',
-		'emails/cancelled-subscription.php',
-		'emails/customer-completed-renewal-order.php',
-		'emails/customer-completed-switch-order.php',
-		'emails/customer-on-hold-renewal-order.php',
-		'emails/customer-payment-retry.php',
-		'emails/customer-processing-renewal-order.php',
-		'emails/customer-renewal-invoice.php',
-		'emails/email-order-details.php',
-		'emails/expired-subscription.php',
-		'emails/on-hold-subscription.php',
-		'emails/plain/admin-new-renewal-order.php',
-		'emails/plain/admin-new-switch-order.php',
-		'emails/plain/admin-payment-retry.php',
-		'emails/plain/cancelled-subscription.php',
-		'emails/plain/customer-completed-renewal-order.php',
-		'emails/plain/customer-completed-switch-order.php',
-		'emails/plain/customer-on-hold-renewal-order.php',
-		'emails/plain/customer-payment-retry.php',
-		'emails/plain/customer-processing-renewal-order.php',
-		'emails/plain/customer-renewal-invoice.php',
-		'emails/plain/email-order-details.php',
-		'emails/plain/expired-subscription.php',
-		'emails/plain/on-hold-subscription.php',
-		'emails/plain/subscription-info.php',
-		'emails/subscription-info.php',
-		'html-modal.php',
-		'myaccount/my-subscriptions.php',
-		'myaccount/related-orders.php',
-		'myaccount/related-subscriptions.php',
-		'myaccount/subscription-details.php',
-		'myaccount/subscription-totals-table.php',
-		'myaccount/subscription-totals.php',
-		'myaccount/subscriptions.php',
-		'myaccount/view-subscription.php',
-		'single-product/add-to-cart/subscription.php',
-		'single-product/add-to-cart/variable-subscription.php',
+		'html-variation-price.php'                => 'admin/deprecated/',
+		'html-variation-synchronisation.php'      => 'admin/deprecated/',
+		'order-shipping-html.php'                 => 'admin/deprecated/',
+		'order-tax-html.php'                      => 'admin/deprecated/',
+		'html-admin-notice.php'                   => 'admin/',
+		'html-failed-scheduled-action-notice.php' => 'admin/',
+		'html-variation-price.php'                => 'admin/',
+		'html-variation-synchronisation.php'      => 'admin/',
+		'status.php'                              => 'admin/',
+		'cart-recurring-shipping.php'             => 'cart/',
+		'form-change-payment-method.php'          => 'checkout/',
+		'recurring-coupon-totals.php'             => 'checkout/',
+		'recurring-fee-totals.php'                => 'checkout/',
+		'recurring-itemized-tax-totals.php'       => 'checkout/',
+		'recurring-subscription-totals.php'       => 'checkout/',
+		'recurring-subtotals.php'                 => 'checkout/',
+		'recurring-tax-totals.php'                => 'checkout/',
+		'recurring-totals.php'                    => 'checkout/',
+		'subscription-receipt.php'                => 'checkout/',
+		'admin-new-renewal-order.php'             => 'emails/',
+		'admin-new-switch-order.php'              => 'emails/',
+		'admin-payment-retry.php'                 => 'emails/',
+		'cancelled-subscription.php'              => 'emails/',
+		'customer-completed-renewal-order.php'    => 'emails/',
+		'customer-completed-switch-order.php'     => 'emails/',
+		'customer-on-hold-renewal-order.php'      => 'emails/',
+		'customer-payment-retry.php'              => 'emails/',
+		'customer-processing-renewal-order.php'   => 'emails/',
+		'customer-renewal-invoice.php'            => 'emails/',
+		'email-order-details.php'                 => 'emails/',
+		'expired-subscription.php'                => 'emails/',
+		'on-hold-subscription.php'                => 'emails/',
+		'admin-new-renewal-order.php'             => 'emails/plain/',
+		'admin-new-switch-order.php'              => 'emails/plain/',
+		'admin-payment-retry.php'                 => 'emails/plain/',
+		'cancelled-subscription.php'              => 'emails/plain/',
+		'customer-completed-renewal-order.php'    => 'emails/plain/',
+		'customer-completed-switch-order.php'     => 'emails/plain/',
+		'customer-on-hold-renewal-order.php'      => 'emails/plain/',
+		'customer-payment-retry.php'              => 'emails/plain/',
+		'customer-processing-renewal-order.php'   => 'emails/plain/',
+		'customer-renewal-invoice.php'            => 'emails/plain/',
+		'email-order-details.php'                 => 'emails/plain/',
+		'expired-subscription.php'                => 'emails/plain/',
+		'on-hold-subscription.php'                => 'emails/plain/',
+		'subscription-info.php'                   => 'emails/plain/',
+		'subscription-info.php'                   => 'emails/',
+		'html-modal.php'                          => '',
+		'my-subscriptions.php'                    => 'myaccount/',
+		'related-orders.php'                      => 'myaccount/',
+		'related-subscriptions.php'               => 'myaccount/',
+		'subscription-details.php'                => 'myaccount/',
+		'subscription-totals-table.php'           => 'myaccount/',
+		'subscription-totals.php'                 => 'myaccount/',
+		'subscriptions.php'                       => 'myaccount/',
+		'view-subscription.php'                   => 'myaccount/',
+		'subscription.php'                        => 'single-product/add-to-cart/',
+		'variable-subscription.php'               => 'single-product/add-to-cart/',
 	];
 
 	public static function init() {
@@ -359,51 +359,65 @@ class WCS_Template_Loader {
 	}
 
 	/**
-	 * Handles relocated templates.
+	 * Handles relocated subscription templates.
 	 *
-	 * Hooked onto 'wc_get_templates'.
+	 * Hooked onto 'wc_get_template'.
 	 *
 	 * @since 1.4.0
+	 *
+	 * @param string $template
+	 * @param string $tempalte_name
+	 * @param array  $args
+	 * @param string $template_path
+	 * @param
 	 */
 	public static function handle_relocated_templates( $template, $template_name, $args, $template_path, $default_path ) {
-		if ( ! $default_path || ! in_array( $template_name, self::$relocated_templates, true ) ) {
+		// We only want to relocate subscription template files that can't be found.
+		if ( file_exists( $template ) ) {
 			return $template;
 		}
 
-		$subscriptions_core_templates_path = WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' );
-		if ( $default_path === $subscriptions_core_templates_path ) {
+		$subscriptions_core_path = WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory();
+		$template_file           = basename( $template_name );
+
+		if ( ! $default_path || strpos( $default_path, $subscriptions_core_path ) !== false || ! self::is_deprecated_default_path( $template_file, $default_path ) ) {
 			return $template;
 		}
 
+		return $subscriptions_core_path . 'templates/' . self::$relocated_templates[ $template_file ] . $template_file;
+	}
+
+	/**
+	 * Determine if the given template file and default path is sourcing the template
+	 * from a outdated location.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string $template_file Template file name.
+	 * @param string $default_path  Default path passed to `wc_get_template()`.
+	 *
+	 * @return bool
+	 */
+	public static function is_deprecated_default_path( $template_file, $default_path ) {
 		$is_default_path_wcs = false;
-		if ( class_exists( 'WC_Subscriptions_Plugin' ) ) {
-			// WCS 4+ is active.
-			$wcs_templates_path  = WC_Subscriptions_Plugin::instance()->get_plugin_directory( 'templates/' );
-			$is_default_path_wcs = $default_path === $wcs_templates_path;
-		} elseif ( class_exists( 'WC_Subscriptions' ) ) {
-			// WCS 3 or older is active.
-			$wcs_templates_path  = plugin_dir_path( WC_Subscriptions::$plugin_file ) . 'templates/';
-			$is_default_path_wcs = $default_path === $wcs_templates_path;
-		} elseif ( file_exists( dirname( $default_path ) . '/woocommerce-subscriptions.php' ) ) {
-			// WCS is installed but not active.
-			$is_default_path_wcs = true;
-		} elseif ( preg_match( '/woocommerce-subscriptions(|[A-Za-z0-9\-\_ ]+)\/templates/', $default_path ) ) {
-			$maybe_a_plugin_name = basename( dirname( $default_path ) );
-			// Avoid the case where $default_path is referring to some other plugin like woocommerce-subscriptions-extension.
-			if ( ! file_exists( dirname( $default_path ) . "/$maybe_a_plugin_name.php" ) ) {
+
+		if ( in_array( $template_file, self::$relocated_templates, true ) ) {
+			if ( class_exists( 'WC_Subscriptions_Plugin' ) ) {
+				// WCS 4+ is active.
+				$wcs_templates_path  = WC_Subscriptions_Plugin::instance()->get_plugin_directory();
+				$is_default_path_wcs = strpos( $default_path, $wcs_templates_path ) !== false;
+			} elseif ( file_exists( dirname( $default_path ) . '/woocommerce-subscriptions.php' ) ) {
+				// WCS is installed but not active.
 				$is_default_path_wcs = true;
+			} elseif ( preg_match( '/woocommerce-subscriptions(|[A-Za-z0-9\-\_ ]+)\/templates/', $default_path ) ) {
+				$maybe_a_plugin_name = basename( dirname( $default_path ) );
+				// Avoid the case where $default_path is referring to some other plugin like woocommerce-subscriptions-extension.
+				if ( ! file_exists( dirname( $default_path ) . "/$maybe_a_plugin_name.php" ) ) {
+					$is_default_path_wcs = true;
+				}
 			}
 		}
 
-		if ( ! $is_default_path_wcs ) {
-			return $template;
-		}
-
-		return wc_get_template(
-			$template_name,
-			$args,
-			$template_path,
-			$subscriptions_core_templates_path
-		);
+		return $is_default_path_wcs;
 	}
 }

--- a/includes/class-wcs-template-loader.php
+++ b/includes/class-wcs-template-loader.php
@@ -401,7 +401,7 @@ class WCS_Template_Loader {
 	public static function is_deprecated_default_path( $template_file, $default_path ) {
 		$is_default_path_wcs = false;
 
-		if ( in_array( $template_file, self::$relocated_templates, true ) ) {
+		if ( isset( self::$relocated_templates[ $template_file ] ) ) {
 			if ( class_exists( 'WC_Subscriptions_Plugin' ) ) {
 				// WCS 4+ is active.
 				$wcs_templates_path  = WC_Subscriptions_Plugin::instance()->get_plugin_directory();

--- a/includes/class-wcs-template-loader.php
+++ b/includes/class-wcs-template-loader.php
@@ -363,7 +363,7 @@ class WCS_Template_Loader {
 	 *
 	 * Hooked onto 'wc_get_templates'.
 	 *
-	 * @since 1.5.0
+	 * @since 1.4.0
 	 */
 	public static function handle_relocated_templates( $template, $template_name, $args, $template_path, $default_path ) {
 		if ( ! $default_path || ! in_array( $template_name, self::$relocated_templates, true ) ) {


### PR DESCRIPTION
Fixes #85

## Description

A continuation of 4293-gh-woocommerce/woocommerce-subscriptions#pullrequestreview-845268689.
Hook to `wc_get_template` to handle relocated subscriptions templates from WCS to subscriptions-core.

## How to test this PR

I only have testing instructions for subscriptions-core loaded from WCS. Copy-pasted from 4293-gh-woocommerce/woocommerce-subscriptions:
1. Install All Products for WooCommerce Subscriptions 3.1.31.
2. Go to Admin > WooCommerce > Settings > Subscriptions > enable "Add to Subscription" for Products and Carts.
3. Create a simple product and add subscription plan under Product Data > Subscriptions.
4. Purchase that product with subscription.
5. After purchasing, now that you have subscription for that product, open the the product page again and there will be 'Add to an existing subscription' option. With this PR branch, a table of subscriptions should show up correctly. With base branch, nothing should show up.

![Screen Recording 2022-01-06 at 06 06 40](https://user-images.githubusercontent.com/73803630/148476200-deabb184-b8ac-4726-a444-d4945ee0034e.gif)

## Product impact

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? 4291-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments? https://github.com/Automattic/woocommerce-payments/issues/3606