### PR TITLE
v1.6.0 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-2022-xx-xx - version 1.6.0
+2022-01-17 - version 1.6.0
 * Fix: When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown. PR#87 wcpay#3401
 * Fix: When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown. PR#87 wcpay#3401
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-subscriptions-core",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-subscriptions-core",
-			"version": "1.5.0",
+			"version": "1.6.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "WooCommerce Subscriptions Core",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
 	"main": "Gruntfile.js",

--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -6,5 +6,5 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Requires WP: 5.6
- * Version: 1.5.0
+ * Version: 1.6.0
  */


### PR DESCRIPTION
## Description

This PR:
- Updates changelog release date for `1.6.0`.
- Updates version in `package.json` and `woocommerce-subscriptions-core.php` to `1.6.0`.
- Updates `package-lock.json` as a result of running `npm install`.

## How to test this PR

- Make sure release date for `1.6.0` is correct.
- Make sure versions are updated in `package.json` and `woocommerce-subscriptions-core.php`.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? no
- [x] Will this PR affect WooCommerce Payments? yes. https://github.com/Automattic/woocommerce-payments/issues/3401