### PR TITLE
Fixes for showing/hiding other gateways express payment buttons on product pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@
 2022-01-03 - version 1.4.0
 * Fix: Simple subscription elements on the product edit page not shown/hidden when necessary. PR#80
 * Fix: Prevent fatal errors on the admin subscriptions screen when a subscription fails to load. PR#84 wcpay#3596 wcs#4286
+* Fix: When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown. PR# wcpay#3401
+* Fix: When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown. PR# wcpay#3401
 
 2021-12-21 - version 1.3.0
 * Fix: Remove references to the Subscription extension in the tooltips found on the Payment Methods settings table. PR#55 wcpay#3234


### PR DESCRIPTION
Fixes #81 

## Description

This PR is fixing a few issues around `get_available_payment_methods()` not being filtered on product pages. For some background, `subscriptions-core` filters this WC function to make sure only WC Payments is the only available when the cart contains a subscriptions.

On `trunk` there are two known issues caused by this area of code:
- Viewing a WC simple product with a subscription product in cart doesn't show any Stripe or PayPal express payment buttons on product page :x:
- Viewing a subscription product was incorrectly loading the Stripe and PayPal express payment buttons on the page :x:

These issue have been fixed with this PR:

- Subscription product pages don't show other gateway buttons ✅ 
- Mini-cart widget still shows other gateway buttons if the cart contains WC simple products ✅ 
![image](https://user-images.githubusercontent.com/2275145/148708605-b60c187f-228c-46b4-af25-126a2bafefad.png)

- WC simple product pages now show other gateways buttons when there's a subscription product in cart
![image](https://user-images.githubusercontent.com/2275145/148708521-2dd03a4b-5a36-477b-9ba3-5c4ec5671395.png)


<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

1. Make sure WC Subscriptions plugin is deactivated
1. Enable WCPay Subscriptions feature
1. Install and activate the Stripe gateway
   - Enable express payment buttons
1. Install and activate the PayPal Checkout gateway (you'll have to setup a PayPal sandbox account if you don't have one yet)
   - Make sure the PayPal Buttons are being shown on product, cart, checkout and mini-cart
1. View a subscription product page and confirm no Stripe Google Pay or PayPal buttons are being shown
1. View a WC simple product page and confirm Stripe Google Pay and PayPal buttons are loading

---

Test cases I've ran:
 - Viewing a Simple Product with an empty cart 🟢
 - Viewing a Simple Product with subscription in cart 🟢
 - Viewing a Variable Product page 🟢
 - Viewing a Subscription Product page 🟢
 - Viewing a Variable Subscription page 🟢
 - Cart page with no subscription 🟢
 - Cart page with a subscription 🟢
 - Checkout page with a subscription 🟢
 - Checkout page with no subscription 🟢

## Product impact
<!-- What products will this PR ship in? -->

- ✅  Added changelog entry (or does not apply)
- :x: Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- ✅  Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
  - https://github.com/Automattic/woocommerce-payments/issues/3401
