### PR TITLE
Attach is purchasable limited product callbacks during checkout/cart block api requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.7.0
+* Fix - When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
+
 2022-02-10 - version 1.6.4
 * Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR#111 wcpay#3768
 

--- a/includes/class-wcs-limiter.php
+++ b/includes/class-wcs-limiter.php
@@ -19,8 +19,8 @@ class WCS_Limiter {
 		// Add limiting subscriptions options on edit product page
 		add_action( 'woocommerce_product_options_advanced', __CLASS__ . '::admin_edit_product_fields' );
 
-		// Only attach limited subscription purchasability logic on the front end.
-		if ( wcs_is_frontend_request() ) {
+		// Only attach limited subscription purchasability logic on the front end or during checkout block requests.
+		if ( wcs_is_frontend_request() || wcs_is_checkout_blocks_api_request() ) {
 			add_filter( 'woocommerce_subscription_is_purchasable', __CLASS__ . '::is_purchasable_switch', 12, 2 );
 			add_filter( 'woocommerce_subscription_variation_is_purchasable', __CLASS__ . '::is_purchasable_switch', 12, 2 );
 			add_filter( 'woocommerce_subscription_is_purchasable', __CLASS__ . '::is_purchasable_renewal', 12, 2 );

--- a/includes/wcs-compatibility-functions.php
+++ b/includes/wcs-compatibility-functions.php
@@ -515,6 +515,28 @@ function wcs_is_rest_api_request() {
 }
 
 /**
+ * Determines if the current request is to any or a specific Checkout blocks REST API endpoint.
+ *
+ * @see Automattic\WooCommerce\Blocks\StoreApi\RoutesController::initialize() for a list of routes.
+ *
+ * @since 1.7.0
+ * @param string $endpoint The checkout/checkout blocks endpoint. Optional. Can be empty (any checkout blocks API) or a specific endpoint ('checkout', 'cart', 'products' etc)
+ * @return bool Whether the current request is for a cart/checkout blocks REST API endpoint.
+ */
+function wcs_is_checkout_blocks_api_request( $endpoint = '' ) {
+
+	if ( ! wcs_is_rest_api_request() || empty( $_SERVER['REQUEST_URI'] ) ) {
+		return false;
+	}
+
+	$endpoint    = empty( $endpoint ) ? '' : '/' . $endpoint;
+	$rest_prefix = trailingslashit( rest_get_url_prefix() );
+	$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+
+	return false !== strpos( $request_uri, $rest_prefix . 'wc/store' . $endpoint );
+}
+
+/**
  * Determines whether the current request is a WordPress cron request.
  *
  * This function is a compatibility wrapper for wp_doing_cron() which was introduced in WP 4.8.


### PR DESCRIPTION
Fixes #118

## Description

When the cart contains a limited subscription product where the customer already has a subscription to that limited product, normally this product would be removed from the cart because the customer isn't eligible to purchase another one of those products. There are exceptions to this though when the customer is renewing a subscription manually or switching an existing subscription. 

These logical exceptions are handled by the `WCS_Limiter` class however were only getting attached on front end requests (via `wcs_is_frontend_request()`). Because the checkout/cart block requests are done via the REST api, these requests weren't passing [this logic check](https://github.com/automattic/woocommerce-subscriptions-core/blob/1.6.0/includes/class-wcs-limiter.php#L23) and so we weren't attaching callbacks correctly.

## How to test this PR

1. Install and activate the following plugins:
    - [**WooCommerce Blocks**](https://wordpress.org/plugins/woo-gutenberg-products-block/)
    - WooCommerce Subscriptions
2. Create a checkout block page.
     1. **Pages > New** from your WP dashboard.
     2. `/checkout` - Add the checkout block
4. Enable switching in the Subscription settings (**WooCommerce > Settings > Subscriptions**).
5. Create a variable subscription with multiple variations and in the **Advanced** product settings tab, set the product to be [limited to any status](https://user-images.githubusercontent.com/8490476/155456023-d1c2a539-7a62-476c-afd1-1636da5731bf.png).
6. Purchase any variation of that product. 
7. On the **My Account > View Subscription** page click the **'Upgrade & downgrade'** and select a different variation.
8. Using the checkout block page, attempt to complete the switch. 
   - On `trunk` you will get the error message below. 
   - With this branch of subscriptions-core you will be able to complete the order.

- While working on this bug I noticed that making edits to the checkout (like changing your email), the cart would also get emptied this is also fixed on this branch.

<img width="1132" alt="Screen Shot 2022-02-24 at 1 13 49 pm" src="https://user-images.githubusercontent.com/8490476/155450947-94292591-8c8d-4f5e-a7d5-16b0dbeb8ee9.png">

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
    - 4232-gh-woocommerce/woocommerce-subscriptions
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref