### PR TITLE
Add support for payment gateways to return the minimum that can be processed in recurring transactions

### DIFF
--- a/assets/js/admin/payment-method-restrictions.js
+++ b/assets/js/admin/payment-method-restrictions.js
@@ -21,13 +21,13 @@ jQuery( function( $ ) {
 
 		// Reformat the product price - remove the decimal place separator and remove excess decimal places.
 		var price = accounting.unformat( $( element ).val(), wcs_gateway_restrictions.decimal_point_separator );
-		price     = accounting.formatNumber( price, wcs_gateway_restrictions.number_of_decimal_places );
+		price     = accounting.formatNumber( price, wcs_gateway_restrictions.number_of_decimal_places, '' );
 
 		// Error types to validate.
 		var zero_error            = 'i18n_zero_subscription_error';
 		var displaying_zero_error = element.parent().find( '.wc_error_tip, .' + zero_error ).length !== 0;
 
-		// Check if the product price is above 0.
+		// Check if the product price is 0 or less.
 		if ( 0 >= price ) {
 			$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, zero_error ] );
 			displaying_zero_error = true;
@@ -41,7 +41,7 @@ jQuery( function( $ ) {
 			var below_minimum_error      = 'i18n_below_minimum_subscription_error';
 			var displaying_minimum_error = element.parent().find( '.wc_error_tip, .' + below_minimum_error ).length !== 0;
 
-			if ( parseFloat( wcs_gateway_restrictions.minimum_subscription_amount ) >= parseFloat( price ) ) {
+			if ( parseFloat( wcs_gateway_restrictions.minimum_subscription_amount ) > parseFloat( price ) ) {
 				$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, below_minimum_error ] );
 				displaying_minimum_error = true;
 			} else if ( displaying_minimum_error && removed_error_type !== below_minimum_error ) {

--- a/assets/js/admin/payment-method-restrictions.js
+++ b/assets/js/admin/payment-method-restrictions.js
@@ -24,21 +24,30 @@ jQuery( function( $ ) {
 		price     = accounting.formatNumber( price, wcs_gateway_restrictions.number_of_decimal_places );
 
 		// Error types to validate.
-		var zero_error              = 'i18n_zero_subscription_error';
-		var below_minimum_error     = 'i18n_below_minimum_subscription_error';
+		var zero_error            = 'i18n_zero_subscription_error';
+		var displaying_zero_error = element.parent().find( '.wc_error_tip, .' + zero_error ).length !== 0;
 
 		// Check if the product price is above 0.
 		if ( 0 >= price ) {
 			$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, zero_error ] );
-		} else if ( removed_error_type !== zero_error ) {
+			displaying_zero_error = true;
+		} else if ( displaying_zero_error && removed_error_type !== zero_error ) {
 			$( document.body ).triggerHandler( 'wc_remove_error_tip', [ element, zero_error ] );
+			displaying_zero_error = false;
 		}
 
 		// Check if the product price is below the amount that can be processed by the payment gateway.
-		if ( 0 < price && wcs_gateway_restrictions.minimum_subscription_amount >= price ) {
-			$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, below_minimum_error ] );
-		} else if ( removed_error_type !== below_minimum_error ) {
-			$( document.body ).triggerHandler( 'wc_remove_error_tip', [ element, below_minimum_error ] );
+		if ( ! displaying_zero_error && 'undefined' !== typeof wcs_gateway_restrictions.minimum_subscription_amount ) {
+			var below_minimum_error      = 'i18n_below_minimum_subscription_error';
+			var displaying_minimum_error = element.parent().find( '.wc_error_tip, .' + below_minimum_error ).length !== 0;
+
+			if ( wcs_gateway_restrictions.minimum_subscription_amount >= price ) {
+				$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, below_minimum_error ] );
+				displaying_minimum_error = true;
+			} else if ( displaying_minimum_error && removed_error_type !== below_minimum_error ) {
+				$( document.body ).triggerHandler( 'wc_remove_error_tip', [ element, below_minimum_error ] );
+				displaying_minimum_error = false;
+			}
 		}
 	} );
 

--- a/assets/js/admin/payment-method-restrictions.js
+++ b/assets/js/admin/payment-method-restrictions.js
@@ -4,13 +4,6 @@ jQuery( function( $ ) {
 	 * If the WC core validation passes (errors removed), check our own validation.
 	 */
 	$( document.body ).on( 'wc_remove_error_tip', function( e, element, removed_error_type ) {
-		var type_error = 'i18n_zero_subscription_error';
-
-		// Exit early if it's the zero subscription error that has been removed.
-		if ( removed_error_type === type_error ) {
-			return;
-		}
-
 		var product_type = $( '#product-type' ).val();
 
 		if ( 'subscription' !== product_type && 'variable-subscription' !== product_type ) {
@@ -30,10 +23,22 @@ jQuery( function( $ ) {
 		var price = accounting.unformat( $( element ).val(), wcs_gateway_restrictions.decimal_point_separator );
 		price     = accounting.formatNumber( price, wcs_gateway_restrictions.number_of_decimal_places );
 
+		// Error types to validate.
+		var zero_error              = 'i18n_zero_subscription_error';
+		var below_minimum_error     = 'i18n_below_minimum_subscription_error';
+
+		// Check if the product price is above 0.
 		if ( 0 >= price ) {
-			$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, type_error ] );
-		} else {
-			$( document.body ).triggerHandler( 'wc_remove_error_tip', [ element, type_error ] );
+			$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, zero_error ] );
+		} else if ( removed_error_type !== zero_error ) {
+			$( document.body ).triggerHandler( 'wc_remove_error_tip', [ element, zero_error ] );
+		}
+
+		// Check if the product price is below the amount that can be processed by the payment gateway.
+		if ( 0 < price && wcs_gateway_restrictions.minimum_subscription_amount >= price ) {
+			$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, below_minimum_error ] );
+		} else if ( removed_error_type !== below_minimum_error ) {
+			$( document.body ).triggerHandler( 'wc_remove_error_tip', [ element, below_minimum_error ] );
 		}
 	} );
 
@@ -80,12 +85,16 @@ jQuery( function( $ ) {
 	$( document.body ).on( 'wc_subscriptions_add_error_tip', function( e, element, error_type ) {
 		var offset = element.position();
 
-		if ( element.parent().find( '.wc_error_tip' ).length === 0 ) {
-			element.after( '<div class="wc_error_tip ' + error_type + '">' + wcs_gateway_restrictions[ error_type ] + '</div>' );
-			element.parent().find( '.wc_error_tip' )
-				.css( 'left', offset.left + element.width() - ( element.width() / 2 ) - ( $( '.wc_error_tip' ).width() / 2 ) )
-				.css( 'top', offset.top + element.height() )
-				.fadeIn( '100' );
+		// Remove any error that is already being shown before adding a new one.
+		if ( element.parent().find( '.wc_error_tip' ).length !== 0 ) {
+			element.parent().find( '.wc_error_tip' ).remove();
 		}
+
+		element.after( '<div class="wc_error_tip ' + error_type + '">' + wcs_gateway_restrictions[ error_type ] + '</div>' );
+		element.parent().find( '.wc_error_tip' )
+			.css( 'left', offset.left + element.width() - ( element.width() / 2 ) - ( $( '.wc_error_tip' ).width() / 2 ) )
+			.css( 'top', offset.top + element.height() )
+			.fadeIn( '100' );
+
 	})
 } );

--- a/assets/js/admin/payment-method-restrictions.js
+++ b/assets/js/admin/payment-method-restrictions.js
@@ -41,7 +41,7 @@ jQuery( function( $ ) {
 			var below_minimum_error      = 'i18n_below_minimum_subscription_error';
 			var displaying_minimum_error = element.parent().find( '.wc_error_tip, .' + below_minimum_error ).length !== 0;
 
-			if ( wcs_gateway_restrictions.minimum_subscription_amount >= price ) {
+			if ( parseFloat( wcs_gateway_restrictions.minimum_subscription_amount ) >= parseFloat( price ) ) {
 				$( document.body ).triggerHandler( 'wc_subscriptions_add_error_tip', [ element, below_minimum_error ] );
 				displaying_minimum_error = true;
 			} else if ( displaying_minimum_error && removed_error_type !== below_minimum_error ) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.5.0
+* New: Introduce filter to allow third-parties to specify the minimum recurring amount the payment method can support. Displays a warning to the merchant when creating products below that amount. #PR89 wcpay#3542
+
 2022-01-03 - version 1.4.0
 * Fix: Simple subscription elements on the product edit page not shown/hidden when necessary. PR#80
 * Fix: Prevent fatal errors on the admin subscriptions screen when a subscription fails to load. PR#84 wcpay#3596 wcs#4286

--- a/includes/gateways/class-wc-subscriptions-gateway-restrictions-manager.php
+++ b/includes/gateways/class-wc-subscriptions-gateway-restrictions-manager.php
@@ -46,6 +46,24 @@ class WC_Subscriptions_Gateway_Restrictions_Manager {
 				'decimal_point_separator'      => $decimal_separator,
 			);
 
+			/**
+			 * Allow WC Payments to return the minimum amount that can be processed.
+			 *
+			 * @since 1.5.0
+			 *
+			 * @param bool|float The minimum amount that can be processed in the given currency.
+			 * @param string.    The currency.
+			 */
+			$minimum_processable_amount = apply_filters( 'woocommerce_subscriptions_minimum_processable_recurring_amount', false, get_woocommerce_currency() );
+
+			if ( $minimum_processable_amount ) {
+				$i18n_minimum_price                         = sprintf( get_woocommerce_price_format(), get_woocommerce_currency_symbol(), number_format( $minimum_processable_amount, $decimals, $decimal_separator, '' ) );
+				$script_data['minimum_subscription_amount'] = $minimum_processable_amount;
+
+				// Translators: The %1 placeholder is the localized minimum price string ($0.50). %2 is the currency identifier string ('USD').
+				$script_data['i18n_below_minimum_subscription_error'] = sprintf( __( 'Warning! Your store\'s payment method cannot process a recurring total below %1$s %2$s.', 'woocommerce-subscriptions' ), $i18n_minimum_price, get_woocommerce_currency() );
+			}
+
 			wp_localize_script( 'woocommerce_subscriptions_payment_restrictions', 'wcs_gateway_restrictions', $script_data );
 		}
 	}

--- a/includes/gateways/class-wc-subscriptions-gateway-restrictions-manager.php
+++ b/includes/gateways/class-wc-subscriptions-gateway-restrictions-manager.php
@@ -60,8 +60,8 @@ class WC_Subscriptions_Gateway_Restrictions_Manager {
 				$i18n_minimum_price                         = sprintf( get_woocommerce_price_format(), get_woocommerce_currency_symbol(), number_format( $minimum_processable_amount, $decimals, $decimal_separator, '' ) );
 				$script_data['minimum_subscription_amount'] = $minimum_processable_amount;
 
-				// Translators: The %1 placeholder is the localized minimum price string ($0.50). %2 is the currency identifier string ('USD').
-				$script_data['i18n_below_minimum_subscription_error'] = sprintf( __( 'Warning! Your store\'s payment method cannot process a recurring total below %1$s %2$s.', 'woocommerce-subscriptions' ), $i18n_minimum_price, get_woocommerce_currency() );
+				// Translators: Placeholder is a localized price string (eg. $1.00).
+				$script_data['i18n_below_minimum_subscription_error'] = sprintf( __( "Warning! Your store's payment method cannot process a recurring total below %s", 'woocommerce-subscriptions' ), $i18n_minimum_price );
 			}
 
 			wp_localize_script( 'woocommerce_subscriptions_payment_restrictions', 'wcs_gateway_restrictions', $script_data );

--- a/includes/gateways/class-wc-subscriptions-gateway-restrictions-manager.php
+++ b/includes/gateways/class-wc-subscriptions-gateway-restrictions-manager.php
@@ -51,17 +51,17 @@ class WC_Subscriptions_Gateway_Restrictions_Manager {
 			 *
 			 * @since 1.5.0
 			 *
-			 * @param bool|float The minimum amount that can be processed in the given currency.
-			 * @param string.    The currency.
+			 * @param false|float The minimum amount that can be processed in the given currency.
+			 * @param string      The currency.
 			 */
 			$minimum_processable_amount = apply_filters( 'woocommerce_subscriptions_minimum_processable_recurring_amount', false, get_woocommerce_currency() );
 
-			if ( $minimum_processable_amount ) {
+			if ( is_numeric( $minimum_processable_amount ) ) {
 				$i18n_minimum_price                         = sprintf( get_woocommerce_price_format(), get_woocommerce_currency_symbol(), number_format( $minimum_processable_amount, $decimals, $decimal_separator, '' ) );
 				$script_data['minimum_subscription_amount'] = $minimum_processable_amount;
 
 				// Translators: Placeholder is a localized price string (eg. $1.00).
-				$script_data['i18n_below_minimum_subscription_error'] = sprintf( __( "Warning! Your store's payment method cannot process a recurring total below %s", 'woocommerce-subscriptions' ), $i18n_minimum_price );
+				$script_data['i18n_below_minimum_subscription_error'] = sprintf( __( 'Warning! Your store cannot create subscriptions less than %s', 'woocommerce-subscriptions' ), $i18n_minimum_price );
 			}
 
 			wp_localize_script( 'woocommerce_subscriptions_payment_restrictions', 'wcs_gateway_restrictions', $script_data );


### PR DESCRIPTION
Part of https://github.com/Automattic/woocommerce-payments/issues/3542

## Description

This PR introduces a filter that can be used by WC Payments to return the minimum amount it can process in recurring transactions. 

If the filter returns a value, the JS will display a warning to the user when they attempt to enter a product price below that amount. 

<img width="658" alt="Screen Shot 2022-01-11 at 5 53 33 pm" src="https://user-images.githubusercontent.com/8490476/148902521-a5c822bc-1582-41fe-b448-242b1f970d5b.png">

If no value is returned from the filter, then no extra validation occurs, only $0 subscriptions throw an error.

## How to test this PR

**Requirements for testing:** 

- This branch `issue/wcpay/3542`
- WCPay Server branch `wcpay_issue/3542` (1473-gh-Automattic/woocommerce-payments-server)
- WCPay `issue/3542` (https://github.com/Automattic/woocommerce-payments/pull/3615)

-- 

1. With all those branches running, attempt to create a subscription product below your store's base currency. You should see the error message shown above. 
2. If you change your store's base currency ([**WooCommerce -> Settings**](https://user-images.githubusercontent.com/8490476/148901796-9638a56f-8d4e-4785-9a1b-4adf9c90ac61.png)) and re-run the test you will see your WC Pay account's base currency minimum being converted into your store's new currency. 


<img width="469.5" alt="Screen Shot 2022-01-11 at 5 52 37 pm" src="https://user-images.githubusercontent.com/8490476/148902425-dda4d74b-8475-4550-9c08-7ed63241aa77.png">

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions?
    - No. The code will ship in WC Subscriptions but it won't be loaded because of [this logic](https://github.com/automattic/woocommerce-subscriptions-core/blob/issue/wcpay/3542/includes/class-wc-subscriptions-core-plugin.php#L160). 
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
   - https://github.com/Automattic/woocommerce-payments/issues/3542