### PR TITLE
Version 1.7.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-2022-xx-xx - version 1.7.0
+2022-03-18 - version 1.7.0
 * Fix: Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks. PR#103
 * Fix: When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
 * Fix: When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-subscriptions-core",
-	"version": "1.6.4",
+	"version": "1.7.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-subscriptions-core",
-			"version": "1.6.4",
+			"version": "1.7.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "WooCommerce Subscriptions Core",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
-	"version": "1.6.4",
+	"version": "1.7.0",
 	"description": "",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
 	"main": "Gruntfile.js",

--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -6,5 +6,5 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Requires WP: 5.6
- * Version: 1.6.4
+ * Version: 1.7.0
  */


### PR DESCRIPTION
```
2022-03-18 - version 1.7.0
* Fix: Sets up subscriptions integration with the Mini Cart Block and adds new hook to filter compatible blocks. PR#103
* Fix: When using a WooCommerce Blocks powered checkout, fix an issue that led to limited products being removed from the cart when completing a switch or renewal order. PR#119 wcs#4232
* Fix: When there is only one Shipping Method available in the recurring shipping package, make sure that this method is treated as selected in the current session and the `woocommerce_after_shipping_rate` action runs. PR#115
* Fix: Don't anonymize new subscriptions related to old subscriptions via a resubscribe relationship. PR#121 wcs#4304 wcpay#3889
* Fix: Content that appears on the My account > Payment methods page should be translatable. PR#125 wcs#4180 wcpay#3974
```