### PR TITLE
When COT is enabled, allow using wc_get_order() with a Subscription ID to get a subscription object

### DIFF
--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -201,6 +201,11 @@ class WC_Subscriptions_Core_Plugin {
 		if ( class_exists( 'WC_Abstract_Privacy' ) ) {
 			new WCS_Privacy();
 		}
+
+		// Load Subscriptions COT compatibility class for stores that have COT enabled.
+		if ( method_exists( 'Automattic\WooCommerce\Utilities\OrderUtil', 'custom_orders_table_usage_is_enabled' ) && Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			WC_Subscriptions_COT_Compatibility::init();
+		}
 	}
 
 	/**

--- a/includes/class-wcs-core-autoloader.php
+++ b/includes/class-wcs-core-autoloader.php
@@ -247,6 +247,8 @@ class WCS_Core_Autoloader {
 			$path .= '/privacy';
 		} elseif ( false !== strpos( $class, 'upgrade' ) || false !== strpos( $class, 'repair' ) ) {
 			$path .= '/upgrades';
+		} elseif ( false !== strpos( $class, 'compatibility' ) ) {
+			$path .= '/compatibility';
 		}
 
 		return trailingslashit( $path );

--- a/includes/compatibility/class-wc-subscriptions-cot-compatibility.php
+++ b/includes/compatibility/class-wc-subscriptions-cot-compatibility.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WC Subscriptions Custom Order Tables Compatibility Class
+ *
+ * @since 2.3
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+class WC_Subscriptions_COT_Compatibility {
+
+	/**
+	 * Initialise subscription COT compat hooks.
+	 *
+	 * @since 2.3
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_order_class', [ __CLASS__, 'get_subscription_classname_with_cot' ], 10, 3 );
+	}
+
+	/**
+	 * When custom order tables is enabled, the Order_Factory::get_order_class_name_by_id()
+	 * is unable to get the WC Subscriptions classname because the $order_type param is empty due to
+	 * the OrderTableDataStore data store being loaded.
+	 *
+	 * While WC Subscriptions remain a custom order type that is found in the Posts table, this
+	 * function will serve as a compatibility layer to allow using order functions to get a
+	 * subscription object like wc_get_order( $sub_id ) and WC()->order_factory->get_order( $sub_id ).
+	 *
+	 * @since 2.3
+	 *
+	 * @param string $classname
+	 * @param string $order_type
+	 * @param int    $order_id
+	 *
+	 * @return string
+	 */
+	public static function get_subscription_classname_with_cot( $classname, $order_type, $order_id ) {
+		// if classname and order type wasn't found (due to the COT data store loaded), manually check if it's a subscription
+		if ( empty( $classname ) && empty( $order_type ) ) {
+			$order_type      = WC_Data_Store::load( 'subscription' )->get_order_type( $order_id );
+			$order_type_data = wc_get_order_type( $order_type );
+
+			if ( 'shop_subscription' === $order_type && $order_type_data ) {
+				$classname = $order_type_data['class_name'];
+			}
+		}
+
+		return $classname;
+	}
+}

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -225,7 +225,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * @return string
 	 * @since 2.2.0
 	 */
-	public function get_total_refunded( $subscription ) : float {
+	public function get_total_refunded( $subscription ) {
 
 		$total = 0;
 

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -225,7 +225,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * @return string
 	 * @since 2.2.0
 	 */
-	public function get_total_refunded( $subscription ) {
+	public function get_total_refunded( $subscription ) : float {
 
 		$total = 0;
 


### PR DESCRIPTION
Fixes #187

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

When a store has Custom Order tables enabled (coming in WC 6.9), trying to purchase a subscription on the checkout results in the following fatal error:

```
2022-08-02T05:40:06+00:00 CRITICAL Uncaught Error: Call to a member function get_items() on bool in /srv/users/usereaea7e7b/apps/usereaea7e7b/public/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/class-wc-subscriptions-synchroniser.php:1148
```

This error is caused by our `wcs_get_subscription()` using the `WC()->order_factory->get_order( $subscription_id )` which no longer works to fetch a Subscription object. This is because Subscription object are staying in the wp posts table and when COT is enabled, the new order data store is loaded and so calling `WC_Data_Store::load( 'order' )->get_order_type( $subscription_id )` returns an empty string as the 'shop_subscription' order type is unknown in this new context.

Using `wc_get_order()` with a subscription ID is not only used within our own codebase but is used widely by other plugins (like WC Payments for one) and so this PR aims to provide a workaround for this problem.

As per this internal slack discussion (p1659414499655349-slack-C9QDV4TL4), it was suggested to refactor our `wcs_get_subscriptions()` and remove the Order Factory usage, however, after doing that there was other issues outside of Subscriptions Core where `wc_get_orders()` was being called with a subscription ID and returning `false`. See #187 which was an issue in WC Payments.

---

With this PR, the issue in #186 is also fixed but since it was suggested we remove Order Factory code from `wcs_get_subscription()`, I'm going to leave that issue open for us to still get to.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout the latest WooCommerce `cot-branch` and build it
2. Enable the COT feature by using the following custom code:
```
function enable_cot(){
   $order_controller = wc_get_container()
       ->get('Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController');
   if( isset( $order_controller ) ) {
       $order_controller->show_feature();
   }
}
add_action( 'init', 'enable_cot', 99 );
```
4. Go into **WooCommerce > Status > Tools** and run the Create Order Tables tool
5. Go into **WooCommerce > Settings > Advanced > Custom Data Stores**
6. Make sure "Use the WooCommerce orders tables" is enabled
   1. You will need to sync order data to custom tables to enabled this the first time by checking  "Keep the posts table and the orders tables synchronized"
7. Try to purchase a subscription on the checkout with WC Payments

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
