### PR TITLE
Replace any code using `get_post_type( $order_id )` with WC Data Store `get_order_type()`

### DIFF
--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -85,7 +85,7 @@ class WCS_Admin_Meta_Boxes {
 		add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', 'shop_subscription', 'normal', 'low' );
 
 		// Only display the meta box if an order relates to a subscription
-		if ( 'shop_order' === get_post_type( $post_ID ) && wcs_order_contains_subscription( $post_ID, 'any' ) ) {
+		if ( 'shop_order' === WC_Data_Store::load( 'order' )->get_order_type( $post_ID ) && wcs_order_contains_subscription( $post_ID, 'any' ) ) {
 			add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', 'shop_order', 'normal', 'low' );
 		}
 	}

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -794,8 +794,7 @@ class WC_Subscriptions_Manager {
 	 * @since 1.0
 	 */
 	public static function maybe_trash_subscription( $post_id ) {
-
-		if ( 'shop_order' == get_post_type( $post_id ) ) {
+		if ( 'shop_order' === WC_Data_Store::load( 'order' )->get_order_type( $post_id ) ) {
 
 			// delete subscription
 			foreach ( wcs_get_subscriptions_for_order( $post_id, array( 'order_type' => 'parent' ) ) as $subscription ) {
@@ -810,7 +809,7 @@ class WC_Subscriptions_Manager {
 	 * @since 2.2.17
 	 */
 	public static function maybe_untrash_subscription( $post_id ) {
-		if ( 'shop_order' == get_post_type( $post_id ) ) {
+		if ( 'shop_order' === WC_Data_Store::load( 'order' )->get_order_type( $post_id ) ) {
 			foreach ( wcs_get_subscriptions_for_order( $post_id, array( 'order_type' => 'parent', 'subscription_status' => array( 'trash' ) ) ) as $subscription ) { // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound
 				wp_untrash_post( $subscription->get_id() );
 			}
@@ -825,7 +824,7 @@ class WC_Subscriptions_Manager {
 	 * @param int $post_id The post ID being deleted.
 	 */
 	public static function maybe_delete_subscription( $post_id ) {
-		if ( 'shop_order' !== get_post_type( $post_id ) ) {
+		if ( 'shop_order' !== WC_Data_Store::load( 'order' )->get_order_type( $post_id ) ) {
 			return;
 		}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -391,7 +391,7 @@ class WCS_Cart_Renewal {
 				continue;
 			}
 
-			if ( isset( $item[ $this->cart_item_key ]['renewal_order_id'] ) && ! 'shop_order' == get_post_type( $item[ $this->cart_item_key ]['renewal_order_id'] ) ) {
+			if ( isset( $item[ $this->cart_item_key ]['renewal_order_id'] ) && ! 'shop_order' === WC_Data_Store::load( 'order' )->get_order_type( $item[ $this->cart_item_key ]['renewal_order_id'] ) ) {
 				$cart->remove_cart_item( $key );
 				$removed_count_order++;
 				continue;

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -62,13 +62,13 @@ function wcs_date_input( $timestamp = 0, $args = array() ) {
  * @since 2.0
  */
 function wcs_get_edit_post_link( $post_id ) {
-	$post_type_object = get_post_type_object( get_post_type( $post_id ) );
+	$object = wc_get_order( $post_id ); // works for both WC Order and WC Subscription objects.
 
-	if ( ! $post_type_object || ! in_array( $post_type_object->name, array( 'shop_order', 'shop_subscription' ) ) ) {
+	if ( ! $object || ! in_array( $object->get_type(), array( 'shop_order', 'shop_subscription' ), true ) ) {
 		return;
 	}
 
-	return apply_filters( 'get_edit_post_link', admin_url( sprintf( $post_type_object->_edit_link . '&action=edit', $post_id ) ), $post_id, '' );
+	return apply_filters( 'get_edit_post_link', $object->get_edit_order_url(), $post_id, '' );
 }
 
 /**

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -440,7 +440,7 @@ function wcs_get_subscriptions( $args ) {
 	);
 
 	// if order_id is not a shop_order
-	if ( 0 !== $args['order_id'] && 'shop_order' !== get_post_type( $args['order_id'] ) ) {
+	if ( 0 !== $args['order_id'] && 'shop_order' !== WC_Data_Store::load( 'order' )->get_order_type( $args['order_id'] ) ) {
 		return array();
 	}
 


### PR DESCRIPTION
Fixes #153

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

In this PR we're updating any code in Subscriptions Core that uses `get_post_type( $order_id )` to get the `'shop_order'` order type.

With Custom Order Tables being worked on by the WC Core team ([public announcement](https://developer.woocommerce.com/2022/01/17/the-plan-for-the-woocommerce-custom-order-table/)), we need to begin updating our code to remove any areas of code which assume WC Orders are custom post types.

Updating `get_post_type( $order_id )` is fairly straight forward and any code that looks like:

```
if ( 'shop_order' === get_post_type( $post_id ) ) {
    return;
}
```

Will now look like this:

```
if ( 'shop_order' === WC_Data_Store::load( 'order' )->get_order_type( $order_id ) ) {
    return;
}
```

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR is touching a few areas of code so we'll need to test a few different scenarios:

### Subscriptions Manager Changes

The functions we've updated are hooked onto trashing/untrashing parent orders of a subscription.
To test this functionality:

1. Purchase a subscription product
2. Vist the Edit Order page for the parent order of the new subscription
3. Trash the parent order and confirm the subscription has been trashed
4. Untrash the parent order, confirm the subscription is not untrashed
5. Permanently delete the parent order, confirm the subscription is also deleted.


### Admin Meta Box changes

Confirm the related orders meta box appears on Edit Order pages that belong to a subscription

1. Visit the Edit Subscription page for any subscription
2. Use the related orders meta box to navigate to any related order
3. Confirm the related orders meta box appears on Edit Order pages

### Helper Function changes

Some helper functions needed changing in this PR. To test these I just used the WP Console plugin and the following snippets of code to test calling these functions returned the expected result.

 - `wcs_get_edit_post_link( $post_id );`

```
<?php
$subscription_id = 101851;
$order_id        = 101854;
echo wcs_get_edit_post_link( $subscription_id ) . "\n";
echo wcs_get_edit_post_link( $order_id ) . "\n"; 
```

- `wcs_get_subscriptions( $args );`

```
<?php
$order_id = 101854;
echo var_export( wcs_get_subscriptions( [ 'order_id' => $order_id ] ), true );
```

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes
