### PR TITLE
Replace is_ajax() calls with wp_doing_ajax()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.6.3
+* Fix: Replace uses of is_ajax() with wp_doing_ajax(). PR#108 wcpay#3695 wcs#4296
+
 2022-01-19 - version 1.6.2
 * Fix: Prevent fatal error when too few arguments passed to widget_title filter. PR#100
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -408,7 +408,7 @@ class WCS_Admin_Meta_Boxes {
 			return;
 		}
 
-		$order = wc_get_order( wp_doing_ajax() ? absint( $_POST['order_id'] ) : $order_id );
+		$order = wc_get_order( wp_doing_ajax() && isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : $order_id );
 
 		if ( ! $order ) {
 			return;

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -408,7 +408,7 @@ class WCS_Admin_Meta_Boxes {
 			return;
 		}
 
-		$order = wc_get_order( is_ajax() ? absint( $_POST['order_id'] ) : $order_id );
+		$order = wc_get_order( wp_doing_ajax() ? absint( $_POST['order_id'] ) : $order_id );
 
 		if ( ! $order ) {
 			return;

--- a/includes/wcs-deprecated-functions.php
+++ b/includes/wcs-deprecated-functions.php
@@ -54,7 +54,7 @@ function wcs_deprecated_function( $function, $version, $replacement = null ) {
 	if ( function_exists( 'wc_deprecated_function' ) ) {
 		wc_deprecated_function( $function, $version, $replacement );
 	} else {
-		// Reimplment wcs_deprecated_function() when WC 3.0 is not active
+		// Reimplement wcs_deprecated_function() when WC 3.0 is not active
 		if ( wp_doing_ajax() ) {
 			do_action( 'deprecated_function_run', $function, $replacement, $version );
 			$log_string  = "The {$function} function is deprecated since version {$version}.";

--- a/includes/wcs-deprecated-functions.php
+++ b/includes/wcs-deprecated-functions.php
@@ -29,7 +29,7 @@ function wcs_doing_it_wrong( $function, $message, $version ) {
 	if ( function_exists( 'wc_doing_it_wrong' ) ) {
 		wc_doing_it_wrong( $function, $message, $version );
 	} else {
-		// Reimplment wc_doing_it_wrong() when WC 3.0 is not active
+		// Reimplement wc_doing_it_wrong() when WC 3.0 is not active
 		if ( wp_doing_ajax() ) {
 			do_action( 'doing_it_wrong_run', $function, $message, $version );
 			error_log( "{$function} was called incorrectly. {$message}. This message was added in version {$version}." );

--- a/includes/wcs-deprecated-functions.php
+++ b/includes/wcs-deprecated-functions.php
@@ -30,7 +30,7 @@ function wcs_doing_it_wrong( $function, $message, $version ) {
 		wc_doing_it_wrong( $function, $message, $version );
 	} else {
 		// Reimplment wc_doing_it_wrong() when WC 3.0 is not active
-		if ( is_ajax() ) {
+		if ( wp_doing_ajax() ) {
 			do_action( 'doing_it_wrong_run', $function, $message, $version );
 			error_log( "{$function} was called incorrectly. {$message}. This message was added in version {$version}." );
 		} else {
@@ -55,7 +55,7 @@ function wcs_deprecated_function( $function, $version, $replacement = null ) {
 		wc_deprecated_function( $function, $version, $replacement );
 	} else {
 		// Reimplment wcs_deprecated_function() when WC 3.0 is not active
-		if ( is_ajax() ) {
+		if ( wp_doing_ajax() ) {
 			do_action( 'deprecated_function_run', $function, $replacement, $version );
 			$log_string  = "The {$function} function is deprecated since version {$version}.";
 			$log_string .= $replacement ? " Replace with {$replacement}." : '';
@@ -75,7 +75,7 @@ function wcs_deprecated_function( $function, $version, $replacement = null ) {
  * @param  string $message
  */
 function wcs_deprecated_argument( $function, $version, $message = null ) {
-	if ( is_ajax() ) {
+	if ( wp_doing_ajax() ) {
 		do_action( 'deprecated_argument_run', $function, $message, $version );
 		error_log( "{$function} was called with an argument that is deprecated since version {$version}. {$message}" );
 	} else {
@@ -274,7 +274,7 @@ function wcs_deprecated_hook( $hook, $version, $replacement = null, $message = n
 		wc_deprecated_hook( $hook, $version, $replacement, $message );
 	} else {
 		// Reimplement wcs_deprecated_function() when WC 3.0 is not active
-		if ( is_ajax() ) {
+		if ( wp_doing_ajax() ) {
 			do_action( 'deprecated_hook_run', $hook, $replacement, $version, $message );
 
 			$message    = empty( $message ) ? '' : ' ' . $message;


### PR DESCRIPTION
Fixes #102 

## Description

In WC 6.1.0 they deprecated the use of `is_ajax()` with the intent to now use the WP core function `wp_doing_ajax()`. They have since reverted that change to WC core (in WC 6.1.1).   

## How to test this PR

1. Install WooCommerce 6.1.
2. Install woocommerce-subscriptions-core as a plugin.
3. Enable debugging by setting this constant in `wp-config.php`.
```
define( 'WP_DEBUG', true );
```
4. Purchase something so there is an order created in your store. If there is already an order, skip this step.
5. Edit an order and click the update button (no need to change anything).
6. Observe the deprecation warning:
```
Deprecated: is_ajax is deprecated since version 6.1.0! Use wp_doing_ajax instead. in {wordpress_path}/wp-includes/functions.php on line 5211
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
