### PR TITLE
Add order note when subscription address is changed.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 2.3.0 - 2022-xx-xx =
+* Add - Add a subscription/order note when the Subscription address has been changed.
 * Fix - Move One Time Shipping metabox fields to use the woocommerce_product_options_shipping_product_data hook introduced in WC 6.0.
 
 = 2.2.1 - 2022-08-25 =

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -165,6 +165,7 @@ class WC_Subscriptions_Addresses {
 			foreach ( $users_subscriptions as $subscription ) {
 				if ( $subscription->has_status( array( 'active', 'on-hold' ) ) ) {
 					$subscription->set_address( $address, $address_type );
+					$subscription->add_order_note( __( 'Subscription address has been changed. You may need to recalculate taxes and/or shipping.', 'woocommerce-subscriptions' ) );
 				}
 			}
 		} elseif ( isset( $_POST['update_subscription_address'] ) ) {
@@ -174,7 +175,7 @@ class WC_Subscriptions_Addresses {
 			if ( $subscription && self::can_user_edit_subscription_address( $subscription->get_id() ) ) {
 				// Update the address only if the user actually owns the subscription
 				$subscription->set_address( $address, $address_type );
-
+				$subscription->add_order_note( __( 'Subscription address has been changed. You may need to recalculate taxes and/or shipping.', 'woocommerce-subscriptions' ) );
 				wp_safe_redirect( $subscription->get_view_order_url() );
 				exit();
 			}


### PR DESCRIPTION
Addresses 3747-gh-woocommerce/woocommerce-subscriptions

## Description
When a customer updates their address from the My Account->My Subscriptions page, add an order note such that the store owner can be made aware of the change. Currently, an address change made by a customer is silent; the store owner may not notice and taxes and/or shipping could be incorrectly charged on subsequent renewals. This PR creates a note and prompts the store owner that a recalculation of the subscription may be necessary.

Questions for PR author:
- How can this code break?
This code relies on `$subscription` being an instance of `WC_Subscription` in order to call `add_order_note()`. It's possible to try to get a WC_Subscription object and instead get a `false` return value but the code already in place above this new code should handle that( it checks if it has a valid status or if `$subscription` is truthy). So we shouldn't accidentally cause a fatal by trying to call an undefined method.

## How to test this PR

1. Create a Simple Subscription product and purchase it to activate the subscription.
2. Go to My Account->My Subscriptions->Change Address, enter a new address, save.
3. Go to WP Admin->Subscriptions, click on the subscription, and note that the Subscription notes area on the right has a note that says:
> Subscription address has been changed. You may need to recalculate taxes and/or shipping.

![Screen Shot 2022-09-15 at 15 31 01](https://user-images.githubusercontent.com/6723003/190491074-1a40ae02-6362-402b-8625-d17c05a9e39b.png)

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? unsure