### PR TITLE
Division by zero error during renewals

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.1.0 - 2022-xx-xx =
+* Fix - Fatal Error caused in rare cases where quantity is zero during renewal.
+
 = 2.0.0 - 2022-05-20 =
 * Dev - Retrieving users subscriptions order has been updated to use the WooCommerce specific APIs in WC_Subscriptions_Order.
 * Dev - Deprecate the WC_Subscriptions_Order::get_meta() function. Use wcs_get_objects_property( $order, $meta_key, "single", $default ) instead.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -451,7 +451,10 @@ class WCS_Cart_Renewal {
 					}
 				}
 
-				$_product->set_price( $price / $item_to_renew['qty'] );
+				// In rare cases quantity can be zero. Check first to prevent triggering a fatal error in php8+
+				if ( 0 !== $item_to_renew['qty'] ) {
+					$_product->set_price( $price / $item_to_renew['qty'] );
+				}
 
 				// Don't carry over any sign up fee
 				wcs_set_objects_property( $_product, 'subscription_sign_up_fee', 0, 'set_prop_only' );


### PR DESCRIPTION
Fixes #175

## Description

In php8 Division by zero throws an exception whereas in previous versions only a warning is thrown. This has caused issues in rare cases where the quantity is zero during a renewal

## How to test this PR

I haven't been able to reproduce this issue so have been unable to test.

There are some reproduction steps in #175 but results may vary.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? 4359-gh-woocommerce/woocommerce-subscriptions
- [x] Will this PR affect WooCommerce Payments? Assuming yes – unconfirmed