### PR TITLE
v1.6.1 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-2022-xx-xx - version 1.6.1
+2022-01-18 - version 1.6.1
 * Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files. PR#97
 * Dev: Set the composer package type to "wordpress-plugin". PR#96
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-subscriptions-core",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-subscriptions-core",
-			"version": "1.6.0",
+			"version": "1.6.1",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "WooCommerce Subscriptions Core",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
 	"main": "Gruntfile.js",

--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -6,5 +6,5 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Requires WP: 5.6
- * Version: 1.6.0
+ * Version: 1.6.1
  */


### PR DESCRIPTION
```
2022-01-18 - version 1.6.1
* Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files. PR#97
* Dev: Set the composer package type to "wordpress-plugin". PR#96
```