### PR TITLE
Add missing elements and action in recurring shipping packages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2022-xx-xx - version 1.7.0
 * Fix - When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
+* Fix - When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115
 
 2022-02-10 - version 1.6.4
 * Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR#111 wcpay#3768

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -105,10 +105,8 @@ function wcs_cart_totals_shipping_html() {
 						?>
 						">
 							<?php echo wp_kses_post( wcs_cart_totals_shipping_method_price_label( $shipping_method, $recurring_cart ) ); ?>
-							<?php if ( 1 === count( $package['rates'] ) ) : ?>
-								<?php wcs_cart_print_shipping_input( $recurring_cart_package_key, $shipping_method ); ?>
-								<?php do_action( 'woocommerce_after_shipping_rate', $shipping_method, $recurring_cart_package_key ); ?>
-							<?php endif; ?>
+							<?php wcs_cart_print_shipping_input( $recurring_cart_package_key, $shipping_method ); ?>
+							<?php do_action( 'woocommerce_after_shipping_rate', $shipping_method, $recurring_cart_package_key ); ?>
 							<?php if ( ! empty( $show_package_details ) ) : ?>
 								<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
 							<?php endif; ?>


### PR DESCRIPTION
Fixes #114 

## Description

When the recurring package rates match the initial package rates and 1 Shipping Method is displayed, then:
- the Shipping Methods radio buttons must be hidden,
- the hidden input element should be added and;
- the `woocommerce_after_shipping_rate` action should run.

This PR takes care of that. 

## Product impact
- [ ] Added changelog entry 
