### PR TITLE
Add missing developer files to .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,11 @@ bin export-ignore
 .husky export-ignore
 tests export-ignore
 lint-staged.config.js export-ignore
+.eslintignore export-ignore
+.eslintrc export-ignore
+.gitignore export-ignore
+.prettierignore export-ignore
+.prettierrc export-ignore
+.stylelintrc.json export-ignore
+phpunit.xml.dist export-ignore
+webpack.config.js export-ignore

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2022-xx-xx - version 1.6.1
-* Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files.
+* Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files. PR#97
 
 2022-01-17 - version 1.6.0
 * Fix: When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown. PR#87 wcpay#3401

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.6.1
+* Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files.
+
 2022-01-17 - version 1.6.0
 * Fix: When viewing a WCPay Subscription product page, make sure other gateway's express payment buttons aren't shown. PR#87 wcpay#3401
 * Fix: When viewing a WC Product page with a WCPay subscription product in cart, make sure other gateway's express payment buttons are shown. PR#87 wcpay#3401


### PR DESCRIPTION
Fixes #94 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

When poking through `/vendor/woocommerce/subscriptions-core` I noticed there's a bunch of developer files being downloaded and included in WC Subscriptions and WC Payments:

![image](https://user-images.githubusercontent.com/2275145/149712001-bb697f4a-7648-4997-9deb-baf1a4483cb9.png)

This PR adds these developer files to the list of `export-ignore` files found in `.gitattributes`.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go into `vendor/woocommerce/subscriptions-core` in WC Payments and notice the above developer files seen in the screenshot :x:
2. Inside the `composer.json` of either WC Subscriptions or WC Payments, update the subscriptions core package version to `"woocommerce/subscriptions-core": "dev-fix/94-add-developer-files-to-gitattributes"`
2. Run `composer update`
3. Notice none of the developer files are found in `vendor/woocommerce/subscriptions-core`

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
