### PR TITLE
Changelog for 2.0.0.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,11 @@
 
 = 2.0.0 - 2022-xx-xx =
 * Dev - Retrieving users subscriptions order has been updated to use the WooCommerce specific APIs in WC_Subscriptions_Order.
-* Dev - Subscriptions meta is now retrieved and saved using WooCommerce specific APIs.
+* Dev - Deprecate the WC_Subscriptions_Order::get_meta() function. Use wcs_get_objects_property( $order, $meta_key, "single", $default ) instead.
+* Dev - Update the wcs_get_objects_property() function to prevent calls to get_post_meta() on objects that support calling the get_meta() function.
+* Dev - Remove the get_post_meta() call from WCS_Post_Meta_Cache_Manager::maybe_update_for_post_change().
+* Dev - Replace code using get_post_type( $order_id ) with WC Data Store get_order_type().
+* Dev - Replace all cases of update_post_meta() where an Order ID is passed to use WC_Order::update_meta_data() instead. 
 
 = 1.9.0 - 2022-04-27 =
 * Fix: Display subscription billing details in the Cart Block when purchasing products with subscription plans created using the All Products extension. PR#149

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.0.0 - 2022-xx-xx =
+* Dev - Retrieving users subscriptions order has been updated to use the WooCommerce specific APIs in WC_Subscriptions_Order. #161
+* Dev - Subscriptions meta is now retrieved and saved using WooCommerce specific APIs. #159 #162 #168
+
 = 1.9.0 - 2022-04-27 =
 * Fix: Display subscription billing details in the Cart Block when purchasing products with subscription plans created using the All Products extension. PR#149
 * Dev: Update phpunit to v9 to allow testing against newer php versions. PR#140

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 2.0.0 - 2022-xx-xx =
-* Dev - Retrieving users subscriptions order has been updated to use the WooCommerce specific APIs in WC_Subscriptions_Order. #161
-* Dev - Subscriptions meta is now retrieved and saved using WooCommerce specific APIs. #159 #162 #168
+* Dev - Retrieving users subscriptions order has been updated to use the WooCommerce specific APIs in WC_Subscriptions_Order.
+* Dev - Subscriptions meta is now retrieved and saved using WooCommerce specific APIs.
 
 = 1.9.0 - 2022-04-27 =
 * Fix: Display subscription billing details in the Cart Block when purchasing products with subscription plans created using the All Products extension. PR#149


### PR DESCRIPTION
Changelog for 2.0.0.

Note: per pdjTHR-11q-p2#comment-1222, we are no longer add PR references to changelog entries.