### PR TITLE
Fixed missing order placeholder variables in subscription cancelled admin email template.

### DIFF
--- a/includes/emails/class-wcs-email-cancelled-subscription.php
+++ b/includes/emails/class-wcs-email-cancelled-subscription.php
@@ -98,6 +98,7 @@ class WCS_Email_Cancelled_Subscription extends WC_Email {
 			$this->template_html,
 			array(
 				'subscription'       => $this->object,
+				'order'              => $this->object,
 				'email_heading'      => $this->get_heading(),
 				'additional_content' => is_callable( array( $this, 'get_additional_content' ) ) ? $this->get_additional_content() : '', // WC 3.7 introduced an additional content field for all emails.
 				'sent_to_admin'      => true,
@@ -120,6 +121,7 @@ class WCS_Email_Cancelled_Subscription extends WC_Email {
 			$this->template_plain,
 			array(
 				'subscription'       => $this->object,
+				'order'              => $this->object,
 				'email_heading'      => $this->get_heading(),
 				'additional_content' => is_callable( array( $this, 'get_additional_content' ) ) ? $this->get_additional_content() : '', // WC 3.7 introduced an additional content field for all emails.
 				'sent_to_admin'      => true,


### PR DESCRIPTION
## Description

Problem
- When a user cancels a subscription, the email sent to the admin shows empty data related to that subscription.

Details
- The plugin woocommerce-email-customizer-plus expects an order object for it to load the subscription data as in all other woocommerce email templates. This is simply not set by woocommerce-subscriptions.

Proposed solution
1. Add the order object to the email template context variables.

## How to test this PR

1. Install plugin woocommerce-email-customizer-plus.
2. Customize the subscription cancelled admin email notification template, outputting information from the subscription/order.
3. Test the customized email template; the values should appear in the admin email notification.

## Product impact

- [ ] Added changelog entry
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
