### PR TITLE
Blocks Integration: Switch to global functions to remove deprecation warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+2022-xx-xx - version 1.8.0
+* Update: Switch to global functions to remove deprecation warnings originating from WooCommerce Blocks. PR#124
+
 2022-03-18 - version 1.7.0
 * Fix: Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks. PR#103
 * Fix: When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232

--- a/includes/class-wc-subscriptions-extend-store-endpoint.php
+++ b/includes/class-wc-subscriptions-extend-store-endpoint.php
@@ -11,11 +11,16 @@
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
-use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartItemSchema;
 
 class WC_Subscriptions_Extend_Store_Endpoint {
+	/**
+		 * Stores Rest Schema Controller.
+		 *
+		 * @var Automattic\WooCommerce\StoreApi\SchemaController
+		 */
+	private static $schema;
 
 	/**
 	 * Stores Money formatter instance.
@@ -44,6 +49,7 @@ class WC_Subscriptions_Extend_Store_Endpoint {
 	 * @since WCBLOCKS-DEV
 	 */
 	public static function init() {
+		self::$schema             = class_exists( 'Automattic\WooCommerce\StoreApi\StoreApi' ) ? Automattic\WooCommerce\StoreApi\StoreApi::container()->get( Automattic\WooCommerce\StoreApi\SchemaController::class ) : Package::container()->get( Automattic\WooCommerce\Blocks\StoreApi\SchemaController::class );
 		self::$money_formatter    = function_exists( 'woocommerce_store_api_get_formatter' ) ? woocommerce_store_api_get_formatter( 'money' ) : Package::container()->get( ExtendRestApi::class )->get_formatter( 'money' );
 		self::$currency_formatter = function_exists( 'woocommerce_store_api_get_formatter' ) ? woocommerce_store_api_get_formatter( 'currency' ) : Package::container()->get( ExtendRestApi::class )->get_formatter( 'currency' );
 		self::extend_store();
@@ -328,7 +334,7 @@ class WC_Subscriptions_Extend_Store_Endpoint {
 							'tax_lines'          => self::get_tax_lines( $cart ),
 						)
 					),
-					'shipping_rates'      => array_values( array_map( array( Package::container()->get( SchemaController::class )->get( 'cart-shipping-rate' ), 'get_item_response' ), $shipping_packages ) ),
+					'shipping_rates'      => array_values( array_map( array( self::$schema->get( 'cart-shipping-rate' ), 'get_item_response' ), $shipping_packages ) ),
 				);
 			}
 		}

--- a/includes/class-wc-subscriptions-extend-store-endpoint.php
+++ b/includes/class-wc-subscriptions-extend-store-endpoint.php
@@ -16,10 +16,10 @@ use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartItemSchema;
 
 class WC_Subscriptions_Extend_Store_Endpoint {
 	/**
-		 * Stores Rest Schema Controller.
-		 *
-		 * @var Automattic\WooCommerce\StoreApi\SchemaController
-		 */
+	 * Stores Rest Schema Controller.
+	 *
+	 * @var Automattic\WooCommerce\StoreApi\SchemaController
+	 */
 	private static $schema;
 
 	/**

--- a/includes/class-wc-subscriptions-extend-store-endpoint.php
+++ b/includes/class-wc-subscriptions-extend-store-endpoint.php
@@ -56,49 +56,63 @@ class WC_Subscriptions_Extend_Store_Endpoint {
 	}
 
 	/**
+	 * Register endpoint data with the API.
+	 *
+	 * @param array $args Endpoint data to register.
+	 */
+	protected static function register_endpoint_data( $args ) {
+		if ( function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
+			woocommerce_store_api_register_endpoint_data( $args );
+		} else {
+			Package::container()->get( ExtendRestApi::class )->register_endpoint_data( $args );
+		}
+	}
+
+	/**
+	 * Register payment requirements with the API.
+	 *
+	 * @param array $args Data to register.
+	 */
+	protected static function register_payment_requirements( $args ) {
+		if ( function_exists( 'woocommerce_store_api_register_payment_requirements' ) ) {
+			woocommerce_store_api_register_payment_requirements( $args );
+		} else {
+			Package::container()->get( ExtendRestApi::class )->register_payment_requirements( $args );
+		}
+	}
+
+	/**
 	 * Registers the actual data into each endpoint.
 	 */
 	public static function extend_store() {
 		// Register into `cart/items`
-		$cart_item_endpoint_data = array(
-			'endpoint'        => CartItemSchema::IDENTIFIER,
-			'namespace'       => self::IDENTIFIER,
-			'data_callback'   => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_item_data' ),
-			'schema_callback' => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_item_schema' ),
-			'schema_type'     => ARRAY_A,
+		self::register_endpoint_data(
+			array(
+				'endpoint'        => CartItemSchema::IDENTIFIER,
+				'namespace'       => self::IDENTIFIER,
+				'data_callback'   => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_item_data' ),
+				'schema_callback' => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_item_schema' ),
+				'schema_type'     => ARRAY_A,
+			)
 		);
 
 		// Register into `cart`
-		$cart_endpoint_data = array(
-			'endpoint'        => CartSchema::IDENTIFIER,
-			'namespace'       => self::IDENTIFIER,
-			'data_callback'   => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_data' ),
-			'schema_callback' => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_schema' ),
-			'schema_type'     => ARRAY_N,
+		self::register_endpoint_data(
+			array(
+				'endpoint'        => CartSchema::IDENTIFIER,
+				'namespace'       => self::IDENTIFIER,
+				'data_callback'   => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_data' ),
+				'schema_callback' => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_schema' ),
+				'schema_type'     => ARRAY_N,
+			)
 		);
 
-		if ( function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
-			woocommerce_store_api_register_endpoint_data( $cart_item_endpoint_data );
-			woocommerce_store_api_register_endpoint_data( $cart_endpoint_data );
-		} else {
-			Package::container()->get( ExtendRestApi::class )->register_endpoint_data( $cart_item_endpoint_data );
-			Package::container()->get( ExtendRestApi::class )->register_endpoint_data( $cart_endpoint_data );
-		}
-
 		// Register payment requirements.
-		if ( function_exists( 'woocommerce_store_api_register_payment_requirements' ) ) {
-			woocommerce_store_api_register_payment_requirements(
-				array(
-					'data_callback' => array( WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class(), 'inject_payment_feature_requirements_for_cart_api' ),
-				)
-			);
-		} else {
-			Package::container()->get( ExtendRestApi::class )->register_payment_requirements(
-				array(
-					'data_callback' => array( WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class(), 'inject_payment_feature_requirements_for_cart_api' ),
-				)
-			);
-		}
+		self::register_payment_requirements(
+			array(
+				'data_callback' => array( WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class(), 'inject_payment_feature_requirements_for_cart_api' ),
+			)
+		);
 	}
 
 	/**

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -93,10 +93,10 @@ class WCS_Cart_Renewal {
 			add_action( 'woocommerce_checkout_update_order_meta', array( &$this, 'set_order_item_id' ), 10, 2 );
 
 			// After order meta is saved, get the order line item ID for the renewal so we can update it later
-			if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && ( version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '6.3.0', '>=' ) || \Automattic\WooCommerce\Blocks\Package::is_experimental_build() ) ) {
-				add_action( 'woocommerce_blocks_checkout_update_order_meta', array( &$this, 'set_order_item_id' ), 10, 1 );
+			if ( version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '7.2.0', '>=' ) ) {
+				add_action( 'woocommerce_store_api_checkout_update_order_meta', array( &$this, 'set_order_item_id' ) );
 			} else {
-				add_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', array( &$this, 'set_order_item_id' ), 10, 1 );
+				add_action( 'woocommerce_blocks_checkout_update_order_meta', array( &$this, 'set_order_item_id' ) );
 			}
 
 			// Don't display cart item key meta stored above on the Edit Order screen


### PR DESCRIPTION
## Description

In preparation for Store API moving to Woo Core, some namespacing changes were made in Woo Blocks. While these are backwards compatible changes, there are some deprecation warnings thrown in WP Admin and on the frontend:

```
Deprecated: Automattic\WooCommerce\Blocks\StoreApi\SchemaController is deprecated since version 7.2.0! Use Automattic\WooCommerce\StoreApi\SchemaController instead. in /Users/mikejolley/Developer/local/app/public/wp-includes/functions.php on line 5316

Deprecated: Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi is deprecated since version 7.2.0! Use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema instead. in /Users/mikejolley/Developer/local/app/public/wp-includes/functions.php on line 5316
```

This PR resolves these by seeing if the new global functions exist first, before using the Package/Namespaces used prior.

Also handles the deprecated `woocommerce_blocks_checkout_update_order_meta` action hook.

cc @senadir @haszari

## How to test this PR

With Woo Blocks installed and Cart/Checkout Blocks up and running.

1. Check there are no deprecation warnings shown on the top of the page on the frontend/admin area
2. Add subscription product to cart
3. Visit Cart Block. Check totals etc for subscriptions are rendered.
4. Visit Checkout Block. Check totals etc for subscriptions are rendered.
5. Place order successfully.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes - 4322-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments? yes - https://github.com/Automattic/woocommerce-payments/issues/4004