### PR TITLE
Fix for rare cases when division by zero error happens during renewal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.3.0 - 2022-xx-xx =
+* Fix - Fatal Error caused in rare cases where quantity is zero during renewal.
+
 = 2.2.0 - 2022-08-03 =
 * Fix - Update subscription address when changed with renewals on block checkout.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 2.3.0 - 2022-xx-xx =
+= 2.2.1 - 2022-xx-xx =
 * Fix - Fatal Error caused in rare cases where quantity is zero during renewal.
 
 = 2.2.0 - 2022-08-03 =

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -454,7 +454,7 @@ class WCS_Cart_Renewal {
 				}
 
 				// In rare cases quantity can be zero. Check first to prevent triggering a fatal error in php8+
-				if ( 0 !== $item_to_renew['qty'] ) {
+				if ( 0 !== (int) $item_to_renew['qty'] ) {
 					$_product->set_price( $price / $item_to_renew['qty'] );
 				}
 


### PR DESCRIPTION
Fixes #197 

## Description

A DivisionByZero exception was thrown in rare cases during renewals. We were unable to replicate the circumstances that triggered the bug. #177 was raised to fix this bug.

As replication wasn't possible I tested around the affected code and confirmed that `$item_to_renew['qty']` was always an `int`. New bug reports (#197) show that this is not always the case.  This is likely the cause of the error, a missing or invalid quantity.

The solution to prevent these fatal errors is to ensure the variable is cast to an `int`
```diff
-if ( 0 !== $item_to_renew['qty'] ) {
+if ( 0 !== (int) $item_to_renew['qty'] ) {
```
 
## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Does this issue affect WooCommerce Subscriptions? Yes, 4359-gh-woocommerce/woocommerce-subscriptions
- [x] Does this issue affect WooCommerce Payments? **Assuming yes – unconfirmed**
