### PR TITLE
Replace `get_posts()` with `wc_get_orders()` in WC_Subscriptions_Order::get_users_subscription_orders()

### DIFF
--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -644,20 +644,23 @@ class WC_Subscriptions_Order {
 			'orderby'     => 'date',
 			'order'       => 'DESC',
 			'customer_id' => $user_id,
+			'return'      => 'ids',
 		);
 
 		$args['_non_subscription_renewal'] = true;
 
-		$orders = wc_get_orders( $args );
+		$order_ids = wc_get_orders( $args );
 
 		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $custom_query_var_handler, 10 );
 
-		$order_ids = [];
-		foreach ( $orders as $order ) {
-			if ( wcs_order_contains_subscription( $order->id, 'parent' ) ) {
-				$order_ids[] = $order->id;
+		foreach ( $order_ids as $index => $order_id ) {
+			if ( ! wcs_order_contains_subscription( $order_id, 'parent' ) ) {
+				unset( $order_ids[ $index ] );
 			}
 		}
+
+		// Normalise array keys
+		$order_ids = array_values( $order_ids );
 
 		return apply_filters( 'users_subscription_orders', $order_ids, $user_id );
 	}

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -628,6 +628,7 @@ class WC_Subscriptions_Order {
 					'key'     => '_subscription_renewal',
 					'compare' => 'NOT EXISTS',
 				);
+				unset( $query_vars['_non_subscription_renewal'] );
 			}
 
 			return $query;

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -635,12 +635,12 @@ class WC_Subscriptions_Order {
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $custom_query_var_handler, 10, 2 );
 
 		$args = array(
-			'limit'    => 1,
-			'type'     => 'shop_order',
-			'status'   => 'any',
-			'orderby'  => 'date',
-			'order'    => 'DESC',
-			'customer' => $user_id,
+			'limit'       => 1,
+			'type'        => 'shop_order',
+			'status'      => 'any',
+			'orderby'     => 'date',
+			'order'       => 'DESC',
+			'customer_id' => $user_id,
 		);
 
 		$args['_non_subscription_renewal'] = true;

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -638,7 +638,6 @@ class WC_Subscriptions_Order {
 		$all_possible_statuses = array_values( array_unique( array_keys( wc_get_order_statuses() ) ) );
 
 		$args = array(
-			'limit'       => 1,
 			'type'        => 'shop_order',
 			'status'      => $all_possible_statuses,
 			'orderby'     => 'date',

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -635,10 +635,12 @@ class WC_Subscriptions_Order {
 		};
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $custom_query_var_handler, 10, 2 );
 
+		$all_possible_statuses = array_values( array_unique( array_keys( wc_get_order_statuses() ) ) );
+
 		$args = array(
 			'limit'       => 1,
 			'type'        => 'shop_order',
-			'status'      => 'any',
+			'status'      => $all_possible_statuses,
 			'orderby'     => 'date',
 			'order'       => 'DESC',
 			'customer_id' => $user_id,


### PR DESCRIPTION
Fixes #144 partially.

## Description

This PR only replaces `get_posts()` call in [get_users_subscription_orders()](https://github.com/Automattic/woocommerce-subscriptions-core/blob/97c279bdb6131462de9e90161a6a172ce0447293/includes/class-wc-subscriptions-order.php#L617) with `wc_get_orders()`.

Some key points:
- I follow [this guide](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#adding-custom-parameter-support) to pass the `meta_query` bit.
- I change the field name following [this map](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/wc-order-functions.php#L27-L36).
- I use `customer_id` [parameter](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#customer), instead of passing it in `meta_query`.

## How to test this PR

1. Install `woocommerce-subscriptions-core` as a plugin.
2. Since I [get_users_subscription_orders()](https://github.com/Automattic/woocommerce-subscriptions-core/blob/97c279bdb6131462de9e90161a6a172ce0447293/includes/class-wc-subscriptions-order.php#L617) isn't called anywhere, I use [wp-console](https://wordpress.org/plugins/wp-console/) to call it.

![Screen Shot 2022-04-28 at 22 52 10](https://user-images.githubusercontent.com/73803630/165793406-0c3beb93-27ee-4af7-b447-56dbba8769e7.png)

Actually, I wondered if we can just delete `get_users_subscription_orders()` but then I think someone out there (another plugin or custom code) might depend on it.

3. Run `WC_Subscriptions_Order::get_users_subscription_orders();` and make sure base branch and PR branch returns the same output.

4. I also add this code as a [mu-plugin](https://wordpress.org/support/article/must-use-plugins/), in a file `wp-content/mu-plugins/something.php`.

```
define('SAVEQUERIES', true);
add_action( 'shutdown', function() {
    global $wpdb;
    foreach($wpdb->queries as $q) {
        file_put_contents('/tmp/debug.log', "-----start\n" . $q[0] . "\n-----end\n");
    }
} );
```

To log queries going to the database. I search for `subscription_renewal`. I format the query and diff the query made using base branch vs PR branch.

There is some diff but looks OK:

![Screen Shot 2022-04-28 at 23 07 01](https://user-images.githubusercontent.com/73803630/165796388-9d4cdcea-7fd9-43c7-b1b1-37b7f4828b1f.png)


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? no
- [x] Will this PR affect WooCommerce Payments? no
