### PR TITLE
Set the package type of "subscriptions-core" to a "wordpress-plugin"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.6.1
+* Dev: Set the composer package type to "wordpress-plugin". PR#96
+
 2022-01-17 - version 1.6.0
 * Fix: When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown. PR#87 wcpay#3401
 * Fix: When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown. PR#87 wcpay#3401

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/subscriptions-core",
 	"description": "Sell products and services with recurring payments in your WooCommerce Store.",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
-	"type": "library",
+	"type": "wordpress-plugin",
 	"license": "GPL-3.0-or-later",
 	"require": {
 		"php": "^7.0",


### PR DESCRIPTION
Fixes #95 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

This PR updates the "type" set in `composer.json` to "wordpress-plugin", which is a [supported package type](https://github.com/composer/installers#current-supported-package-types) for projects loading `subscriptions-core` using `composer/installer`.

This change is needed to be able to install `subscriptions-core` in a custom path like explained in https://github.com/composer/installers#custom-install-paths.
See more details for our specific case in #95 

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Inside WC Subscriptions project, open the `composer.json` and make the following changes:
   1. Set require to "woocommerce/subscriptions-core": "dev-set-composer-type"
   2. Add a custom install path but editting the "extra" param to be:
```
"extra": {
	"installer-paths": {
		"packages/{$name}": [
			"woocommerce/subscriptions-core"
		]
	},
	"phpcodesniffer-search-depth": 2
},
```
2. Run `composer update` and you'll notice subscriptions-core is installed in the custom path

You should notice `subscriptions-core` is installed inside `packages/` instead of `vendor/`

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions?
- [ ] Will this PR affect WooCommerce Payments?
