### PR TITLE
Fix i18n issue with strings that appear on the My account > Payment methods page.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix: When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
 * Fix: When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115
 * Fix: Don't anonymize new subscriptions related to old subscriptions via a resubscribe relationship. PR#121 wcs#4304 wcpay#3889
+* Fix: Content that appears on the My account > Payment methods page should be translatable. PR#125 wcs#4180 wcpay#3974
 
 2022-02-10 - version 1.6.4
 * Fix: When changing the payment method, make sure the subscription total returns $0 when `subscriptions-core` is loaded after the `woocommerce_loaded` action hook. PR#111 wcpay#3768

--- a/includes/class-wcs-my-account-payment-methods.php
+++ b/includes/class-wcs-my-account-payment-methods.php
@@ -245,21 +245,19 @@ class WCS_My_Account_Payment_Methods {
 			return;
 		}
 
-		$script_params  = array(
-			'add_method_error' => __(
-				sprintf(
-					'That payment method cannot be deleted because it is linked to an automatic subscription. Please %1$sadd a payment method%2$s, before trying again.',
-					'<strong>',
-					'</strong>'
-				)
+		$script_params = array(
+			'add_method_error'     => sprintf(
+				// translators: %1$s opening strong HTML tag, %2$s closing strong HTML tag.
+				__( 'That payment method cannot be deleted because it is linked to an automatic subscription. Please %1$sadd a payment method%2$s, before trying again.', 'woocommerce-subscriptions' ),
+				'<strong>',
+				'</strong>'
 			),
-			'choose_default_error' => __(
-				sprintf(
-					'That payment method cannot be deleted because it is linked to an automatic subscription. Please choose a %1$sdefault%2$s payment method%3$s, before trying again.',
-					'<strong><em>',
-					'</em>',
-					'</strong>'
-				)
+			'choose_default_error' => sprintf(
+				// translators: %1$s opening strong and em HTML tags, %2$s closing em HTML tag, %3$s closing strong HTML tag.
+				__( 'That payment method cannot be deleted because it is linked to an automatic subscription. Please choose a %1$sdefault%2$s payment method%3$s, before trying again.', 'woocommerce-subscriptions' ),
+				'<strong><em>',
+				'</em>',
+				'</strong>'
 			),
 		);
 


### PR DESCRIPTION
Fixes
- 4180-gh-woocommerce/woocommerce-subscriptions
- https://github.com/Automattic/woocommerce-payments/issues/3974

## Description

The two strings inside the `enqueue_frontend_scripts()` function in `includes/class-wcs-my-account-payment-methods.php` were using the `__()` function incorrectly.

1. The first param must contain a string literal. Instead, the first param contained a `sprintf()` function call.
2. The text domain param was missing, i.e. `'woocommerce-subscriptions'`.

This PR fixes both of these issues.

## How to test this PR

1. As a shopper, purchase a subscription.
2. Navigate to **My account → Payment methods**.
3. Attempt to delete the payment method that was used to purchase the subscription in step 1.
4. Confirm that the "That payment method cannot be deleted because it is linked to an automatic subscription. Please choose a default payment method, before trying again." error message appears and renders correctly. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes - 4180-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments? yes - https://github.com/Automattic/woocommerce-payments/issues/3974