### PR TITLE
Update shipping and billing address on parent subscription order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.2.0 - 2022-xx-xx =
+* Fix - Update subscription address when changed with renewals on block checkout.
+
 = 2.1.0 - 2022-06-06 =
 * Fix - Fatal Error caused in rare cases where quantity is zero during renewal.
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1190,8 +1190,7 @@ class WCS_Cart_Renewal {
 		$cart_renewal_item = $this->cart_contains();
 
 		if ( false !== $cart_renewal_item ) {
-			$subscription    = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
-
+			$subscription = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
 
 			// Billing address is a required field.
 			foreach ( $request['billing_address'] as $key => $value ) {
@@ -1199,8 +1198,6 @@ class WCS_Cart_Renewal {
 					$customer->{"set_billing_$key"}( $value );
 				}
 			}
-			error_log(print_r($request['billing_address'], true));
-			error_log(print_r($request['shipping_address'], true));
 			// Billing address is a required field.
 			$subscription->set_address( $request['billing_address'], 'billing' );
 			// If shipping address (optional field) was not provided, set it to the given billing address (required field).

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -104,6 +104,8 @@ class WCS_Cart_Renewal {
 
 			// Update customer's address on the subscription if it is changed during renewal
 			add_filter( 'woocommerce_checkout_update_user_meta', array( &$this, 'maybe_update_subscription_address_data' ), 10, 2 );
+			add_filter( 'woocommerce_store_api_checkout_update_customer_from_request', array( &$this, 'maybe_update_subscription_address_data_from_store_api' ), 10, 2 );
+
 		}
 	}
 
@@ -1159,7 +1161,6 @@ class WCS_Cart_Renewal {
 		if ( false !== $cart_renewal_item ) {
 			$subscription    = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
 			$billing_address = $shipping_address = array();
-
 			foreach ( array( 'billing', 'shipping' ) as $address_type ) {
 				$checkout_fields = WC()->checkout()->get_checkout_fields( $address_type );
 
@@ -1172,9 +1173,38 @@ class WCS_Cart_Renewal {
 					}
 				}
 			}
-
 			$subscription->set_address( $billing_address, 'billing' );
 			$subscription->set_address( $shipping_address, 'shipping' );
+		}
+	}
+
+	/**
+	 * When completing checkout for a subscription renewal, update the subscription's address to match
+	 * the shipping/billing address entered on checkout.
+	 *
+	 * @param \WC_Customer $customer
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @since 4.1.1
+	 */
+	public function maybe_update_subscription_address_data_from_store_api( $customer, $request ) {
+		$cart_renewal_item = $this->cart_contains();
+
+		if ( false !== $cart_renewal_item ) {
+			$subscription    = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
+
+
+			// Billing address is a required field.
+			foreach ( $request['billing_address'] as $key => $value ) {
+				if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
+					$customer->{"set_billing_$key"}( $value );
+				}
+			}
+			error_log(print_r($request['billing_address'], true));
+			error_log(print_r($request['shipping_address'], true));
+			// Billing address is a required field.
+			$subscription->set_address( $request['billing_address'], 'billing' );
+			// If shipping address (optional field) was not provided, set it to the given billing address (required field).
+			$subscription->set_address( $request['shipping_address'] ?? $request['billing_address'], 'shipping' );
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/5457
Related to https://github.com/woocommerce/woocommerce-subscriptions/pull/4384
Related to https://github.com/woocommerce/woocommerce-blocks/pull/6792

## Description
This PR allows subscription core to copy shipping and billing address to the main subscription order if it was changed on renewals.

I decided to add a new function because the shape of data coming from both actions is different.

I also removed some deprecated actions calls because they're outside the support window by a huge gap.

## How to test this PR

Testing steps are a bit convoluted because you need to jump between 3 repos.
- Clone this PR from WooCommerce Subscriptions https://github.com/woocommerce/woocommerce-subscriptions/pull/4384
- Run `npm install` `composer install` `npm run build`
- Clone this PR
- Symlink the subs core repository to the vendor/woocommerce folder of WooCommerce subscriptions `ln -s ~/path-to-subscription-core-local-clone ~/path-to-subscription/vendor/woocommerce/subscriptions-core`
- Use this ZIP from WooCommerce Blocks PR https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-6792.zip
- On Checkout page, change it from Checkout shortcode to Checkout block.
- Create a subscription product.
- Add item to your cart, checkout using Checkout block.
- Go to WooCommerce -> Subscriptions -> new created subscription.
- Mind the address there, on the right, Subscriptions actions -> create pending renewal order.
- On My Account -> Orders you will see the new order, click Pay.
- On Checkout page, change your name or address, mind the new address.
- Place the order.
- Visit the Subscription page again, the address should have updated.

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
