### PR TITLE
Fix get_items() on null error in Synchroniser when purchasing subscription with HPOS & Syncing to CPT enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 2.5.0 - 2022-xx-xx =
-* Fix - When saving sync meta data on a new subscription don't use the 'save_post' action hook - use 'woocommerce_new_subscription' instead. This prevents errors when purchasing a subscription on stores that have HPOS enabled.
+* Fix - When saving sync meta data on a new subscription, use 'woocommerce_new_subscription' instead of 'save_post'. This is to prevent errors when purchasing a subscription on stores that have HPOS enabled.
 * Update - Improve maybe_add_subscription_meta() and subscription_contains_synced_product() inside our WC_Subscriptions_Synchroniser class to use CRUD methods. 
 
 = 2.4.1 - 2022-11-02 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.5.0 - 2022-xx-xx =
+* Fix - When saving sync meta data on a new subscription don't use the 'save_post' action hook - use 'woocommerce_new_subscription' instead. This prevents errors when purchasing a subscription on stores that have HPOS enabled.
+* Update - Improve maybe_add_subscription_meta() and subscription_contains_synced_product() inside our WC_Subscriptions_Synchroniser class to use CRUD methods. 
+
 = 2.4.1 - 2022-11-02 =
 * Fix - Undefined method WC_Order::set_shipping_address() on stores running pre-7.1 of WooCommerce which prevented subscriptions from being purchased.
 

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -1156,6 +1156,7 @@ class WC_Subscriptions_Synchroniser {
 
 				if ( self::is_product_synced( $product ) ) {
 					$subscription->update_meta_data( '_contains_synced_subscription', 'true' );
+					$subscription->save();
 					break;
 				}
 			}

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -93,7 +93,7 @@ class WC_Subscriptions_Synchroniser {
 		add_filter( 'woocommerce_subscriptions_cart_get_price', __CLASS__ . '::set_prorated_price_for_calculation', 10, 2 );
 
 		// When creating a subscription check if it contains a synced product and make sure the correct meta is set on the subscription
-		add_action( 'woocommerce_after_subscription_object_save', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
+		add_action( 'woocommerce_new_subscription', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
 
 		// When adding an item to a subscription, check if it is for a synced product to make sure the sync meta is set on the subscription. We can't attach to just the 'woocommerce_new_order_item' here because the '_product_id' and '_variation_id' meta are not set before it fires
 		add_action( 'woocommerce_ajax_add_order_item_meta', __CLASS__ . '::ajax_maybe_add_meta_for_item', 10, 2 );

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -1202,13 +1202,12 @@ class WC_Subscriptions_Synchroniser {
 	 * @return bool
 	 * @since 2.0
 	 */
-	public static function subscription_contains_synced_product( $subscription_id ) {
-
-		if ( is_object( $subscription_id ) ) {
-			$subscription_id = $subscription_id->get_id();
+	public static function subscription_contains_synced_product( $subscription ) {
+		if ( ! is_object( $subscription ) ) {
+			$subscription = wcs_get_subscription( $subscription );
 		}
 
-		return 'true' == get_post_meta( $subscription_id, '_contains_synced_subscription', true );
+		return is_a( $subscription, 'WC_Subscription' ) && 'true' === $subscription->get_meta( '_contains_synced_subscription' );
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -1133,13 +1133,11 @@ class WC_Subscriptions_Synchroniser {
 	}
 
 	/**
-	 * Add subscription meta for subscription that contains a synced product.
+	 * Adds meta on a subscription that contains a synced product.
 	 *
 	 * @since 2.0
 	 *
 	 * @param WC_Subscription|int Subscription object or ID.
-	 *
-	 * @return void
 	 */
 	public static function maybe_add_subscription_meta( $subscription ) {
 		if ( ! is_object( $subscription ) ) {
@@ -1192,11 +1190,12 @@ class WC_Subscriptions_Synchroniser {
 	}
 
 	/**
-	 * Check if a given subscription is synced to a certain day.
+	 * Checks if a given subscription is synced to a certain day.
 	 *
-	 * @param int|WC_Subscription Accepts either a subscription object of post id
-	 * @return bool
 	 * @since 2.0
+	 *
+	 * @param int|WC_Subscription Accepts either a subscription object or ID.
+	 * @return bool True if the subscription is synced, false otherwise.
 	 */
 	public static function subscription_contains_synced_product( $subscription ) {
 		if ( ! is_object( $subscription ) ) {

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -1139,9 +1139,11 @@ class WC_Subscriptions_Synchroniser {
 	/**
 	 * Add subscription meta for subscription that contains a synced product.
 	 *
-	 * @param WC_Order Parent order for the subscription
-	 * @param WC_Subscription new subscription
 	 * @since 2.0
+	 *
+	 * @param WC_Subscription|int Subscription object or ID.
+	 *
+	 * @return void
 	 */
 	public static function maybe_add_subscription_meta( $subscription ) {
 		if ( ! is_object( $subscription ) ) {

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -93,11 +93,7 @@ class WC_Subscriptions_Synchroniser {
 		add_filter( 'woocommerce_subscriptions_cart_get_price', __CLASS__ . '::set_prorated_price_for_calculation', 10, 2 );
 
 		// When creating a subscription check if it contains a synced product and make sure the correct meta is set on the subscription
-		if ( wcs_is_custom_order_tables_usage_enabled() ) {
-			add_action( 'woocommerce_after_subscription_object_save', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
-		} else {
-			add_action( 'save_post', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
-		}
+		add_action( 'woocommerce_after_subscription_object_save', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
 
 		// When adding an item to a subscription, check if it is for a synced product to make sure the sync meta is set on the subscription. We can't attach to just the 'woocommerce_new_order_item' here because the '_product_id' and '_variation_id' meta are not set before it fires
 		add_action( 'woocommerce_ajax_add_order_item_meta', __CLASS__ . '::ajax_maybe_add_meta_for_item', 10, 2 );
@@ -1150,7 +1146,7 @@ class WC_Subscriptions_Synchroniser {
 			$subscription = wcs_get_subscription( $subscription );
 		}
 
-		if ( $subscription && ! self::subscription_contains_synced_product( $subscription->get_id() ) ) {
+		if ( $subscription && ! self::subscription_contains_synced_product( $subscription ) ) {
 			foreach ( $subscription->get_items() as $item ) {
 				$product = $item->get_product();
 

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -93,7 +93,11 @@ class WC_Subscriptions_Synchroniser {
 		add_filter( 'woocommerce_subscriptions_cart_get_price', __CLASS__ . '::set_prorated_price_for_calculation', 10, 2 );
 
 		// When creating a subscription check if it contains a synced product and make sure the correct meta is set on the subscription
-		add_action( 'save_post', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			add_action( 'woocommerce_after_subscription_object_save', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
+		} else {
+			add_action( 'save_post', __CLASS__ . '::maybe_add_subscription_meta', 10, 1 );
+		}
 
 		// When adding an item to a subscription, check if it is for a synced product to make sure the sync meta is set on the subscription. We can't attach to just the 'woocommerce_new_order_item' here because the '_product_id' and '_variation_id' meta are not set before it fires
 		add_action( 'woocommerce_ajax_add_order_item_meta', __CLASS__ . '::ajax_maybe_add_meta_for_item', 10, 2 );
@@ -1139,17 +1143,17 @@ class WC_Subscriptions_Synchroniser {
 	 * @param WC_Subscription new subscription
 	 * @since 2.0
 	 */
-	public static function maybe_add_subscription_meta( $post_id ) {
+	public static function maybe_add_subscription_meta( $subscription ) {
+		if ( ! is_object( $subscription ) ) {
+			$subscription = wcs_get_subscription( $subscription );
+		}
 
-		if ( 'shop_subscription' == get_post_type( $post_id ) && ! self::subscription_contains_synced_product( $post_id ) ) {
-
-			$subscription = wcs_get_subscription( $post_id );
-
+		if ( $subscription && ! self::subscription_contains_synced_product( $subscription->get_id() ) ) {
 			foreach ( $subscription->get_items() as $item ) {
 				$product = $item->get_product();
 
 				if ( self::is_product_synced( $product ) ) {
-					update_post_meta( $subscription->get_id(), '_contains_synced_subscription', 'true' );
+					$subscription->update_meta_data( '_contains_synced_subscription', 'true' );
 					break;
 				}
 			}


### PR DESCRIPTION
Part of #223 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR fixes an issue when customers try to purchase a subscription with HPOS enabled and HPOS syncing turned on.

```
[11-Oct-2022 03:33:01 UTC] PHP Fatal error:  Uncaught Error: Call to a member function get_items() on bool in /Users/matt/local/hpos/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscriptions-synchroniser.php:1148
Stack trace:
#0 /Users/matt/local/hpos/wp-includes/class-wp-hook.php(309): WC_Subscriptions_Synchroniser::maybe_add_subscription_meta(15)
#1 /Users/matt/local/hpos/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters(NULL, Array)
#2 /Users/matt/local/hpos/wp-includes/plugin.php(476): WP_Hook->do_action(Array)
#3 /Users/matt/local/hpos/wp-includes/post.php(4673): do_action('save_post', 15, Object(WP_Post), false)
#4 /Users/matt/local/hpos/wp-admin/includes/post.php(700): wp_insert_post(Array, false, false)
#5 /Users/matt/local/hpos/wp-admin/post-new.php(66): get_default_post_to_edit('shop_subscripti...', true)
#6 /Users/matt/.composer/vendor/laravel/valet/server.php(235): require('/Users/matt/loc...')
#7 {main}
```

This code in the Synchroniser class that is causing the error is hooked onto the `'save_post'` hook which then tries to fetch a subscription using `wcs_get_subscription()`. At the time of running the `save_post` hook, when HPOS is enabled and syncing turned on, the new subscription hasn't been saved in the new HPOS tables yet, which results in the following `get_items()` on bool error.

Since #226 has been merged into `trunk`, subscriptions are created with CRUD methods and the `$subscription->create()` function is called, so to fix this problem we can now reliably change this hook to use `woocommerce_new_subscription`.

Replacing the `'save_post'` hook means we're no longer going to be setting this meta when third-party code uses the following functions on a `shop_subscription` post type:
 - `wp_insert_post()`
 - `wp_update_post()`
 - `wp_publish_post()`

I don't think this is a big problem we should try solve.

Alternative hooks:
 - `woocommerce_after_subscription_object_save` - This PR originally started using this hook but I found it was saving multiple copies of the `_order_contains_synced_subscription` metadata on the subscription. This was caused by multiple instances of the subscription objects being passed into the `maybe_add_subscription_meta()` function (from calling subscription->save() and `$subscription->save_items()`) and so I swapped over to use `woocommerce_new_subscription` which better suits the purpose of attaching this meta when subscription is created.


Because we're also hooking onto the `woocommerce_new_order_item` and `woocommerce_ajax_add_order_item_meta`, the `woocommerce_new_subscription` hook feels kind of redundant, but I think it's better to keep this functionality in place instead of simply getting rid of it.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In order to test this, make sure you have:
- Subscriptions Syncing feature enabled in **WooCommerce > Settings > Subscriptions**
- A synced subscription product created


**For WP Posts:**

1. Set data store settings to WP Posts ([settings](https://d.pr/i/LLNjCa))
2. Purchase the synced subscription
3. Confirm the subscription created in posts table
4. Confirm `_contains_synced_subscription` meta exists in `wp_postmeta` and is set to `'true'`

**For HPOS without syncing:**

1. Set data store settings to Order Tables ([settings](https://d.pr/i/SR3HfF))
2. Purchase the synced subscription
3. Confirm the subscription created in `wp_wc_orders` table
4. Confirm `_contains_synced_subscription` meta exists in `wp_wc_orders_meta` and is set to `'true'`

**For HPOS with syncing:**

1. Set data store settings to Order Tables with syncing to posts table ([settings](https://d.pr/i/SR3HfF))
2. Purchase the synced subscription
3. Confirm the subscription created in `wp_wc_orders` table
4. Confirm `_contains_synced_subscription` meta exists in both `wp_wc_orders_meta` and `wp_postmeta`is set to `true`


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
