### PR TITLE
Add GitHub workflow to automate release PRs

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           repository: woocommerce/woorelease
           ref: 2.2.0
+          # This token uses the "repo" scope to check out the private Woorelease repo.
+          # This personal access token is owned by the botwoo account - https://github.com/botwoo
+          # Note: GITHUB_TOKEN does not work here.
           token: ${{ secrets.GH_REPO_PAT }}
           path: woorelease
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -63,21 +63,16 @@ jobs:
         run: |
           git checkout -b release/$VERSION
 
-      - name: Build assets
-        run: |
-          # Temporarily remove the postinstall script as it runs "composer install".
-          npm set-script postinstall ""
-          npm ci
-
-          # Revert the changes to the postinstall script.
-          git reset --hard
-          npm run build:js
-
       - name: Update version
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
         run: |
           php bin/update-version.php $VERSION
+
+      - name: Build assets
+        run: |
+          npm install
+          npm run build:js
 
       - name: Commit changes and create PR
         env:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,95 @@
+name: Create release PR
+
+on: workflow_dispatch
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./main
+    steps:
+      - name: Check out the woocommerce-subscriptions-core repository
+        uses: actions/checkout@v3
+        with:
+          ref: trunk
+          path: main
+
+      - name: Check out the woorelease repository
+        uses: actions/checkout@v3
+        with:
+          repository: woocommerce/woorelease
+          ref: 2.2.0
+          token: ${{ secrets.GH_REPO_PAT }}
+          path: woorelease
+
+      - name: Enable composer dependencies caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/composer/
+          key: ${{ runner.os }}-composer-${{ hashFiles('woorelease/composer.lock') }}
+
+      - name: Enable npm dependencies caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm/
+          key: ${{ runner.os }}-npm-${{ hashFiles('main/package-lock.json') }}
+
+      - name: Setup PHP with composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          coverage: none
+
+      - name: Install Woorelease composer dependencies
+        run: |
+          cd $GITHUB_WORKSPACE/woorelease
+          composer install --prefer-dist --no-dev
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(sed -n '/^= /s/^.*[^0-9]\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/p' changelog.txt | head -1)
+
+          echo "::set-output name=VERSION::$(echo $VERSION)"
+
+      - name: Create the release branch
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          git checkout -b release/$VERSION
+
+      - name: Build assets
+        run: |
+          # Temporarily remove the postinstall script as it runs "composer install".
+          npm set-script postinstall ""
+          npm ci
+
+          # Revert the changes to the postinstall script.
+          git reset --hard
+          npm run build:js
+
+      - name: Update version
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          php bin/update-version.php $VERSION
+
+      - name: Commit changes and create PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am "Version $VERSION"
+          git push --set-upstream origin release/$VERSION
+
+          echo "Picking up changelog for version '$VERSION'..."
+
+          CHANGELOG=$(awk -v ver="$VERSION" '/^= / { if (p) { exit }; if ($2 == ver) { p=1; next } } p && NF' changelog.txt)
+
+          echo -e "\`\`\`\n${CHANGELOG}\n\`\`\`" > commitmsg
+
+          gh pr create --title "Version $VERSION" --body-file commitmsg

--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This script bumps version strings across the codebase for the given version.
+ * It is executed in the "Create release PR" GitHub workflow.
+ */
+
+use Bramus\Monolog\Formatter\ColoredLineFormatter;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Monolog\Processor\PsrLogMessageProcessor;
+use WR\Tools\Version_Bump;
+
+$version          = $argv[1];
+$plugin_slug      = 'woocommerce-subscriptions-core';
+$plugin_folder    = dirname( __DIR__ );
+$main_plugin_file = $plugin_folder . '/' . $plugin_slug . '.php';
+
+// Load the Woorelease autoloader.
+require_once dirname( __DIR__, 2 ) . '/woorelease/vendor/autoload.php';
+
+// Set up the logger.
+$time_format   = 'H:i:s';
+$output_format = "WR [%datetime%] [%level_name%] %message%\n";
+
+$logger  = new Logger( 'Woorelease' );
+$handler = new StreamHandler( 'php://stdout', Logger::INFO );
+$handler->pushProcessor( new PsrLogMessageProcessor() );
+$handler->setFormatter( new ColoredLineFormatter( null, $output_format, $time_format ) );
+$logger->pushHandler( $handler );
+
+Monolog\Registry::addLogger( $logger, 'default' );
+
+// Bump versions across the codebase.
+Version_Bump::maybe_bump(
+	$plugin_slug,
+	$plugin_folder,
+	$main_plugin_file,
+	$version,
+	true
+);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/Automattic/woocommerce-subscriptions-core/issues"
 	},
 	"scripts": {
-		"postinstall": "composer install",
+		"postinstall": "is-ci || composer install",
 		"prepare": "is-ci || husky install",
 		"archive": "composer archive --file=$npm_package_name --format=zip",
 		"build": "npm run build:js && npm run archive",


### PR DESCRIPTION
Fixes #135

## Description

This PR adds a GitHub workflow to automate release PRs. This workflow uses the "workflow_dispatch" trigger, this means the workflow must be manually triggered via the "Actions" page (see below for an example).

<img width="1215" alt="Screen Shot 2022-03-29 at 4 50 18 pm" src="https://user-images.githubusercontent.com/1527164/161455573-607b8331-9b55-46c5-a1ca-0467c98c9ccb.png">

You can also watch a video demo here → p1648783295601769/1648532936.655589-slack-C02BW3Z8SHK 

The workflow performs the following steps:
- Check out the `woocommerce-subscriptions-core` repository (on the `trunk` branch)
- Check out the `woorelease` repository (the latest version, i.e. `2.2.0`)
- Enable composer dependencies caching
- Enable npm dependencies caching
- Setup PHP with composer
- Install Woorelease composer dependencies
- Create the release branch
- Build `woocommerce-subscriptions-core` assets
- Bumps version strings across the codebase
- Commit changes and create the release PR

## Goals/outcomes

The two goals of this PR are:
- **Time-saving**: The current release process is very manual. Each of the steps listed above must be carried out manually. This takes quite a bit of time, especially if the release lead has some local changes on a feature branch. In comparison, the proposed GitHub workflow takes a little over **1 minute** to run and happens entirely within a CI environment.
- **Reduce human error**: Since these steps are manual, there's always the potential to make small mistakes when preparing a release. These mistakes should be minimized/eliminated when using an automated process like the workflow proposed in this PR. 

## How to test this PR

This PR is tricky to test as the workflow must be present on the default branch (i.e. `trunk`) before you can run it.

I was mostly testing this in a fork I created → https://github.com/aprea/woocommerce-subscriptions-core

You can see the workflow runs here → https://github.com/aprea/woocommerce-subscriptions-core/actions/workflows/create-release-pr.yml

And here is an example of a PR created by the workflow → https://github.com/aprea/woocommerce-subscriptions-core/pull/7

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? no
- [x] Will this PR affect WooCommerce Payments? no