### PR TITLE
Display billing details in the Cart/Checkout Block when purchasing products with subscription plans

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 1.9.0 - 20xx-xx-xx =
+* Fix: Display subscription billing details in the Cart Block when purchasing products with subscription plans created using the All Products extension. PR#149
 * Dev: Update phpunit to v9 to allow testing against newer php versions. PR#140
 
 = 1.8.0 - 2022-04-04 =

--- a/includes/class-wc-subscriptions-extend-store-endpoint.php
+++ b/includes/class-wc-subscriptions-extend-store-endpoint.php
@@ -138,7 +138,7 @@ class WC_Subscriptions_Extend_Store_Endpoint {
 
 		);
 
-		if ( in_array( $product->get_type(), array( 'subscription', 'subscription_variation' ), true ) ) {
+		if ( WC_Subscriptions_Product::is_subscription( $product ) ) {
 			$item_data = array_merge(
 				array(
 					'billing_period'      => WC_Subscriptions_Product::get_period( $product ),


### PR DESCRIPTION
## Description

This PR restores some of the functionality of the All Products for WCS extension when using the block-based checkout. 

Background:

To convert any product to a subscription (regardless of type), APFS sets the current "subscription plan" on product instances directly, and filters the output of WC_Subscriptions_Product::is_subscription to help WCS recognize any product as a subscription.

WCS is coded in a type-agnostic manner to be compatible with APFS. In contexts where a product object is available, it should always be used instead of its id or type to detect whether it's a "subscription product" or not.

This PR replaces the use of `is_type` with `WC_Subscriptions_Product::is_subscription` to determine if a product that has been added to the cart is being purchased on subscription or not.

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

- Install WCS, WCS Core, and the APFS Add-on.
- Create a simple product, and go to **Product Data > Subscriptions**.
- Add a monthly plan.
- Purchase the product on subscription.
- Go to the Cart page (containing the Cart Block).
- Observe that, without this fix, the cart item price and subtotal do not include the subscription billing details.

Here's an example to summarize the issue -- in this scenario, I have added to the cart: (i) a simple subscription-type product and (ii) a simple product with a monthly subscription plan.

The prices and subtotals of both items should include the subscription billing details. This is not happening without the fix:

<img width="1190" alt="Screen Shot 2022-04-20 at 11 56 31 AM" src="https://user-images.githubusercontent.com/1783726/164191060-437da687-3d56-4859-8436-159065a6a442.png">

And here's the Cart Block with the fix:

<img width="1143" alt="Screen Shot 2022-04-20 at 11 58 59 AM" src="https://user-images.githubusercontent.com/1783726/164191541-8cb5fe74-87c5-4f0d-bad0-9c511d89c116.png">

Note that the recurring totals calculation, which is done internally on the Store API side, is not affected. The issue is limited to cart item prices/subtotals.

## Product impact

This fix needs to be included in both WCS and WC Payments.

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref

Change log:

> Fixed an issue that prevented subscription billing details from being displayed in the Cart Block when purchasing products with subscription plans created using the All Products extension.