### PR TITLE
Fix: set up integration for Mini Cart Block and add new filter to compatible blocks.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.7.0
+* Fix: Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks. PR#103
+
 2022-01-19 - version 1.6.2
 * Fix: Prevent fatal error when too few arguments passed to widget_title filter. PR#100
 

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -556,7 +556,7 @@ class WC_Subscriptions_Core_Plugin {
 			[ 'cart', 'checkout', 'mini-cart' ]
 		);
 
-		foreach( $compatible_blocks as $block_name ) {
+		foreach ( $compatible_blocks as $block_name ) {
 			add_action(
 				"woocommerce_blocks_{$block_name}_block_registration",
 				function( $integration_registry ) {

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -548,18 +548,22 @@ class WC_Subscriptions_Core_Plugin {
 	 * @since 4.0.0
 	 */
 	public function setup_blocks_integration() {
-		add_action(
-			'woocommerce_blocks_cart_block_registration',
-			function( $integration_registry ) {
-				$integration_registry->register( new WCS_Blocks_Integration() );
-			}
+		/**
+		 * Filter the compatible blocks for WooCommerce Subscriptions.
+		 */
+		$compatible_blocks = apply_filters(
+			'wcs_compatible_blocks',
+			[ 'cart', 'checkout', 'mini-cart' ]
 		);
-		add_action(
-			'woocommerce_blocks_checkout_block_registration',
-			function( $integration_registry ) {
-				$integration_registry->register( new WCS_Blocks_Integration() );
-			}
-		);
+
+		foreach( $compatible_blocks as $block_name ) {
+			add_action(
+				"woocommerce_blocks_{$block_name}_block_registration",
+				function( $integration_registry ) {
+					$integration_registry->register( new WCS_Blocks_Integration() );
+				}
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5642

## Description

This PR sets up the Subscriptions integration for the Mini Cart block to display the amount due and subscriptions period inside the Mini Cart Contents. This also adds a new filter (`wcs_compatible_blocks`) and refactors `WC_Subscriptions_Core_Plugin::setup_blocks_integration`.

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

![image](https://user-images.githubusercontent.com/5423135/151514994-805f1776-4cdf-4101-8bb8-7599f5c56ba4.png)

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On WP 5.9, clone and build (`npm run dev`) https://github.com/woocommerce/woocommerce-gutenberg-products-block@trunk.
2. Add Mini Cart block to the header.
3. Create/edit a subscription product with free trial.
4. On the front end, add that subscription product to the cart.
5. Open the Mini Cart, see the amount due and subscription period info in the products table.

## Product impact
<!-- What products will this PR ship in? -->
WooCommerce Blocks.

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
