### PR TITLE
Update `update_post_meta()` code where an order ID is passed to use CRUD

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,6 @@
 
 = 1.9.0 - 20xx-xx-xx =
 * Dev: Update phpunit to v9 to allow testing against newer php versions. PR#140
-* Dev: Update `update_post_meta($order_id, ...)` function calls to use CRUD layer. PR#159
 
 = 1.8.0 - 2022-04-04 =
 * Update: Switch to global functions to remove deprecation warnings originating from WooCommerce Blocks. PR#124

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 1.9.0 - 20xx-xx-xx =
 * Dev: Update phpunit to v9 to allow testing against newer php versions. PR#140
+* Dev: Update `update_post_meta($order_id, ...)` function calls to use CRUD layer. PR#159
 
 = 1.8.0 - 2022-04-04 =
 * Update: Switch to global functions to remove deprecation warnings originating from WooCommerce Blocks. PR#124

--- a/includes/gateways/paypal/includes/class-wcs-paypal-standard-switcher.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-standard-switcher.php
@@ -157,22 +157,24 @@ class WCS_PayPal_Standard_Switcher {
 	public static function save_old_paypal_meta( $order_id, $posted ) {
 		$order = wc_get_order( $order_id );
 
-		if ( wcs_is_order( $order ) && wcs_order_contains_switch( $order ) ) {
-			$subscriptions = wcs_get_subscriptions_for_order( $order, array( 'order_type' => 'switch' ) );
+		if ( ! wcs_is_order( $order ) || ! wcs_order_contains_switch( $order ) ) {
+			return;
+		}
 
-			foreach ( $subscriptions as $subscription ) {
+		$subscriptions = wcs_get_subscriptions_for_order( $order, array( 'order_type' => 'switch' ) );
 
-				if ( 'paypal' === $subscription->get_payment_method() ) {
+		foreach ( $subscriptions as $subscription ) {
 
-					$paypal_id = wcs_get_paypal_id( $subscription->get_id() );
+			if ( 'paypal' === $subscription->get_payment_method() ) {
 
-					if ( ! wcs_is_paypal_profile_a( $paypal_id, 'billing_agreement' ) ) {
-						$order->update_meta_data( '_old_payment_method', 'paypal_standard' );
-						$order->update_meta_data( '_old_paypal_subscription_id', $paypal_id );
-						$order->save();
+				$paypal_id = wcs_get_paypal_id( $subscription->get_id() );
 
-						update_post_meta( $subscription->get_id(), '_switched_paypal_subscription_id', $paypal_id );
-					}
+				if ( ! wcs_is_paypal_profile_a( $paypal_id, 'billing_agreement' ) ) {
+					$order->update_meta_data( '_old_payment_method', 'paypal_standard' );
+					$order->update_meta_data( '_old_paypal_subscription_id', $paypal_id );
+					$order->save();
+
+					update_post_meta( $subscription->get_id(), '_switched_paypal_subscription_id', $paypal_id );
 				}
 			}
 		}

--- a/includes/gateways/paypal/includes/class-wcs-paypal-standard-switcher.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-standard-switcher.php
@@ -155,9 +155,10 @@ class WCS_PayPal_Standard_Switcher {
 	 * @since 2.0.15
 	 */
 	public static function save_old_paypal_meta( $order_id, $posted ) {
+		$order = wc_get_order( $order_id );
 
-		if ( wcs_order_contains_switch( $order_id ) ) {
-			$subscriptions = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'switch' ) );
+		if ( wcs_is_order( $order ) && wcs_order_contains_switch( $order ) ) {
+			$subscriptions = wcs_get_subscriptions_for_order( $order, array( 'order_type' => 'switch' ) );
 
 			foreach ( $subscriptions as $subscription ) {
 
@@ -166,8 +167,10 @@ class WCS_PayPal_Standard_Switcher {
 					$paypal_id = wcs_get_paypal_id( $subscription->get_id() );
 
 					if ( ! wcs_is_paypal_profile_a( $paypal_id, 'billing_agreement' ) ) {
-						update_post_meta( $order_id, '_old_payment_method', 'paypal_standard' );
-						update_post_meta( $order_id, '_old_paypal_subscription_id', $paypal_id );
+						$order->update_meta_data( '_old_payment_method', 'paypal_standard' );
+						$order->update_meta_data( '_old_paypal_subscription_id', $paypal_id );
+						$order->save();
+
 						update_post_meta( $subscription->get_id(), '_switched_paypal_subscription_id', $paypal_id );
 					}
 				}

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -1137,13 +1137,13 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 			if ( in_array( $status, $expected_to_pass, true ) ) {
 
 				try {
-
-					$start_date = gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) );
+					$expected_end_date = gmdate( 'Y-m-d H:i:s' );
+					$start_date        = gmdate( 'Y-m-d H:i:s', strtotime( $expected_end_date . ' -1 month' ) );
 					$subscription->update_dates( [ 'start' => $start_date ] );
 
 					$subscription->update_status( 'pending-cancel' );
 
-					$this->assertEquals( time(), $subscription->get_time( 'end' ), '', 2 );
+					$this->assertEquals( strtotime( $expected_end_date ), $subscription->get_time( 'end' ), '', 2 );
 				} catch ( Exception $e ) {
 
 					$this->fail( $e->getMessage() );

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -1137,15 +1137,13 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 			if ( in_array( $status, $expected_to_pass, true ) ) {
 
 				try {
-					$expected_end_date = gmdate( 'Y-m-d H:i:s' );
-					$start_date        = gmdate( 'Y-m-d H:i:s', strtotime( $expected_end_date . ' -1 month' ) );
-					$subscription->update_dates( [ 'start' => $start_date ] );
+					$start_date = gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) );
 
+					$subscription->update_dates( [ 'start' => $start_date ] );
 					$subscription->update_status( 'pending-cancel' );
 
-					$this->assertEquals( strtotime( $expected_end_date ), $subscription->get_time( 'end' ), '', 2 );
+					$this->assertEqualsWithDelta( time(), $subscription->get_time( 'end' ), 3 ); // delta set to 3 as a margin of error between the dates, shouldn't be more than 1 but just to be safe.
 				} catch ( Exception $e ) {
-
 					$this->fail( $e->getMessage() );
 				}
 			} else {

--- a/tests/unit/test-wcs-compatibility-functions.php
+++ b/tests/unit/test-wcs-compatibility-functions.php
@@ -23,11 +23,20 @@ class WCS_Compatibility_Functions_Test extends WP_UnitTestCase {
 		$this->assertEquals( get_post( $simple_product->get_id() ), wcs_get_objects_property( $simple_product, 'post' ) );
 		$this->assertEquals( get_post( $variation_product->get_parent_id() ), wcs_get_objects_property( $variation_product, 'post' ) );
 
-		// post_status.
+		// post_status - now deprecated as a property
+		$this->expected_deprecated = [
+			'wcs_get_objects_property',
+		];
 		$this->assertEquals( get_post( $subscription->get_id() )->post_status, wcs_get_objects_property( $subscription, 'post_status' ) );
 		$this->assertEquals( get_post( $order->get_id() )->post_status, wcs_get_objects_property( $order, 'post_status' ) );
 		$this->assertEquals( get_post( $simple_product->get_id() )->post_status, wcs_get_objects_property( $simple_product, 'post_status' ) );
 		$this->assertEquals( get_post( $variation_product->get_parent_id() )->post_status, wcs_get_objects_property( $variation_product, 'post_status' ) );
+
+		// status.
+		$this->assertEquals( $subscription->get_status(), wcs_get_objects_property( $subscription, 'status' ) );
+		$this->assertEquals( $order->get_status(), wcs_get_objects_property( $order, 'status' ) );
+		$this->assertEquals( $simple_product->get_status(), wcs_get_objects_property( $simple_product, 'status' ) );
+		$this->assertEquals( $variation_product->get_status(), wcs_get_objects_property( $variation_product, 'status' ) );
 
 		// parent_id.
 		$this->assertEquals( $subscription->get_parent_id(), wcs_get_objects_property( $subscription, 'parent_id' ) );
@@ -105,5 +114,47 @@ class WCS_Compatibility_Functions_Test extends WP_UnitTestCase {
 		$this->assertNull( wcs_get_objects_property( false, 'FAKE_PROPERTY' ) );
 		$this->assertNull( wcs_get_objects_property( '', 'name' ) );
 		$this->assertNull( wcs_get_objects_property( null, 'ID' ) );
+	}
+
+	public function test_wcs_set_objects_property() {
+		$simple_product      = WC_Helper_Product::create_simple_product();
+		$meta_key            = uniqid( 'meta_key_' );
+		$original_name       = 'Original Name';
+		$original_meta_value = 'original_meta_value';
+		$updated_name        = 'Test Product';
+		$updated_meta_value  = 'updated_meta_value';
+
+		$simple_product->set_name( $original_name );
+		$simple_product->update_meta_data( $meta_key, $original_meta_value );
+		$simple_product->save();
+
+		// property without saving
+		wcs_set_objects_property( $simple_product, 'name', $updated_name, 'no save' );
+		$this->assertEquals( $updated_name, $simple_product->get_name() );
+
+		// meta without saving
+		wcs_set_objects_property( $simple_product, $meta_key, $updated_meta_value, 'no save', '', 'no prefix' );
+		$this->assertEquals( $updated_meta_value, $simple_product->get_meta( $meta_key ) );
+
+		// verify reloaded object has original values
+		$reloaded_product = wc_get_product( $simple_product->get_id() );
+		$this->assertEquals( $original_name, $reloaded_product->get_name() );
+		$this->assertEquals( $original_meta_value, $reloaded_product->get_meta( $meta_key ) );
+
+		$simple_product->set_name( $original_name );
+		$simple_product->update_meta_data( $meta_key, $original_meta_value );
+
+		// property with saving
+		wcs_set_objects_property( $simple_product, 'name', $updated_name );
+		$this->assertEquals( $updated_name, $simple_product->get_name() );
+
+		// meta with saving
+		wcs_set_objects_property( $simple_product, $meta_key, $updated_meta_value, 'save', '', 'no prefix' );
+		$this->assertEquals( $updated_meta_value, $simple_product->get_meta( $meta_key ) );
+
+		// verify reloaded object has updated values
+		$reloaded_product = wc_get_product( $simple_product->get_id() );
+		$this->assertEquals( $updated_name, $reloaded_product->get_name() );
+		$this->assertEquals( $updated_meta_value, $reloaded_product->get_meta( $meta_key ) );
 	}
 }

--- a/tests/unit/test-wcs-compatibility-functions.php
+++ b/tests/unit/test-wcs-compatibility-functions.php
@@ -23,7 +23,7 @@ class WCS_Compatibility_Functions_Test extends WP_UnitTestCase {
 		$this->assertEquals( get_post( $simple_product->get_id() ), wcs_get_objects_property( $simple_product, 'post' ) );
 		$this->assertEquals( get_post( $variation_product->get_parent_id() ), wcs_get_objects_property( $variation_product, 'post' ) );
 
-		// post_status - now deprecated as a property
+		// post_status
 		$this->assertEquals( get_post( $subscription->get_id() )->post_status, wcs_get_objects_property( $subscription, 'post_status' ) );
 		$this->assertEquals( get_post( $order->get_id() )->post_status, wcs_get_objects_property( $order, 'post_status' ) );
 		$this->assertEquals( get_post( $simple_product->get_id() )->post_status, wcs_get_objects_property( $simple_product, 'post_status' ) );

--- a/tests/unit/test-wcs-compatibility-functions.php
+++ b/tests/unit/test-wcs-compatibility-functions.php
@@ -24,9 +24,6 @@ class WCS_Compatibility_Functions_Test extends WP_UnitTestCase {
 		$this->assertEquals( get_post( $variation_product->get_parent_id() ), wcs_get_objects_property( $variation_product, 'post' ) );
 
 		// post_status - now deprecated as a property
-		$this->expected_deprecated = [
-			'wcs_get_objects_property',
-		];
 		$this->assertEquals( get_post( $subscription->get_id() )->post_status, wcs_get_objects_property( $subscription, 'post_status' ) );
 		$this->assertEquals( get_post( $order->get_id() )->post_status, wcs_get_objects_property( $order, 'post_status' ) );
 		$this->assertEquals( get_post( $simple_product->get_id() )->post_status, wcs_get_objects_property( $simple_product, 'post_status' ) );


### PR DESCRIPTION
Fixes #142

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

When order data is moved to custom tables, updating order meta using `update_post_meta()` will no longer work. This PR updates all cases of `update_post_meta()` where an Order ID is passed - thankfully there wasn't many cases in our codebase 😅 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

**Testing `wcs_set_objects_property()` changes**

This function is pretty well covered in unit tests, however to test nothing is broken a simple test would be to process a subscription renewal order and make sure the renewal order has the correct meta data.

1. With an active subscription, process a renewal order
2. Confirm the new renewal order has `_billing_address_1` metadata set

**Testing `save_old_paypal_meta()` changes**

This one was a little trickier to test so I just hacked some of the conditions because the only changes we cared about is the order updating post meta:
1. Edit the `save_old_paypal_meta()` function to pass if conditions using, `true ||`
2. Manually set `$subscriptions` to be `$subscriptions = [ 101823 => wcs_get_subscription( 101823 ) ];`
3. Run the following snippet:

```
add_action( 'admin_footer', function() {
	update_post_meta( 101823, '_paypal_subscription_id', 'S-fake1234' );
	update_post_meta( 101823, '_payment_method', 'paypal' );

	WCS_PayPal_Standard_Switcher::save_old_paypal_meta( 101824, [] );
} );
```

4. Confirm the $order meta is set in the DB

![image](https://user-images.githubusercontent.com/2275145/165427171-425642d1-86d8-4657-8fd8-e06601cbbefd.png)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
