### PR TITLE
Subscriptions search performance fix

### DIFF
--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -461,13 +461,25 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 
 		if ( ! empty( $search_fields ) ) {
 
+			$search_fields_results = array();
+
+			foreach ( $search_fields AS $search_field ) {
+				$search_fields_results = array_merge(
+					$search_fields_results,
+					$wpdb->get_col(
+						$wpdb->prepare( "
+							SELECT DISTINCT p1.post_id
+							FROM {$wpdb->postmeta} p1
+							WHERE p1.meta_value LIKE '%%%s%%' AND p1.meta_key = %s",
+							$wpdb->esc_like( wc_clean( $term ) ),
+							$search_field
+						)
+					)
+				);
+			}
+
 			$subscription_ids = array_unique( array_merge(
-				$wpdb->get_col(
-					$wpdb->prepare( "
-						SELECT DISTINCT p1.post_id
-						FROM {$wpdb->postmeta} p1
-						WHERE p1.meta_value LIKE '%%%s%%'", $wpdb->esc_like( wc_clean( $term ) ) ) . " AND p1.meta_key IN ('" . implode( "','", array_map( 'esc_sql', $search_fields ) ) . "')"
-				),
+				$search_fields_results,
 				$wpdb->get_col(
 					$wpdb->prepare( "
 						SELECT order_id


### PR DESCRIPTION
## Description

The Subscriptions search in wp-admin -> WooCommerce -> Subscriptions is very slow. It takes as much as 30 seconds on our client website.

We find that this query in WCS_Subscription_Data_Store_CPT::search_subscriptions() is way too slow:

```
SELECT DISTINCT p1.post_id
FROM wp_postmeta p1
WHERE p1.meta_value LIKE '%phrase%' AND p1.meta_key IN ('_order_key','_billing_address_index','_shipping_address_index','_billing_email')
```

Looking as the SQL EXPLAIN I can see that on our client website it has to check 4,000,000 fields.When I split that query into 4 individual queries - one for each meta_key, then it's much faster. The above takes 17 to 20 seconds.

We found the The individual queries only take about 4 seconds when I sum the times for each:

```
SELECT SQL_NO_CACHE DISTINCT p1.post_id
FROM wp_postmeta p1
WHERE p1.meta_value LIKE '%phrase%' AND p1.meta_key IN ('_order_key');
```
```
SELECT SQL_NO_CACHE DISTINCT p1.post_id
FROM wp_postmeta p1
WHERE p1.meta_value LIKE '%phrase%' AND p1.meta_key IN ('_billing_address_index');
```
```
SELECT SQL_NO_CACHE DISTINCT p1.post_id
FROM wp_postmeta p1
WHERE p1.meta_value LIKE '%phrase%' AND p1.meta_key IN ('_shipping_address_index');
```
```
SELECT SQL_NO_CACHE DISTINCT p1.post_id
FROM wp_postmeta p1
WHERE p1.meta_value LIKE '%phrase%' AND p1.meta_key IN ('_billing_email');
```

Here's what the Query Monitor plugin reports without the fix:

- total time of 28 seconds
- 5 slow queries, the slowest taking 25
- 
![woocommerce-subscriptions-slow](https://user-images.githubusercontent.com/1180948/173034009-b6e76213-65cd-4777-88b1-9efdb01f797b.png)
 seconds

And here's with the fix:

- total time of 4.1 seconds
- 8 slow queries, but all the 4 individual search queries are still much faster than the single query from before

![woocommerce-subscriptions-fast](https://user-images.githubusercontent.com/1180948/173034022-1f5c3cab-8eab-480e-89a1-074fc32b969f.png)

## How to test this PR

1. Make sure you have a lot of Subscriptions in your database. In our case it's 30,000.
2. Go to wp-admin -> WooCommerce -> Subscriptions
3. Enter some search phrase and click "Search Subscriptions"
4. If you have about 30,000 subscriptions you will wait for 20 - 30 seconds to get the results

## Product impact

- [ ] Added changelog entry (or does not apply)
- [yes] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [no] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
