### PR TITLE
Automate release tagging - #131

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-name: Create new release from release branch
+name: Create a new release when a release PR is merged
 
-# This action will only run when a pull request is closed/merged.
+# This action will only run when a pull request targeting `trunk` is closed/merged.
 on:
-  pull_request:
+  pull_request_target:
+    branches:
+      - 'trunk'
     types:
       - closed
 
@@ -21,7 +23,7 @@ jobs:
         with:
           # We checkout based on the merge_commit_sha trunk so we're acting on post-merge state rather than pre-merge.
           ref: ${{github.event.pull_request.merge_commit_sha}}
-      - name: version
+      - name: Get version
         id: version
         run: echo ::set-output name=data::$(jq '.version' package.json -r)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   create-release:
     # Action will be skipped unless we have a successful merge AND the original PR started with release
     # If this condition isn't matched, then github will show the action as skipped. 
-    if:  startsWith(github.head_ref, 'release') && github.event.pull_request.merged == true
+    if:  startsWith(github.head_ref, 'release/') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - run: echo "A release branch has been merged with trunk, time to create a new release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Create new release from release branch
+
+# This action will only run when a pull request is closed/merged.
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  create-release:
+    # Action will be skipped unless we have a successful merge AND the original PR started with release
+    # If this condition isn't matched, then github will show the action as skipped. 
+    if:  startsWith(github.head_ref, 'release') && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "A release branch has been merged with trunk, time to create a new release"
+
+      # We need to checkout the code so we can access the version from package.json
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # We checkout based on the merge_commit_sha trunk so we're acting on post-merge state rather than pre-merge.
+          ref: ${{github.event.pull_request.merge_commit_sha}}
+      - name: version
+        id: version
+        run: echo ::set-output name=data::$(jq '.version' package.json -r)
+
+      # Tag a new release with the body set to the description of the original PR.
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          tag_name: ${{steps.version.outputs.data}}
+          name: "Version ${{steps.version.outputs.data}}"
+          body: ${{github.event.pull_request.body}}
+          target_commitish: ${{github.event.pull_request.merge_commit_sha}}


### PR DESCRIPTION
Fixes #131 

## Description
This PR introduces some automation to the release process for subscriptions core. Currently there are a number of manual steps which can be automated.  
#133 helps to automate the first part of the release process, updating version numbers and raising a release PR.  

The automation raised in this PR takes over when a release PR is merged.

When a release PR is merged (the original branch must match `releases*`)  this automation will create and tag a new release with the version number and changelog from the release PR.

This automation relies on #133 and may not work properly without it. As it expects the `package.json` file to be updated correctly and have the changelog in the body of the release PR.

## How to test this PR

This PR cannot be tested as it relies on github actions and will only run once the code is merged. Testing has been done in a separate repository. 
 - [Source PR](https://github.com/brucealdridge/gh_action_test/pull/18)
 - [Action Log
](https://github.com/brucealdridge/gh_action_test/runs/5809439290?check_suite_focus=true)
 - [Release](https://github.com/brucealdridge/gh_action_test/releases/tag/1.8.0)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry: Doesn't apply as this is a CI only change.
- [x] Will this PR affect WooCommerce Subscriptions? no
- [x] Will this PR affect WooCommerce Payments? no
