### PR TITLE
Move shipping meta fields

### DIFF
--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -392,7 +392,7 @@ class WC_Subscriptions_Admin {
 
 		$needs_html_fix = 'woocommerce_product_options_shipping' === current_filter();
 
-		 // Old hook is nested and requires invalid html markup to be compatible with other plugins.
+		// Old hook is nested and requires invalid html markup to be compatible with other plugins.
 		if ( $needs_html_fix ) {
 			echo '</div>';
 		}

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -71,7 +71,11 @@ class WC_Subscriptions_Admin {
 		add_action( 'woocommerce_page_wc-status', __CLASS__ . '::clear_subscriptions_transients' );
 
 		// Add subscription shipping options on edit product page
-		add_action( 'woocommerce_product_options_shipping', __CLASS__ . '::subscription_shipping_fields' );
+		if ( wcs_is_woocommerce_pre( '6.0' ) ) {
+			add_action( 'woocommerce_product_options_shipping', __CLASS__ . '::subscription_shipping_fields' );
+		} else {
+			add_action( 'woocommerce_product_options_shipping_product_data', __CLASS__ . '::subscription_shipping_fields' );
+		}
 
 		// And also on the variations section
 		add_action( 'woocommerce_product_after_variable_attributes', __CLASS__ . '::variable_subscription_pricing_fields', 10, 3 );
@@ -386,7 +390,13 @@ class WC_Subscriptions_Admin {
 	public static function subscription_shipping_fields() {
 		global $post;
 
-		echo '</div>';
+		$needs_html_fix = 'woocommerce_product_options_shipping' === current_filter();
+
+		 // Old hook is nested and requires invalid html markup to be compatible with other plugins.
+		if ( $needs_html_fix ) {
+			echo '</div>';
+		}
+
 		echo '<div class="options_group subscription_one_time_shipping show_if_subscription show_if_variable-subscription hidden">';
 
 		// Only one Subscription per customer
@@ -398,6 +408,10 @@ class WC_Subscriptions_Admin {
 		) );
 
 		do_action( 'woocommerce_subscriptions_product_options_shipping' );
+
+		if ( ! $needs_html_fix ) {
+			echo '</div>';
+		}
 
 	}
 


### PR DESCRIPTION
Move fields admin shipping fields to `woocommerce_product_options_shipping_product_data` hook. 

Fixes #203

## Description

As of 6.0, Woo has the `woocommerce_product_options_shipping_product_data` which is outside of an option_group div. Attaching there, with properly closed markup, makes it predictable for other plugins to also attach there with proper markup and nobodies fields get accidentally swallowed up in an unclosed div.

## How to test this PR

My memory is a bit dodgy, but I think prior to the PR you could add something like this:

```
function kia_test_subs_shipping() {
    echo '<div>please send tacos</div>';
}
add_action( 'woocommerce_product_options_shipping', 'kia_test_subs_shipping' );
```

and it would be sucked up into the Subs shipping div and therefore displayed according to subs' hide/show script rules. 

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
