### PR TITLE
Update wcs_copy_order_address() to use modern APIs for setting address fields

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update - The subscription creation function `wcs_create_subscription` has been updated to use WooCommerce CRUD methods in preparation for supporting High Performance Order Storage (HPOS).
 * Breaking - woocommerce_new_subscription_data hook will only work with CPT datastore and so has been deprecated.
 * Breaking - i18n usage of strftime has been deprecated for subscription titles. Date is now formatted using woocommerce standard date formatting.
+* Update - Improve wcs_copy_order_address() to use modern APIs for setting address fields.
 
 = 2.3.0 - 2022-10-07 =
 * Fix - Move One Time Shipping metabox fields to use the woocommerce_product_options_shipping_product_data hook introduced in WC 6.0.

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -95,7 +95,7 @@ function wcs_get_subscriptions_for_order( $order, $args = array() ) {
  */
 function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' ) {
 
-	if ( in_array( $address_type, array( 'shipping', 'all' ), true ) ) {
+	if ( $address_type === 'all' || $address_type === 'shipping' ) {
 		$to_order->set_shipping_address(
 			array(
 				'first_name' => $from_order->get_shipping_first_name( 'edit' ),
@@ -111,7 +111,7 @@ function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' )
 		);
 	}
 
-	if ( in_array( $address_type, array( 'billing', 'all' ), true ) ) {
+	if ( $address_type === 'all' || $address_type === 'billing' ) {
 		$to_order->set_billing_address(
 			array(
 				'first_name' => $from_order->get_billing_first_name( 'edit' ),

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -83,45 +83,50 @@ function wcs_get_subscriptions_for_order( $order, $args = array() ) {
 }
 
 /**
- * Copy the billing, shipping or all addresses from one order to another (including custom order types, like the
- * WC_Subscription order type).
+ * Copy the billing, shipping or all addresses from one order or subscription to another.
  *
- * @param WC_Order $to_order The WC_Order object to copy the address to.
- * @param WC_Order $from_order The WC_Order object to copy the address from.
- * @param string $address_type The address type to copy, can be 'shipping', 'billing' or 'all'
+ * @since 2.0.0
+ *
+ * @param WC_Order $to_order     The WC_Order object to copy the address to.
+ * @param WC_Order $from_order   The WC_Order object to copy the address from.
+ * @param string   $address_type The address type to copy, can be 'shipping', 'billing' or 'all'. Optional. Default is "all".
+ *
  * @return WC_Order The WC_Order object with the new address set.
- * @since  2.0
  */
 function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' ) {
 
-	if ( in_array( $address_type, array( 'shipping', 'all' ) ) ) {
-		$to_order->set_address( array(
-			'first_name' => wcs_get_objects_property( $from_order, 'shipping_first_name' ),
-			'last_name'  => wcs_get_objects_property( $from_order, 'shipping_last_name' ),
-			'company'    => wcs_get_objects_property( $from_order, 'shipping_company' ),
-			'address_1'  => wcs_get_objects_property( $from_order, 'shipping_address_1' ),
-			'address_2'  => wcs_get_objects_property( $from_order, 'shipping_address_2' ),
-			'city'       => wcs_get_objects_property( $from_order, 'shipping_city' ),
-			'state'      => wcs_get_objects_property( $from_order, 'shipping_state' ),
-			'postcode'   => wcs_get_objects_property( $from_order, 'shipping_postcode' ),
-			'country'    => wcs_get_objects_property( $from_order, 'shipping_country' ),
-		), 'shipping' );
+	if ( in_array( $address_type, array( 'shipping', 'all' ), true ) ) {
+		$to_order->set_shipping_address(
+			array(
+				'first_name' => $from_order->get_shipping_first_name( 'edit' ),
+				'last_name'  => $from_order->get_shipping_last_name( 'edit' ),
+				'company'    => $from_order->get_shipping_company( 'edit' ),
+				'address_1'  => $from_order->get_shipping_address_1( 'edit' ),
+				'address_2'  => $from_order->get_shipping_address_2( 'edit' ),
+				'city'       => $from_order->get_shipping_city( 'edit' ),
+				'state'      => $from_order->get_shipping_state( 'edit' ),
+				'postcode'   => $from_order->get_shipping_postcode( 'edit' ),
+				'country'    => $from_order->get_shipping_country( 'edit' ),
+			)
+		);
 	}
 
-	if ( in_array( $address_type, array( 'billing', 'all' ) ) ) {
-		$to_order->set_address( array(
-			'first_name' => wcs_get_objects_property( $from_order, 'billing_first_name' ),
-			'last_name'  => wcs_get_objects_property( $from_order, 'billing_last_name' ),
-			'company'    => wcs_get_objects_property( $from_order, 'billing_company' ),
-			'address_1'  => wcs_get_objects_property( $from_order, 'billing_address_1' ),
-			'address_2'  => wcs_get_objects_property( $from_order, 'billing_address_2' ),
-			'city'       => wcs_get_objects_property( $from_order, 'billing_city' ),
-			'state'      => wcs_get_objects_property( $from_order, 'billing_state' ),
-			'postcode'   => wcs_get_objects_property( $from_order, 'billing_postcode' ),
-			'country'    => wcs_get_objects_property( $from_order, 'billing_country' ),
-			'email'      => wcs_get_objects_property( $from_order, 'billing_email' ),
-			'phone'      => wcs_get_objects_property( $from_order, 'billing_phone' ),
-		), 'billing' );
+	if ( in_array( $address_type, array( 'billing', 'all' ), true ) ) {
+		$to_order->set_billing_address(
+			array(
+				'first_name' => $from_order->get_billing_first_name( 'edit' ),
+				'last_name'  => $from_order->get_billing_last_name( 'edit' ),
+				'company'    => $from_order->get_billing_company( 'edit' ),
+				'address_1'  => $from_order->get_billing_address_1( 'edit' ),
+				'address_2'  => $from_order->get_billing_address_2( 'edit' ),
+				'city'       => $from_order->get_billing_city( 'edit' ),
+				'state'      => $from_order->get_billing_state( 'edit' ),
+				'postcode'   => $from_order->get_billing_postcode( 'edit' ),
+				'country'    => $from_order->get_billing_country( 'edit' ),
+				'email'      => $from_order->get_billing_email( 'edit' ),
+				'phone'      => $from_order->get_billing_phone( 'edit' ),
+			)
+		);
 	}
 
 	return apply_filters( 'woocommerce_subscriptions_copy_order_address', $to_order, $from_order, $address_type );

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -95,7 +95,7 @@ function wcs_get_subscriptions_for_order( $order, $args = array() ) {
  */
 function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' ) {
 
-	if ( $address_type === 'all' || $address_type === 'shipping' ) {
+	if ( 'all' === $address_type || 'shipping' === $address_type ) {
 		$to_order->set_shipping_address(
 			array(
 				'first_name' => $from_order->get_shipping_first_name( 'edit' ),
@@ -111,7 +111,7 @@ function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' )
 		);
 	}
 
-	if ( $address_type === 'all' || $address_type === 'billing' ) {
+	if ( 'all' === $address_type || 'billing' === $address_type ) {
 		$to_order->set_billing_address(
 			array(
 				'first_name' => $from_order->get_billing_first_name( 'edit' ),


### PR DESCRIPTION
Fixes #227 

## Description

While testing https://github.com/Automattic/woocommerce-subscriptions-core/pull/226 I discovered that the billing and presumably the shipping address indexes weren't being saved correctly on checkout.

This issue happens because of the [wcs_copy_order_address()](https://github.com/automattic/woocommerce-subscriptions-core/blob/refactor-create-subscription/includes/wcs-order-functions.php#L95) function which uses a legacy function (`set_address()`) to copy the address data. 

That function sets the address data directly into post meta. Because of that, when the subscription is eventually saved, the address field updates aren't updated [here](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php#L301-L318) (since there is nothing changed) which causes the indexes to not be updated.

This PR replaces the `set_address()` functions with the respective `set_shipping_address()` and `set_billing_address()`. 

## How to test this PR

1. Purchase a subscription on the refactor-create-subscription branch.
   - no HPOS setup is required. Just using the wp post architecture is fine.
1. In the database look at the subscription and notice the billing address index is incomplete.
     - On `trunk` the billing index will be incomplete (only include the email). 
     - On this branch the index field will be complete.

<img width="539" alt="Screen Shot 2022-10-25 at 3 45 42 pm" src="https://user-images.githubusercontent.com/8490476/197692559-966d3161-1f00-445f-ac0a-a6cdc74819bc.png">

^ `trunk` 👎 


<img width="755" alt="Screen Shot 2022-10-25 at 3 45 01 pm" src="https://user-images.githubusercontent.com/8490476/197692453-c72e06c4-6ab0-4d68-a8aa-45b9189a7182.png">

^ this branch. 👍 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
