### PR TITLE
Version 1.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 1.8.0 - 2022-xx-xx =
+= 1.8.0 - 2022-04-04 =
 * Update: Switch to global functions to remove deprecation warnings originating from WooCommerce Blocks. PR#124
 
 = 1.7.0 - 2022-03-18 =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-subscriptions-core",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-subscriptions-core",
-			"version": "1.7.0",
+			"version": "1.8.0",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "WooCommerce Subscriptions Core",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"description": "",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
 	"main": "Gruntfile.js",

--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -6,5 +6,5 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Requires WP: 5.6
- * Version: 1.7.0
+ * Version: 1.8.0
  */


### PR DESCRIPTION
```
= 1.8.0 - 2022-04-04 =
* Update: Switch to global functions to remove deprecation warnings originating from WooCommerce Blocks. PR#124
```