### PR TITLE
Replace `get_post_meta()` with `$order->get_meta()` or `wcs_get_objects_property()`

### DIFF
--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -325,40 +325,6 @@ class WC_Subscriptions_Order {
 	}
 
 	/**
-	 * A unified API for accessing subscription order meta, especially for sign-up fee related order meta.
-	 *
-	 * Because WooCommerce 2.1 deprecated WC_Order::$order_custom_fields, this function is also used to provide
-	 * version independent meta data access to non-subscription meta data.
-	 *
-	 * @param WC_Order|int $order The WC_Order object or ID of the order for which the meta should be sought.
-	 * @param string $meta_key The key as stored in the post meta table for the meta item.
-	 * @param mixed $default (optional) The default value to return if the meta key does not exist. Default 0.
-	 * @since 1.0
-	 */
-	public static function get_meta( $order, $meta_key, $default = 0 ) {
-
-		if ( ! is_object( $order ) ) {
-			$order = wc_get_order( $order );
-		}
-
-		$meta_key = preg_replace( '/^_/', '', $meta_key );
-
-		if ( isset( $order->$meta_key ) ) { // WC 2.1+ magic __isset() & __get() methods
-			$meta_value = $order->$meta_key;
-		} elseif ( is_array( $order->order_custom_fields ) && isset( $order->order_custom_fields[ '_' . $meta_key ][0] ) && $order->order_custom_fields[ '_' . $meta_key ][0] ) {  // < WC 2.1+
-			$meta_value = maybe_unserialize( $order->order_custom_fields[ '_' . $meta_key ][0] );
-		} else {
-			$meta_value = get_post_meta( wcs_get_objects_property( $order, 'id' ), '_' . $meta_key, true );
-
-			if ( empty( $meta_value ) ) {
-				$meta_value = $default;
-			}
-		}
-
-		return $meta_value;
-	}
-
-	/**
 	 * Displays a few details about what happens to their subscription. Hooked
 	 * to the thank you page.
 	 *
@@ -2220,5 +2186,42 @@ class WC_Subscriptions_Order {
 	public static function get_order_currency( $order ) {
 		_deprecated_function( __METHOD__, '2.2.0', 'wcs_get_objects_property( $order, "currency" ) or $order->get_currency()' );
 		return wcs_get_objects_property( $order, 'currency' );
+	}
+
+	/**
+	 * A unified API for accessing subscription order meta, especially for sign-up fee related order meta.
+	 *
+	 * Because WooCommerce 2.1 deprecated WC_Order::$order_custom_fields, this function is also used to provide
+	 * version independent meta data access to non-subscription meta data.
+	 *
+	 * Deprecated in Subscriptions Core 2.0 since we have the wcs_get_objects_property() which serves the same purpose.
+	 *
+	 * @deprecated 2.0
+	 * @since 1.0
+	 *
+	 * @param  WC_Order|int $order    The WC_Order object or ID of the order for which the meta should be sought.
+	 * @param  string       $meta_key The key as stored in the post meta table for the meta item.
+	 * @param  mixed        $default  The default value to return if the meta key does not exist. Default 0.
+	 *
+	 * @return mixed Order meta data found by key.
+	 */
+	public static function get_meta( $order, $meta_key, $default = 0 ) {
+		wcs_deprecated_function( __METHOD__, '2.0', 'wcs_get_objects_property( $order, $meta_key, "single", $default )' );
+
+		if ( ! is_object( $order ) ) {
+			$order = wc_get_order( $order );
+		}
+
+		$meta_key = preg_replace( '/^_/', '', $meta_key );
+
+		if ( isset( $order->$meta_key ) ) { // WC 2.1+ magic __isset() & __get() methods
+			$meta_value = $order->$meta_key;
+		} elseif ( is_array( $order->order_custom_fields ) && isset( $order->order_custom_fields[ '_' . $meta_key ][0] ) && $order->order_custom_fields[ '_' . $meta_key ][0] ) {  // < WC 2.1+
+			$meta_value = maybe_unserialize( $order->order_custom_fields[ '_' . $meta_key ][0] );
+		} else {
+			$meta_value = wcs_get_objects_property( $order, $meta_key, 'single', $default );
+		}
+
+		return $meta_value;
 	}
 }

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2199,9 +2199,9 @@ class WC_Subscriptions_Order {
 	 * @deprecated 2.0
 	 * @since 1.0
 	 *
-	 * @param  WC_Order|int $order    The WC_Order object or ID of the order for which the meta should be sought.
-	 * @param  string       $meta_key The key as stored in the post meta table for the meta item.
-	 * @param  mixed        $default  The default value to return if the meta key does not exist. Default 0.
+	 * @param WC_Order|int $order    The WC_Order object or ID of the order for which the meta should be sought.
+	 * @param string       $meta_key The key as stored in the post meta table for the meta item.
+	 * @param mixed        $default  The default value to return if the meta key does not exist. Default 0.
 	 *
 	 * @return mixed Order meta data found by key.
 	 */

--- a/includes/class-wcs-post-meta-cache-manager.php
+++ b/includes/class-wcs-post-meta-cache-manager.php
@@ -199,8 +199,12 @@ class WCS_Post_Meta_Cache_Manager {
 			throw new InvalidArgumentException( sprintf( __( 'Invalid update type: %s. Post update types supported are "add" or "delete". Updates are done on post meta directly.', 'woocommerce-subscriptions' ), $update_type ) );
 		}
 
+		$object = ( 'shop_order' === $this->post_type ) ? wc_get_order( $post_id ) : get_post( $post_id );
+
 		foreach ( $this->meta_keys as $meta_key => $value ) {
-			$meta_value = ( 'add' === $update_type ) ? get_post_meta( $post_id, $meta_key, true ) : '';
+			$property   = preg_replace( '/^_/', '', $meta_key );
+			$meta_value = ( 'add' === $update_type ) ? wcs_get_objects_property( $object, $property ) : '';
+
 			$this->maybe_trigger_update_cache_hook( $update_type, $post_id, $meta_key, $meta_value );
 		}
 	}

--- a/includes/wcs-compatibility-functions.php
+++ b/includes/wcs-compatibility-functions.php
@@ -98,13 +98,15 @@ function wcs_get_objects_property( $object, $property, $single = 'single', $defa
 			if ( is_callable( array( $object, $function_name ) ) ) {
 				$value = $object->$function_name();
 			} else {
-				// If we don't have a method for this specific property, but we are using WC 3.0, it may be set as meta data on the object so check if we can use that.
-				if ( method_exists( $object, 'get_meta' ) && $object->meta_exists( $prefixed_key ) ) {
-					if ( 'single' === $single ) {
-						$value = $object->get_meta( $prefixed_key, true );
-					} else {
-						// WC_Data::get_meta() returns an array of stdClass objects with id, key & value properties when meta is available.
-						$value = wp_list_pluck( $object->get_meta( $prefixed_key, false ), 'value' );
+				// If we don't have a method for this specific property, but we are using WC 3.0, use $object->get_meta().
+				if ( method_exists( $object, 'get_meta' ) ) {
+					if ( $object->meta_exists( $prefixed_key ) ) {
+						if ( 'single' === $single ) {
+							$value = $object->get_meta( $prefixed_key, true );
+						} else {
+							// WC_Data::get_meta() returns an array of stdClass objects with id, key & value properties when meta is available.
+							$value = wp_list_pluck( $object->get_meta( $prefixed_key, false ), 'value' );
+						}
 					}
 				} elseif ( 'single' === $single && isset( $object->$property ) ) { // WC < 3.0.
 					$value = $object->$property;

--- a/tests/unit/test-wcs-post-meta-cache-manager.php
+++ b/tests/unit/test-wcs-post-meta-cache-manager.php
@@ -41,7 +41,7 @@ class WCS_Post_Meta_Cache_Manager_Test extends WP_UnitTestCase {
 		parent::set_up_before_class();
 		// Create a dummy WP post for the $known_post_id used in these tests.
 		$post_data = array(
-			'post_title'   => 'Test Post ',
+			'post_title'   => 'Test Post',
 			'post_content' => '',
 			'import_id'    => 12358,
 		);

--- a/tests/unit/test-wcs-post-meta-cache-manager.php
+++ b/tests/unit/test-wcs-post-meta-cache-manager.php
@@ -37,6 +37,21 @@ class WCS_Post_Meta_Cache_Manager_Test extends WP_UnitTestCase {
 	/** @var int Keep track of how many times a callback on a hook has been called. */
 	protected $callback_check_count = 0;
 
+	public static function setUpBeforeClass() {
+		// Create a dummy WP post for the $known_post_id used in these tests.
+		$post_data = array(
+			'post_title'   => 'Test Post ',
+			'post_content' => '',
+			'import_id'    => 12358,
+		);
+
+		wp_insert_post( $post_data );
+	}
+
+	public static function tearDownAfterClass() {
+		wp_delete_post( 12358, true );
+	}
+
 	/**
 	 * Check callbacks are attached correctly
 	 */

--- a/tests/unit/test-wcs-post-meta-cache-manager.php
+++ b/tests/unit/test-wcs-post-meta-cache-manager.php
@@ -37,7 +37,8 @@ class WCS_Post_Meta_Cache_Manager_Test extends WP_UnitTestCase {
 	/** @var int Keep track of how many times a callback on a hook has been called. */
 	protected $callback_check_count = 0;
 
-	public static function setUpBeforeClass() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 		// Create a dummy WP post for the $known_post_id used in these tests.
 		$post_data = array(
 			'post_title'   => 'Test Post ',
@@ -48,7 +49,8 @@ class WCS_Post_Meta_Cache_Manager_Test extends WP_UnitTestCase {
 		wp_insert_post( $post_data );
 	}
 
-	public static function tearDownAfterClass() {
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
 		wp_delete_post( 12358, true );
 	}
 


### PR DESCRIPTION
Fixes #141 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR updates sections of our code that calls `get_post_meta()` where an $order ID is passed:

- `WC_Subscriptions_Order::get_meta()`

This function wasn't being used in our code anyway, apart from in very old upgrade scripts, so I updated the function to remove the `get_post_meta()` usage but I also deprecated it. Since WC Subscriptions 2.0, this function has been replaced with `wcs_get_objects_property()`

- `WCS_Post_Meta_Cache_Manager::maybe_update_for_post_change()`

In order to make this function work with Orders in a custom order table, I needed to update it to get the order or post object first, then get the meta using our `wcs_get_objects_property()` function.

Because this class has the word `Post` in it (`WCS_Post_Meta_Cache_Manager`), we could look at creating a whole new class for handling object meta cache (i.e. `WCS_Object_Meta_Cache_Manager`). Keen to get others thoughts on this :)

- `wcs_get_objects_property()`

The other change in this PR is to our helper function which is used to get meta data for a given object (subscriptions, order, or post). Rather than getting rid of the `get_post_meta()` uses entirely from this function, I updated the function so that it always uses `$object->get_meta()` function for orders and subscriptions.

## How to test this PR

#### Testing changes to `WCS_Post_Meta_Cache_Manager::maybe_update_for_post_change()`

Affected flow: Viewing subscriptions related orders in WP Admin and from My Account page
1. Purchase a new subscription
2. Process a renewal
3. View the Edit Subscription > Related Order meta box
4. Process another renewal
5. View the number of orders for the subscription is correct in **WooCommerce > Subscriptions** table
6. Visit My Account > Subscriptions > View
7. Scroll down and check related orders table
8. Delete a related order

#### Testing`wcs_get_objects_property()` changes

The above testing instructions will work for these changes as well.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes
