### PR TITLE
Fix: Changing payment method not filtering the subscription total to be $0 in WC Payments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 2022-xx-xx - version 1.6.4
-* Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR# wcpay#3768
+* Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR#111 wcpay#3768
 
 2022-02-07 - version 1.6.3
 * Fix: Replace uses of is_ajax() with wp_doing_ajax(). PR#108 wcpay#3695 wcs#4296

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.6.4
+* Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR# wcpay#3768
+
 2022-02-07 - version 1.6.3
 * Fix: Replace uses of is_ajax() with wp_doing_ajax(). PR#108 wcpay#3695 wcs#4296
 * Improve handling of session data.

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -29,8 +29,8 @@ class WC_Subscriptions_Change_Payment_Gateway {
 		// Maybe allow for a recurring payment method to be changed
 		add_action( 'plugins_loaded', __CLASS__ . '::set_change_payment_method_flag' );
 
-		// Attach hooks which depend on WooCommerce constants
-		add_action( 'woocommerce_loaded', __CLASS__ . '::attach_dependant_hooks' );
+		// If we're changing the payment method, we want to make sure a number of totals return $0 (to prevent payments being processed now)
+		add_filter( 'woocommerce_subscription_get_total', __CLASS__ . '::maybe_zero_total', 11, 2 );
 
 		// Keep a record of any messages or errors that should be displayed
 		add_action( 'before_woocommerce_pay', __CLASS__ . '::store_pay_shortcode_messages', 5 );
@@ -72,26 +72,6 @@ class WC_Subscriptions_Change_Payment_Gateway {
 		// Display a login form if the customer is requesting to change their payment method but aren't logged in.
 		add_filter( 'the_content', array( __CLASS__, 'maybe_request_log_in' ) );
 
-	}
-
-	/**
-	 * Attach WooCommerce version dependent hooks
-	 *
-	 * @since 2.2.0
-	 */
-	public static function attach_dependant_hooks() {
-
-		if ( wcs_is_woocommerce_pre( '3.0' ) ) {
-
-			// If we're changing the payment method, we want to make sure a number of totals return $0 (to prevent payments being processed now)
-			add_filter( 'woocommerce_order_amount_total', __CLASS__ . '::maybe_zero_total', 11, 2 );
-
-		} else {
-
-			// If we're changing the payment method, we want to make sure a number of totals return $0 (to prevent payments being processed now)
-			add_filter( 'woocommerce_subscription_get_total', __CLASS__ . '::maybe_zero_total', 11, 2 );
-
-		}
 	}
 
 	/**
@@ -900,5 +880,24 @@ class WC_Subscriptions_Change_Payment_Gateway {
 		}
 
 		return $subscription_can_be_changed;
+	}
+
+	/**
+	 * Attach WooCommerce version dependent hooks
+	 *
+	 * @since 1.0.0
+	 *
+	 * @deprecated 1.6.4
+	 */
+	public static function attach_dependant_hooks() {
+		_deprecated_function( __METHOD__, '1.6.4' );
+
+		if ( wcs_is_woocommerce_pre( '3.0' ) ) {
+			// If we're changing the payment method, we want to make sure a number of totals return $0 (to prevent payments being processed now)
+			add_filter( 'woocommerce_order_amount_total', __CLASS__ . '::maybe_zero_total', 11, 2 );
+		} else {
+			// If we're changing the payment method, we want to make sure a number of totals return $0 (to prevent payments being processed now)
+			add_filter( 'woocommerce_subscription_get_total', __CLASS__ . '::maybe_zero_total', 11, 2 );
+		}
 	}
 }

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -54,7 +54,7 @@ class WC_Subscriptions_Core_Plugin {
 		if ( $autoloader ) {
 			$this->autoloader = $autoloader;
 		} else {
-			$this->autoloader = new WCS_Core_Autoloader( $this->get_subscriptions_core_directory() );
+			$this->autoloader = new WCS_Core_Autoloader( $this->get_subscriptions_core_directory()  );
 			$this->autoloader->register();
 		}
 

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -54,7 +54,7 @@ class WC_Subscriptions_Core_Plugin {
 		if ( $autoloader ) {
 			$this->autoloader = $autoloader;
 		} else {
-			$this->autoloader = new WCS_Core_Autoloader( $this->get_subscriptions_core_directory()  );
+			$this->autoloader = new WCS_Core_Autoloader( $this->get_subscriptions_core_directory() );
 			$this->autoloader->register();
 		}
 


### PR DESCRIPTION
For #110 

## Description

While investigating https://github.com/Automattic/woocommerce-payments/issues/3765 we discovered that changing the payment method of a WCPay Subscription was incorrectly charging the customer.

This is caused by an issue in `subscriptions-core` where certain filters are attached to the `woocommerce_loaded` hook which has already been triggered before `subscriptions-core` library is loaded.

The fix in this PR is to move the filter outside of the `woocommerce_loaded` hook which was only being used to check if the current WC version was pre 3.0.

Since the minimum WC version we support is 4.4, we can remove the need for the:

```
add_action( 'woocommerce_loaded', __CLASS__ . '::attach_dependant_hooks' );
```

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure Subscriptions with WooCommerce Payments is enabled and the WC Subscriptions plugin is disabled.
2. Purchase a new subscription
3. Go to My Account > Subscriptions > View your new active subscription
4. Next to the list of Actions, click "Change Payment"
5. Complete the change payment method process.
6. Log into the Stripe dashboard and view Payments for this store.
7. Notice there's a charge whenever you change payment method :x:

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] ~~Will this PR affect WooCommerce Subscriptions?~~
- [x] Will this PR affect WooCommerce Payments? yes

https://github.com/Automattic/woocommerce-payments/issues/3768
