### PR TITLE
Remove the resubscribe relationship from the subscriptions that get anonymized

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Fix: Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks. PR#103
 * Fix: When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
 * Fix: When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115
-* Fix: Don't anonymize new subscriptions related to old subscriptions via a resubscribe relationship. PR#121
+* Fix: Don't anonymize new subscriptions related to old subscriptions via a resubscribe relationship. PR#121 wcs#4304 wcpay#3889
 
 2022-02-10 - version 1.6.4
 * Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR#111 wcpay#3768

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,8 @@
 2022-xx-xx - version 1.7.0
 * Fix: Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks. PR#103
 * Fix: When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
-* Fix - When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115
+* Fix: When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115
+* Fix: Don't anonymize new subscriptions related to old subscriptions via a resubscribe relationship. PR#121
 
 2022-02-10 - version 1.6.4
 * Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR#111 wcpay#3768

--- a/includes/privacy/class-wcs-privacy-background-updater.php
+++ b/includes/privacy/class-wcs-privacy-background-updater.php
@@ -168,7 +168,7 @@ class WCS_Privacy_Background_Updater {
 		// Reschedule the cleanup just in case something goes wrong.
 		$this->schedule_subscription_orders_anonymization( $subscription_id );
 
-		$related_orders = $subscription->get_related_orders( 'ids', array( 'parent', 'renewal', 'switch', 'resubscribe' ) );
+		$related_orders = $subscription->get_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ) );
 		$count          = 0;
 		$limit          = 20;
 


### PR DESCRIPTION
Fixes #120 

## Description

When ended subscriptions get anonymised, we were previously also anonymizing the subscriptions related orders including resubscribe orders. This is an error for a couple of reasons: 

1. The resubscribe order relation is only there to link the old subscription with the new one. The resubscribe order is the parent order for the new subscription so shouldn't get cleaned up.
2. Anonymising the resubscribe order was causing the new subscription to also get anonymised.

## How to test this PR

**Set up:**
1. Go into **WooCommerce > Settings > Accounts & Privacy** and set "Retain ended subscriptions" to be one month ([screenshot](https://user-images.githubusercontent.com/8490476/156500933-307e4192-590a-4942-9f21-c5ea6bb1f168.png)).
1. Install the [Crontrol Plugin](https://wordpress.org/plugins/wp-crontrol/) so you can run cron event manually.  

---

1. Purchase any subscription product.
1. Fully cancel the subscription - not pending cancellation. You will need to do this from the admin UI.
1. Resubscribe to the subscription you cancelled.
    1. At this point you should have a [fully cancelled subscription and a newly resubscribed subscription](https://user-images.githubusercontent.com/8490476/156501331-3e2edd14-fef3-42c1-9066-36183b2a36f1.png). 
1. Run the code snippet below replacing the subscription ID with the first subscription you purchased - the cancelled one.
1. Go into **Tools > Cron Events** and find the cron job with name `woocommerce_cleanup_personal_data`
1. Click on "**run now**" to run this task
1. Go into **Tools > Scheduled Actions > Pending** 
1. Search for a scheduled action with name `woocommerce_subscriptions_privacy_anonymize_ended_subscriptions`
1. Click on "Run" under this scheduled action
1. After the above action is ran, search for pendings actions starting with `"woocommerce_subscriptions_privacy"`
1. You should see a scheduled action to clean up the old/initial subscription that we cancelled (check subscription IDs in the scheduled action args)
1. Manually run the scheduled action to clean up the old/initial subscription.
1. After the initial subscription is cleaned up, refresh the Scheduled Actions table and search for "woocommerce_subscriptions_privacy" again, you will notice there's now a scheduled action to clean up the resubscribed subscription even though it's still active 🚨 

Once those actions run you'll see something like this: 
<img width="1029" alt="Screen Shot 2022-03-03 at 3 52 39 pm" src="https://user-images.githubusercontent.com/8490476/156504772-7b9ddf04-20fd-4822-b272-f33624b9c212.png">

The old and new subscription have been anonymized. 

```php
add_action( 'shutdown', function() {
	$subscription = wcs_get_subscription( 0 );
	$meta_key     = '_wcs-4304-end-date-updated';

	if ( $subscription && ! $subscription->meta_exists( $meta_key ) ) {

		// Simulate the subscription being ended for 1 month + 1 day.
		$subscription->update_dates(
			array(
				'last_order_date_created' => gmdate( 'Y-m-d H:i:s', gmdate( 'U' ) - MONTH_IN_SECONDS - DAY_IN_SECONDS ),
				'cancelled'               => gmdate( 'Y-m-d H:i:s', gmdate( 'U' ) - MONTH_IN_SECONDS - DAY_IN_SECONDS ),
				'end'                     => gmdate( 'Y-m-d H:i:s', gmdate( 'U' ) - MONTH_IN_SECONDS - DAY_IN_SECONDS )
			)
		);

		$subscription->update_meta_data( $meta_key, 'yes' );
		$subscription->save();
	}
} );
```

On this branch, the newly resubscribed subscription and it's parent order (the resubscribe order) shouldn't be anonymised.

----

Questions: 
 
1. Does this mean resubscribe subscriptions won't ever get anonymised? 
    - No, they just won't get anonymised because they are related to an old subscription via a resubscribe. If the new subscription got cancelled it would still get anonymised based on it's own status (ended and for how long ago).

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
    - 4304-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
    - https://github.com/Automattic/woocommerce-payments/issues/3889