### PR TITLE
Fix/widget title too few arguments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2022-xx-xx - version 1.6.2
-* Fix: Prefvent fatal error when too few arguments passed to widget_title filter. PR#100
+* Fix: Prevent fatal error when too few arguments passed to widget_title filter. PR#100
 
 2022-01-18 - version 1.6.1
 * Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files. PR#97

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-2022-xx-xx - version 1.7.0
+2022-xx-xx - version 1.6.2
 * Fix: Prefvent fatal error when too few arguments passed to widget_title filter. PR#100
 
 2022-01-18 - version 1.6.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.7.0
+* Fix: Prefvent fatal error when too few arguments passed to widget_title filter. PR#100
+
 2022-01-18 - version 1.6.1
 * Dev: Update the list of "export-ignore" in `.gitattributes` to include recent developer files. PR#97
 * Dev: Set the composer package type to "wordpress-plugin". PR#96

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -331,7 +331,7 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	 *
 	 * @return string
 	 */
-	public static function before_displaying_mini_cart( $title, $instance, $widget_id ) {
+	public static function before_displaying_mini_cart( $title, $instance, $widget_id = '' ) {
 		self::$is_displaying_mini_cart = 'woocommerce_widget_cart' === $widget_id;
 		return $title;
 	}

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -350,7 +350,7 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	 *
 	 * @return string
 	 */
-	public static function after_displaying_mini_cart( $title, $instance, $widget_id ) {
+	public static function after_displaying_mini_cart( $title, $instance = array(), $widget_id = null ) {
 		self::$is_displaying_mini_cart = false;
 		return $title;
 	}

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -331,7 +331,7 @@ class WC_Subscriptions_Core_Payment_Gateways {
 	 *
 	 * @return string
 	 */
-	public static function before_displaying_mini_cart( $title, $instance, $widget_id = '' ) {
+	public static function before_displaying_mini_cart( $title, $instance = array(), $widget_id = null ) {
 		self::$is_displaying_mini_cart = 'woocommerce_widget_cart' === $widget_id;
 		return $title;
 	}


### PR DESCRIPTION
## Description

Make `widget_title` filter callbacks to handle gracefully when less than 3 arguments passed.

## How to test this PR

Run this code snippet and it shouldn't throw a fatal error while it will with base branch.
```
apply_filter( 'widget_title', 'x' );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
