### PR TITLE
Fix failed PHP 7.1 linting check

### DIFF
--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -87,7 +87,14 @@ jobs:
           php-version: '7.1'
           tools: composer
       # run CI checks
-      - run: bash bin/run-ci-tests.sh
+      - run: |
+          IS_PHP_71_OR_LOWER=`php -r "echo version_compare('7.1', phpversion(), '<=');"`
+          if [[ $IS_PHP_71_OR_LOWER == '1' ]]; then
+            echo "WC_VERSION=6.4.1 bash bin/run-ci-tests.sh"
+            WC_VERSION=6.4.1 bash bin/run-ci-tests.sh
+          else
+            echo "bash bin/run-ci-tests.sh"
+            bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
     runs-on: ubuntu-18.04

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -74,6 +74,7 @@ jobs:
           else
             echo "bash bin/run-ci-tests.sh"
             bash bin/run-ci-tests.sh
+          fi
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
     runs-on: ubuntu-18.04
@@ -94,14 +95,7 @@ jobs:
           php-version: '7.1'
           tools: composer
       # run CI checks
-      - run: |
-          IS_PHP_71_OR_LOWER=`php -r "echo version_compare('7.1', phpversion(), '<=');"`
-          if [[ $IS_PHP_71_OR_LOWER == '1' ]]; then
-            echo "WC_VERSION=6.4.1 bash bin/run-ci-tests.sh"
-            WC_VERSION=6.4.1 bash bin/run-ci-tests.sh
-          else
-            echo "bash bin/run-ci-tests.sh"
-            bash bin/run-ci-tests.sh
+      - run: bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
     runs-on: ubuntu-18.04

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -66,7 +66,14 @@ jobs:
           php-version: ${{ matrix.php }}
           tools:       composer
       # run CI checks
-      - run: bash bin/run-ci-tests.sh
+      - run: |
+          IS_PHP_71_OR_LOWER=`php -r "echo version_compare('7.1', phpversion(), '<=');"`
+          if [[ $IS_PHP_71_OR_LOWER == '1' ]]; then
+            echo "WC_VERSION=6.4.1 bash bin/run-ci-tests.sh"
+            WC_VERSION=6.4.1 bash bin/run-ci-tests.sh
+          else
+            echo "bash bin/run-ci-tests.sh"
+            bash bin/run-ci-tests.sh
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Description

Since WooCommerce just released `6.5` that requires PHP 7.2, our PHP 7.1 linting check [fails](https://github.com/Automattic/woocommerce-subscriptions-core/runs/6385651745?check_suite_focus=true#step:5:177).

This PR set WC version `6.4.1` to be installed when PHP version is <= 7.1.

## How to test this PR

Make sure `PHP linting and tests / PHP testing (7.1)` check is green.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? no
- [x] Will this PR affect WooCommerce Payments? no
