### PR TITLE
Fixes issue caused by wcs_copy_order_address() using new WC Order APIs that aren't available in versions of WC we support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.4.1 - 2022-xx-xx =
+* Fix - Undefined method WC_Order::set_shipping_address() on stores running pre-7.1 of WooCommerce which prevented subscriptions from being purchased.
+
 = 2.4.0 - 2022-10-28 =
 * Update - The subscription creation function `wcs_create_subscription` has been updated to use WooCommerce CRUD methods in preparation for supporting High Performance Order Storage (HPOS).
 * Update - Improve wcs_copy_order_address() to use modern APIs for setting address fields.

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -96,37 +96,29 @@ function wcs_get_subscriptions_for_order( $order, $args = array() ) {
 function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' ) {
 
 	if ( 'all' === $address_type || 'shipping' === $address_type ) {
-		$to_order->set_shipping_address(
-			array(
-				'first_name' => $from_order->get_shipping_first_name( 'edit' ),
-				'last_name'  => $from_order->get_shipping_last_name( 'edit' ),
-				'company'    => $from_order->get_shipping_company( 'edit' ),
-				'address_1'  => $from_order->get_shipping_address_1( 'edit' ),
-				'address_2'  => $from_order->get_shipping_address_2( 'edit' ),
-				'city'       => $from_order->get_shipping_city( 'edit' ),
-				'state'      => $from_order->get_shipping_state( 'edit' ),
-				'postcode'   => $from_order->get_shipping_postcode( 'edit' ),
-				'country'    => $from_order->get_shipping_country( 'edit' ),
-			)
-		);
+		$to_order->set_shipping_first_name( $from_order->get_shipping_first_name() );
+		$to_order->set_shipping_last_name( $from_order->get_shipping_last_name() );
+		$to_order->set_shipping_company( $from_order->get_shipping_company() );
+		$to_order->set_shipping_address_1( $from_order->get_shipping_address_1() );
+		$to_order->set_shipping_address_2( $from_order->get_shipping_address_2() );
+		$to_order->set_shipping_city( $from_order->get_shipping_city() );
+		$to_order->set_shipping_state( $from_order->get_shipping_state() );
+		$to_order->set_shipping_postcode( $from_order->get_shipping_postcode() );
+		$to_order->set_shipping_country( $from_order->get_shipping_country() );
 	}
 
 	if ( 'all' === $address_type || 'billing' === $address_type ) {
-		$to_order->set_billing_address(
-			array(
-				'first_name' => $from_order->get_billing_first_name( 'edit' ),
-				'last_name'  => $from_order->get_billing_last_name( 'edit' ),
-				'company'    => $from_order->get_billing_company( 'edit' ),
-				'address_1'  => $from_order->get_billing_address_1( 'edit' ),
-				'address_2'  => $from_order->get_billing_address_2( 'edit' ),
-				'city'       => $from_order->get_billing_city( 'edit' ),
-				'state'      => $from_order->get_billing_state( 'edit' ),
-				'postcode'   => $from_order->get_billing_postcode( 'edit' ),
-				'country'    => $from_order->get_billing_country( 'edit' ),
-				'email'      => $from_order->get_billing_email( 'edit' ),
-				'phone'      => $from_order->get_billing_phone( 'edit' ),
-			)
-		);
+		$to_order->set_billing_first_name( $from_order->get_billing_first_name() );
+		$to_order->set_billing_last_name( $from_order->get_billing_last_name() );
+		$to_order->set_billing_company( $from_order->get_billing_company() );
+		$to_order->set_billing_address_1( $from_order->get_billing_address_1() );
+		$to_order->set_billing_address_2( $from_order->get_billing_address_2() );
+		$to_order->set_billing_city( $from_order->get_billing_city() );
+		$to_order->set_billing_state( $from_order->get_billing_state() );
+		$to_order->set_billing_postcode( $from_order->get_billing_postcode() );
+		$to_order->set_billing_country( $from_order->get_billing_country() );
+		$to_order->set_billing_email( $from_order->get_billing_email() );
+		$to_order->set_billing_phone( $from_order->get_billing_phone() );
 	}
 
 	return apply_filters( 'woocommerce_subscriptions_copy_order_address', $to_order, $from_order, $address_type );

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -121,6 +121,8 @@ function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' )
 		$to_order->set_billing_phone( $from_order->get_billing_phone() );
 	}
 
+	$to_order->save();
+
 	return apply_filters( 'woocommerce_subscriptions_copy_order_address', $to_order, $from_order, $address_type );
 }
 


### PR DESCRIPTION
Fixes #236

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

In #228 we updated our `wcs_copy_order_address()` function to use CRUD methods, however, the functions we switched over to using were only just introduced in 7.1 (which is still in release candidate stages of development and hasn't been released yet).

This PR updates our `wcs_copy_order_address()` to use single address setter functions which were introduced in WC 3.0.
In these changes I've also added a `$to_order->save()` to fix a backward compatibility issue where the refactored version of this function wasn't writing the changes to the database.

I thought about adding an extra "save_address" parameter to this function which defaults to true and saves the address but not sure if we'd see much use for not wanting to save the address. Keen to get others thoughts though.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install WC 6.8 (earliest supported version in WC Pay)
2. Try to purchase a subscription on the checkout.
3. On `trunk` you will see error: `Fatal error: Uncaught Error: Call to undefined method WC_Subscription::set_shipping_address()
in /srv/users/userf10dd6d1/apps/userf10dd6d1/public/wp-content/plugins/woocommerce-payments/vendor/woocommerce/subscriptions-core/includes/wcs-order-functions.php on line 99`
4. On this branch, you shouldn't see any issues when purchasing a subscription.
5. On this branch, also confirm the address data has been correctly copied from order to subscription.


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
