### PR TITLE
Enable customers to purchase a subscription using WCPay and HPOS tables

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,11 +2,15 @@
 
 = 5.1.0 - 2022-xx-xx =
 * Fix - infinite loop that can occur with `WCS_Orders_Table_Subscription_Data_Store::read_multiple()` on HPOS-enabled stores.
+* Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
+* Fix - On HPOS stores, when saving a subscription make sure subscription properties (like `_requires_manual_renewal`) are saved to the database.
+* Fix - On HPOS stores, when a subscription is loaded from the database, make sure core subscription properties like `_requires_manual_renewal` are read directly from meta.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order
         wcs_subscriptions_for_switch_order
         wcs_subscriptions_for_resubscribe_order
+* Dev - Introduce a WC_Subscription::set_status() function to handle subscriptions set with a draft or auto-draft status. Replaces the need for the overriding WC_Subscription::get_status() which has been deleted.
 
 = 5.0.0 - 2022-11-14 =
 * Dev - The library has been bumped to version to 5.0.0 to reduce confusion with the version of WooCommerce Subscriptions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,8 +3,8 @@
 = 5.1.0 - 2022-xx-xx =
 * Fix - infinite loop that can occur with `WCS_Orders_Table_Subscription_Data_Store::read_multiple()` on HPOS-enabled stores.
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
-* Fix - On HPOS stores, when saving a subscription make sure subscription properties (like `_requires_manual_renewal`) are saved to the database.
-* Fix - On HPOS stores, when a subscription is loaded from the database, make sure core subscription properties like `_requires_manual_renewal` are read directly from meta.
+* Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
+* Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -642,7 +642,7 @@ class WC_Subscription extends WC_Order {
 	 */
 	public function get_status( $context = 'view' ) {
 
-		if ( in_array( get_post_status( $this->get_id() ), array( 'draft', 'auto-draft' ) ) ) {
+		if ( in_array( $this->get_prop( 'status', $context ), array( 'draft', 'auto-draft' ), true ) ) {
 			$this->post_status = 'wc-pending';
 			$status = apply_filters( 'woocommerce_order_get_status', 'pending', $this );
 		} else {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -634,22 +634,26 @@ class WC_Subscription extends WC_Order {
 	}
 
 	/**
-	 * Overrides the WC Order get_status function for draft and auto-draft statuses for a subscription
-	 * so that it will return a pending status instead of draft / auto-draft.
+	 * Sets the subscription status.
 	 *
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
-	 * @return string Status
+	 * Overrides the WC Order set_status() function to handle 'draft' and 'auto-draft' statuses for a subscription.
+	 *
+	 * 'draft' and 'auto-draft' statuses are WP statuses applied to the post when a subscription is created via admin. When
+	 * a subscription is being read from the database, and the status is set to the post's 'draft' or 'auto-draft' status, the
+	 * subscription status is treated as the default status - 'pending'.
+	 *
+	 * @since subscriptions-core 5.1.0
+	 *
+	 * @param string $new_status The new status.
+	 * @param string $note       Optional. The note to add to the subscription.
+	 * @param bool   $manual     Optional. Is the status change triggered manually? Default is false.
 	 */
-	public function get_status( $context = 'view' ) {
-
-		if ( in_array( $this->get_prop( 'status', $context ), array( 'draft', 'auto-draft' ), true ) ) {
-			$this->post_status = 'wc-pending';
-			$status = apply_filters( 'woocommerce_order_get_status', 'pending', $this );
-		} else {
-			$status = parent::get_status();
+	public function set_status( $new_status, $note = '', $manual_update = false ) {
+		if ( ! $this->object_read && in_array( $new_status, [ 'draft', 'auto-draft' ], true ) ) {
+			$new_status = apply_filters( 'woocommerce_default_order_status', 'pending' );
 		}
 
-		return $status;
+		parent::set_status( $new_status, $note, $manual_update );
 	}
 
 	/**

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -650,7 +650,7 @@ class WC_Subscription extends WC_Order {
 	 */
 	public function set_status( $new_status, $note = '', $manual_update = false ) {
 		if ( ! $this->object_read && in_array( $new_status, [ 'draft', 'auto-draft' ], true ) ) {
-			$new_status = apply_filters( 'woocommerce_default_order_status', 'pending' );
+			$new_status = apply_filters( 'woocommerce_default_subscription_status', 'pending' );
 		}
 
 		parent::set_status( $new_status, $note, $manual_update );

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -642,7 +642,7 @@ class WC_Subscription extends WC_Order {
 	 * a subscription is being read from the database, and the status is set to the post's 'draft' or 'auto-draft' status, the
 	 * subscription status is treated as the default status - 'pending'.
 	 *
-	 * @since subscriptions-core 5.1.0
+	 * @since 5.1.0
 	 *
 	 * @param string $new_status The new status.
 	 * @param string $note       Optional. The note to add to the subscription.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -7,7 +7,6 @@
  * @package    WooCommerce Subscriptions
  * @subpackage WC_Subscriptions_Order
  * @category   Class
- * @author     Brent Shepherd
  */
 class WC_Subscriptions_Order {
 
@@ -446,16 +445,17 @@ class WC_Subscriptions_Order {
 	/**
 	 * Records the initial payment against a subscription.
 	 *
-	 * This function is called when an orders status is changed to completed or processing
+	 * This function is called when an order's status is changed to completed or processing
 	 * for those gateways which never call @see WC_Order::payment_complete(), like the core
 	 * WooCommerce Cheque and Bank Transfer gateways.
 	 *
 	 * It will also set the start date on the subscription to the time the payment is completed.
 	 *
-	 * @param $order_id int|WC_Order
-	 * @param $old_order_status
-	 * @param $new_order_status
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+	 *
+	 * @param int|WC_Order $order_id         The order ID or WC_Order object.
+	 * @param string       $old_order_status The old order status.
+	 * @param string       $new_order_status The new order status.
 	 */
 	public static function maybe_record_subscription_payment( $order_id, $old_order_status, $new_order_status ) {
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -11,16 +11,6 @@
 class WC_Subscriptions_Order {
 
 	/**
-	 * Store a record of which product/item IDs need to have subscriptions details updated
-	 * whenever a subscription is saved via the "Edit Order" page.
-	 */
-	private static $requires_update = array(
-		'next_billing_date' => array(),
-		'trial_expiration'  => array(),
-		'expiration_date'   => array(),
-	);
-
-	/**
 	 * A flag to indicate whether subscription price strings should include the subscription length
 	 */
 	public static $recurring_only_price_strings = false;

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -456,7 +456,9 @@ class WC_Subscriptions_Order {
 		$subscriptions   = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'parent' ) );
 		$was_activated   = false;
 		$order           = wc_get_order( $order_id );
-		$order_completed = in_array( $new_order_status, array( apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' ) ) && in_array( $old_order_status, apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'on-hold', 'failed' ), $order ) );
+		$paid_statuses   = array( apply_filters( 'woocommerce_payment_complete_order_status', 'processing', $order_id, $order ), 'processing', 'completed' );
+		$unpaid_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'on-hold', 'failed' ), $order );
+		$order_completed = in_array( $new_order_status, $paid_statuses, true ) && in_array( $old_order_status, $unpaid_statuses, true );
 
 		foreach ( $subscriptions as $subscription ) {
 			// A special case where payment completes after user cancels subscription

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -398,6 +398,61 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	}
 
 	/**
+	 * Saves a subscription to the database.
+	 *
+	 * When a subscription is saved to the database we need to ensure we also save core subscription properties. The
+	 * parent::persist_order_to_db() will create and save the WC_Order inherited data, this method will save the
+	 * subscription core properties.
+	 *
+	 * @param WC_Subscription $subscription The subscription to save.
+	 * @param bool            $force_all_fields Optional. Whether to force all fields to be saved. Default false.
+	 */
+	protected function persist_order_to_db( &$subscription, bool $force_all_fields = false ) {
+		$is_update = ( 0 !== absint( $subscription->get_id() ) );
+
+		// Call the parent function first so WC can get an ID if this a new subscription.
+		parent::persist_order_to_db( $subscription, $force_all_fields );
+
+		// Get the subscription's current raw metadata.
+		$subscription_meta_data = array_column( $this->data_store_meta->read_meta( $subscription ), null, 'meta_key' );
+
+		// Determine what fields need to be saved. Forcing all fields to be saved is only allowed when updating.
+		if ( $force_all_fields && $is_update ) {
+			$props_to_save = $this->subscription_meta_keys_to_props;
+		} else {
+			$props_to_save = $this->get_props_to_update( $subscription, $this->subscription_meta_keys_to_props );
+		}
+
+		foreach ( $props_to_save as $meta_key => $prop ) {
+			$is_date_prop = ( 'schedule_' === substr( $prop, 0, 9 ) );
+
+			if ( $is_date_prop ) {
+				$meta_value = $subscription->get_date( $prop );
+			} else {
+				$meta_value = $subscription->{"get_$prop"}( 'edit' );
+			}
+
+			// Store as a string of the boolean for backward compatibility (yep, it's gross)
+			if ( 'requires_manual_renewal' === $prop ) {
+				$meta_value = wc_string_to_bool( $meta_value ) ? 'true' : 'false';
+			}
+
+			$existing_meta_data = $subscription_meta_data[ $meta_key ] ?? false;
+			$new_meta_data      = [
+				'key'   => $meta_key,
+				'value' => $meta_value,
+			];
+
+			if ( empty( $existing_meta_data ) ) {
+				$this->data_store_meta->add_meta( $subscription, (object) $new_meta_data );
+			} elseif ( $existing_meta_data->meta_value !== $new_meta_data['value'] ) {
+				$new_meta_data['id'] = $existing_meta_data->meta_id;
+				$this->data_store_meta->update_meta( $subscription, (object) $new_meta_data );
+			}
+		}
+	}
+
+	/**
 	 * Sets subscription core properties.
 	 *
 	 * This function is called when the subscription is being read from the database and ensures that
@@ -446,90 +501,6 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 
 		$subscription->update_dates( $dates_to_set );
 		$subscription->set_props( $props_to_set );
-	}
-
-	/**
-	 * Updates meta data based on a subscription object.
-	 *
-	 * This function in HPOS datastores is ONLY called during the `create` flow via `persist_save().
-	 * The purpose of this function is to set core subscription properties ($subscription_meta_keys_to_props) as meta via
-	 * `update_meta_data()` so that the rest of the `create` flow, handled by WC core, will save them to the database.
-	 *
-	 * @see $this->persist_updates() for the equivalent function for saving these properties to the database during subscription update.
-	 *
-	 * @param \WC_Subscription $subscription Subscription object.
-	 */
-	public function update_order_meta( &$subscription ) {
-		$updated_props = [];
-
-		foreach ( $this->get_props_to_update( $subscription, $this->subscription_meta_keys_to_props ) as $meta_key => $prop ) {
-			$is_date_prop = ( 'schedule_' === substr( $prop, 0, 9 ) );
-
-			if ( $is_date_prop ) {
-				$meta_value = $subscription->get_date( $prop );
-			} else {
-				$meta_value = $subscription->{"get_$prop"}( 'edit' );
-			}
-
-			// Store as a string of the boolean for backward compatibility (yep, it's gross)
-			if ( 'requires_manual_renewal' === $prop ) {
-				$meta_value = wc_string_to_bool( $meta_value ) ? 'true' : 'false';
-			}
-
-			$subscription->update_meta_data( $meta_key, $meta_value );
-			$updated_props[] = $prop;
-		}
-
-		do_action( 'woocommerce_subscription_object_updated_props', $subscription, $updated_props );
-
-		parent::update_order_meta( $subscription );
-	}
-
-	/**
-	 * Saves core subscription property updates to the database.
-	 *
-	 * This function in HPOS datastores is ONLY called during the `update` flow via `parent::update()`.
-	 * The purpose of this function is to save core subscription properties ($subscription_meta_keys_to_props) to the database.
-	 *
-	 * This function uses $this->data_store_meta->update_meta() and $this->data_store_meta->add_meta() to save the data directly in the database.
-	 *
-	 * @see $this->update_order_meta() for the equivalent function for saving these properties as meta during subscription creation.
-	 *
-	 * @param WC_Subscription $subscription The subscription object to save updates for.
-	 * @param bool            $backfill     Whether to backfill the subscription's meta data.
-	 */
-	protected function persist_updates( &$subscription, $backfill = true ) {
-		$subscription_meta_data = array_column( $this->data_store_meta->read_meta( $subscription ), null, 'meta_key' );
-
-		foreach ( $this->get_props_to_update( $subscription, $this->subscription_meta_keys_to_props ) as $meta_key => $prop ) {
-			$is_date_prop = ( 'schedule_' === substr( $prop, 0, 9 ) );
-
-			if ( $is_date_prop ) {
-				$meta_value = $subscription->get_date( $prop );
-			} else {
-				$meta_value = $subscription->{"get_$prop"}( 'edit' );
-			}
-
-			// Store as a string of the boolean for backward compatibility (yep, it's gross)
-			if ( 'requires_manual_renewal' === $prop ) {
-				$meta_value = wc_string_to_bool( $meta_value ) ? 'true' : 'false';
-			}
-
-			$existing_meta_data = $subscription_meta_data[ $meta_key ] ?? false;
-			$new_meta_data      = [
-				'key'   => $meta_key,
-				'value' => $meta_value,
-			];
-
-			if ( ! empty( $existing_meta_data ) ) {
-				$new_meta_data['id'] = $existing_meta_data->meta_id;
-				$this->data_store_meta->update_meta( $subscription, (object) $new_meta_data );
-			} else {
-				$this->data_store_meta->add_meta( $subscription, (object) $new_meta_data );
-			}
-		}
-
-		parent::persist_updates( $subscription, $backfill );
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -351,7 +351,12 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	public function read_multiple( &$subscriptions ) {
 		parent::read_multiple( $subscriptions );
 		foreach ( $subscriptions as $subscription ) {
+			// Flag the subscription as still being read so props we set aren't considered changes.
+			$subscription->set_object_read( false );
+
 			$this->set_subscription_props( $subscription );
+
+			$subscription->set_object_read( true );
 		}
 	}
 

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -344,6 +344,16 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	}
 
 	/**
+	 * Reads a subscription object from custom tables.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 */
+	public function read( &$subscription ) {
+		parent::read( $subscription );
+		$this->set_subscription_props( $subscription );
+	}
+
+	/**
 	 * Reads multiple subscription objects from custom tables.
 	 *
 	 * @param \WC_Order $subscriptions Subscription objects.

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -361,12 +361,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	public function read_multiple( &$subscriptions ) {
 		parent::read_multiple( $subscriptions );
 		foreach ( $subscriptions as $subscription ) {
-			// Flag the subscription as still being read so props we set aren't considered changes.
-			$subscription->set_object_read( false );
-
 			$this->set_subscription_props( $subscription );
-
-			$subscription->set_object_read( true );
 		}
 	}
 

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -393,7 +393,11 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	}
 
 	/**
-	 * Sets subscription props.
+	 * Sets subscription core properties.
+	 *
+	 * This function is called when the subscription is being read from the database and ensures that
+	 * core subscription properties ($this->subscription_meta_keys_to_props) are loaded directly from the
+	 * database and set on the subscription via the equivalent setter.
 	 *
 	 * @param \WC_Order $subscription Subscription object.
 	 */
@@ -442,7 +446,11 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	/**
 	 * Updates meta data based on a subscription object.
 	 *
-	 * / Called on create only. See persist_updates() for updates.
+	 * This function in HPOS datastores is ONLY called during the `create` flow via `persist_save().
+	 * The purpose of this function is to set core subscription properties ($subscription_meta_keys_to_props) as meta via
+	 * `update_meta_data()` so that the rest of the `create` flow, handled by WC core, will save them to the database.
+	 *
+	 * @see $this->persist_updates() for the equivalent function for saving these properties to the database during subscription update.
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 */
@@ -473,7 +481,14 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	}
 
 	/**
-	 * Undocumented function
+	 * Saves core subscription property updates to the database.
+	 *
+	 * This function in HPOS datastores is ONLY called during the `update` flow via `parent::update()`.
+	 * The purpose of this function is to save core subscription properties ($subscription_meta_keys_to_props) to the database.
+	 *
+	 * This function uses $this->data_store_meta->update_meta() and $this->data_store_meta->add_meta() to save the data directly in the database.
+	 *
+	 * @see $this->update_order_meta() for the equivalent function for saving these properties as meta during subscription creation.
 	 *
 	 * @param WC_Subscription $subscription The subscription object to save updates for.
 	 * @param bool            $backfill     Whether to backfill the subscription's meta data.

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -344,16 +344,6 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	}
 
 	/**
-	 * Reads a subscription object from custom tables.
-	 *
-	 * @param \WC_Subscription $subscription Subscription object.
-	 */
-	public function read( &$subscription ) {
-		parent::read( $subscription );
-		$this->set_subscription_props( $subscription );
-	}
-
-	/**
 	 * Reads multiple subscription objects from custom tables.
 	 *
 	 * @param \WC_Order $subscriptions Subscription objects.

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -442,17 +442,25 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	/**
 	 * Updates meta data based on a subscription object.
 	 *
+	 * / Called on create only. See persist_updates() for updates.
+	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 */
 	public function update_order_meta( &$subscription ) {
 		$updated_props = [];
 
 		foreach ( $this->get_props_to_update( $subscription, $this->subscription_meta_keys_to_props ) as $meta_key => $prop ) {
-			$meta_value = ( 'schedule_' === substr( $prop, 0, 9 ) ) ? $subscription->get_date( $prop ) : $subscription->{"get_$prop"}( 'edit' );
+			$is_date_prop = ( 'schedule_' === substr( $prop, 0, 9 ) );
+
+			if ( $is_date_prop ) {
+				$meta_value = $subscription->get_date( $prop );
+			} else {
+				$meta_value = $subscription->{"get_$prop"}( 'edit' );
+			}
 
 			// Store as a string of the boolean for backward compatibility (yep, it's gross)
 			if ( 'requires_manual_renewal' === $prop ) {
-				$meta_value = $meta_value ? 'true' : 'false';
+				$meta_value = wc_string_to_bool( $meta_value ) ? 'true' : 'false';
 			}
 
 			$subscription->update_meta_data( $meta_key, $meta_value );

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -337,18 +337,18 @@ function wcs_order_contains_subscription( $order, $order_type = array( 'parent',
 	}
 
 	$contains_subscription = false;
-	$get_all               = in_array( 'any', $order_type );
+	$get_all               = in_array( 'any', $order_type, true );
 
-	if ( ( in_array( 'parent', $order_type ) || $get_all ) && count( wcs_get_subscriptions_for_order( $order->get_id(), array( 'order_type' => 'parent' ) ) ) > 0 ) {
+	if ( ( in_array( 'parent', $order_type, true ) || $get_all ) && count( wcs_get_subscriptions_for_order( $order->get_id(), array( 'order_type' => 'parent' ) ) ) > 0 ) {
 		$contains_subscription = true;
 
-	} elseif ( ( in_array( 'renewal', $order_type ) || $get_all ) && wcs_order_contains_renewal( $order ) ) {
+	} elseif ( ( in_array( 'renewal', $order_type, true ) || $get_all ) && wcs_order_contains_renewal( $order ) ) {
 		$contains_subscription = true;
 
-	} elseif ( ( in_array( 'resubscribe', $order_type ) || $get_all ) && wcs_order_contains_resubscribe( $order ) ) {
+	} elseif ( ( in_array( 'resubscribe', $order_type, true ) || $get_all ) && wcs_order_contains_resubscribe( $order ) ) {
 		$contains_subscription = true;
 
-	} elseif ( ( in_array( 'switch', $order_type ) || $get_all ) && wcs_order_contains_switch( $order ) ) {
+	} elseif ( ( in_array( 'switch', $order_type, true ) || $get_all ) && wcs_order_contains_switch( $order ) ) {
 		$contains_subscription = true;
 
 	}

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -393,7 +393,7 @@ function wcs_get_orders_with_meta_query( $args ) {
 	 * In HPOS environments, the 'any' status now maps to wc_get_order_statuses() statuses. Whereas, in
 	 * WP Post architecture 'any' meant any status except for ‘inherit’, ‘trash’ and ‘auto-draft’.
 	 *
-	 * If querying for subscriptions, we map 'any' to be all valid subscription statuses.
+	 * If we're querying for subscriptions, we need to map 'any' to be all valid subscription statuses otherwise it would just search for order statuses.
 	 */
 	if ( [ 'any' ] === $args['status'] && 'shop_subscription' === $args['type'] && wcs_is_custom_order_tables_usage_enabled() ) {
 		$args['status'] = array_keys( wcs_get_subscription_statuses() );

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -368,9 +368,10 @@ function wcs_order_contains_subscription( $order, $order_type = array( 'parent',
  * @return array An array of WC_Order or WC_Subscription objects or IDs based on the args.
  */
 function wcs_get_orders_with_meta_query( $args ) {
-	$use_meta_query_filter = wcs_is_custom_order_tables_usage_enabled() ? false : true;
+	$is_hpos_in_use = wcs_is_custom_order_tables_usage_enabled();
 
-	if ( $use_meta_query_filter ) {
+	// In CPT datastores, we have to hook into the orders query to insert any meta query args.
+	if ( ! $is_hpos_in_use ) {
 		$meta = $args['meta_query'] ?? [];
 		unset( $args['meta_query'] );
 
@@ -398,14 +399,14 @@ function wcs_get_orders_with_meta_query( $args ) {
 	if ( isset( $args['status'], $args['type'] ) &&
 		[ 'any' ] === $args['status'] &&
 		'shop_subscription' === $args['type'] &&
-		wcs_is_custom_order_tables_usage_enabled()
+		$is_hpos_in_use
 	) {
 		$args['status'] = array_keys( wcs_get_subscription_statuses() );
 	}
 
 	$results = wc_get_orders( $args );
 
-	if ( $use_meta_query_filter ) {
+	if ( ! $is_hpos_in_use ) {
 		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $handle_meta, 10 );
 	}
 

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -395,7 +395,11 @@ function wcs_get_orders_with_meta_query( $args ) {
 	 *
 	 * If we're querying for subscriptions, we need to map 'any' to be all valid subscription statuses otherwise it would just search for order statuses.
 	 */
-	if ( [ 'any' ] === $args['status'] && 'shop_subscription' === $args['type'] && wcs_is_custom_order_tables_usage_enabled() ) {
+	if ( isset( $args['status'], $args['type'] ) &&
+		[ 'any' ] === $args['status'] &&
+		'shop_subscription' === $args['type'] &&
+		wcs_is_custom_order_tables_usage_enabled()
+	) {
 		$args['status'] = array_keys( wcs_get_subscription_statuses() );
 	}
 

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -387,6 +387,18 @@ function wcs_get_orders_with_meta_query( $args ) {
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $handle_meta, 10, 2 );
 	}
 
+	/**
+	 * Map the 'any' status to wcs_get_subscription_statuses() in HPOS environments.
+	 *
+	 * In HPOS environments, the 'any' status now maps to wc_get_order_statuses() statuses. Whereas, in
+	 * WP Post architecture 'any' meant any status except for ‘inherit’, ‘trash’ and ‘auto-draft’.
+	 *
+	 * If querying for subscriptions, we map 'any' to be all valid subscription statuses.
+	 */
+	if ( [ 'any' ] === $args['status'] && 'shop_subscription' === $args['type'] && wcs_is_custom_order_tables_usage_enabled() ) {
+		$args['status'] = array_keys( wcs_get_subscription_statuses() );
+	}
+
 	$results = wc_get_orders( $args );
 
 	if ( $use_meta_query_filter ) {

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -59,10 +59,11 @@ function wcs_get_subscriptions_for_order( $order, $args = array() ) {
 	if ( $get_all || in_array( 'parent', $args['order_type'] ) ) {
 
 		$get_subscriptions_args = array_merge( $args, array(
-			'order_id' => wcs_get_objects_property( $order, 'id' ),
+			'order_id' => $order->get_id(),
 		) );
 
 		$subscriptions = wcs_get_subscriptions( $get_subscriptions_args );
+
 	}
 
 	$all_relation_types = WCS_Related_Order_Store::instance()->get_relation_types();
@@ -338,7 +339,7 @@ function wcs_order_contains_subscription( $order, $order_type = array( 'parent',
 	$contains_subscription = false;
 	$get_all               = in_array( 'any', $order_type );
 
-	if ( ( in_array( 'parent', $order_type ) || $get_all ) && count( wcs_get_subscriptions_for_order( wcs_get_objects_property( $order, 'id' ), array( 'order_type' => 'parent' ) ) ) > 0 ) {
+	if ( ( in_array( 'parent', $order_type ) || $get_all ) && count( wcs_get_subscriptions_for_order( $order->get_id(), array( 'order_type' => 'parent' ) ) ) > 0 ) {
 		$contains_subscription = true;
 
 	} elseif ( ( in_array( 'renewal', $order_type ) || $get_all ) && wcs_order_contains_renewal( $order ) ) {

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -1659,24 +1659,33 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 		foreach ( $subscriptions as $status => $subscription ) {
 			$this->assertEquals( $status, $subscription->get_status() );
 		}
+	}
 
+	/**
+	 * Tests that subscriptions loaded from the database with draft or auto-draft status are treated as pending.
+	 */
+	public function test_draft_subscription_statuses() {
 		$subscription = WCS_Helper_Subscription::create_subscription( [ 'status' => 'active' ] );
+
 		wp_update_post(
 			[
 				'ID'          => $subscription->get_id(),
 				'post_status' => 'draft',
 			]
 		);
-		$this->assertEquals( 'pending', $subscription->get_status() );
 
-		$subscription = WCS_Helper_Subscription::create_subscription( [ 'status' => 'active' ] );
+		// Confirm that a draft subscription when loaded has a pending status.
+		$this->assertEquals( 'pending', wcs_get_subscription( $subscription->get_id() )->get_status() );
+
 		wp_update_post(
 			[
 				'ID'          => $subscription->get_id(),
 				'post_status' => 'auto-draft',
 			]
 		);
-		$this->assertEquals( 'pending', $subscription->get_status() );
+
+		// Confirm that a draft subscription when loaded has a pending status.
+		$this->assertEquals( 'pending', wcs_get_subscription( $subscription->get_id() )->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #257 

## Description

This PR includes the changes necessary to allow customers to purchase a subscription using WC Payments + WC Subscriptions with HPOS tables enabled. 

There were 3 separate issues that I was able to troubleshoot and fix as part of this PR. 

1. With HPOS tables enabled purchasing a subscription was leaving the subscription as `Pending` status.
    -  The `WC_Subscriptions_Order::maybe_record_subscription_payment()` function is responsible for activating a subscription after the order is successfully paid. It was not working as expected. 
    - **_Cause:_** The `wcs_order_contains_subscription()` check at the top of the function was causing the function to exit early even though the order did contain a subscription with the parent order relationship. After troubleshooting I discovered it was because of a different in `wc_get_order()` status args. Fixed with [16adf67](https://github.com/Automattic/woocommerce-subscriptions-core/pull/258/commits/16adf67ee1d8fbb8f8566e374e0000b53edc11c8). 
    - Further reading: https://github.com/Automattic/woocommerce-subscriptions-core/pull/258#discussion_r1019899441
2. When a subscription was updated (`$subscription->save()`, after the original create), some key subscription properties (like `_requires_manual_renewal`) weren't being saved to the database (it remained as `true` for example even after the subscriptions payment method was set to WC Payments). 
     - **_Cause:_** In HPOS environments WC orders no longer store key props in metadata. However, Subscriptions still has key data stored in meta (`_requires_manual_renewal`, all the subscription dates, suspension counts etc). Because WC no longer need to store order data in metadata, there isn't a similar function in the order datastore we could override to save these fields for subscriptions. We had a `update_order_meta ` function, however in the Order datastore that only gets called when a order is created, not when it is updated. 
     - **_Fix:_** I've introduced the `persist_updates()` function to now save these subscription props to the database on update. The existing `update_order_meta()` function can still be used to save the subscription props on create.
3. When reading a subscription from the database key subscription props (`_requires_manual_renewal`, all the subscription dates, suspension counts etc) need to be set via the setter (eg `$subscription->set_requires_manual_renewal()`), they aren't read as meta data even though that is where they are stored (meta table). When reading the subscription we call `set_subscription_props()` to set these properties on load, however, there was a bug in this function when it was copied from the CPT datastore equivalent. The `get_post_meta()` became `$subscription->get_meta()` however that isn't a legitimate mapping in this case because these props aren't read into the subscription metadata (they are internal meta keys). To fix this, I updated `set_subscription_props()` to read the subscription's raw meta and pull these internal meta values out of there instead. Fetching the subscription's raw meta does return these internal meta keys. 
4. With database syncing turn off (only HPOS tables), subscriptions were being saved in the tables with a pending status. After a lot of debugging I discovered that this was happening because WC when they save orders and subscriptions in the database call the `$subscription->get_status()` function. The `WC_Subscription::get_status()` function use to pull the subscription status directly from the database and if it is `draft` or `auto-draft` would return pending. Because the post placeholds have a draft status, this would mean calling `$subscription->get_status()` on a HPOS environment with no sycning would essentially always return a pending status. I fixed this in [0989072](https://github.com/Automattic/woocommerce-subscriptions-core/pull/258/commits/09890725776c3ed2f3ad87db019c10d499a3de18)

## How to test this PR

> **Note**
> _**Tip**_ - _test with a non-monthly subscription as monthly is the default period.  eg test a every 4 day subscription or every 2 weeks, 3 years etc._

1. Enable WC Payments + WC Subscriptions + this branch of subscriptions-core.
2.  Enable HPOS tables ([settings](https://user-images.githubusercontent.com/8490476/201551959-1c87e075-d190-4401-93d4-ded8e3ebe921.png)).
3. Purchase a subscription using WC Payments. 
5. Note the following things:
     1. The related subscriptions now appear on the order received page.
     2. View the my account subscription page (on `trunk` you'll need to access the page via the URL - https://example/my-account/view-subscription/400/)
     3. Compare the data in the database. 

| `trunk`  | This branch |
| ------------- | ------------- |
|  <img width="850" alt="Screen Shot 2022-11-14 at 10 44 10 am" src="https://user-images.githubusercontent.com/8490476/201553787-051e7393-eda1-4dc7-b998-8b600cb12a90.png"> |  <img width="850" alt="Screen Shot 2022-11-14 at 10 16 41 am" src="https://user-images.githubusercontent.com/8490476/201552264-90f27a25-da21-4c3a-b522-ab15440d1281.png"> |

| `trunk`  | This branch |
| ------------- | ------------- |
| <img width="864" alt="Screen Shot 2022-11-14 at 10 46 20 am" src="https://user-images.githubusercontent.com/8490476/201553969-11ef6a5a-5de3-4652-bc95-833b163448df.png">  | <img width="880" alt="Screen Shot 2022-11-14 at 10 22 31 am" src="https://user-images.githubusercontent.com/8490476/201552674-4ae365fe-c7b5-4f76-a7ba-63313c18a066.png"> |

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
