### PR TITLE
Return a new subscription object at the end of WC_Subscriptions_Checkout::create_subscription()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 2.5.2 - 2022-xx-xx =
+* Fix - When creating a subscription via the checkout, make sure a new instance of the subscription is attached to the `woocommerce_checkout_subscription_created` action hook.
+
 = 2.5.1 - 2022-11-04 =
 * Dev - Replace the use of the deprecated wcs_renewal_order_meta hook with wc_subscription_renewal_order_data in the WCS_Related_Order_Store_Cached_CPT class.
 * Dev - Fix typo in deprecation notice for the 'wcs_{type}_meta_query' filter. Incorrect replacement hook.

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -257,7 +257,12 @@ class WC_Subscriptions_Checkout {
 			return new WP_Error( 'checkout-error', $e->getMessage() );
 		}
 
-		// After saving the subscription, we need to fetch the subscription from the database as the current object state doesn't match the loaded state.
+		/**
+		 * Fetch and return a fresh instance of the subscription from the database.
+		 *
+		 * After saving the subscription, we need to fetch the subscription from the database as the current object state may not match the loaded state.
+		 * This occurs because different instances of the subscription might have been saved in any one of the processes above resulting in this object being out of sync.
+		 */
 		return wcs_get_subscription( $subscription );
 	}
 

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -257,7 +257,8 @@ class WC_Subscriptions_Checkout {
 			return new WP_Error( 'checkout-error', $e->getMessage() );
 		}
 
-		return $subscription;
+		// After saving the subscription, we need to fetch the subscription from the database as the current object state doesn't match the loaded state.
+		return wcs_get_subscription( $subscription );
 	}
 
 


### PR DESCRIPTION
Fixes #262
For https://github.com/Automattic/woocommerce-payments/issues/5131

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

We discovered a bug while testing WC Payments Subscriptions with the syncing feature enabled, where the Stripe Billing subscription wasn't being synced.

After investigation, this was caused by the `WC_Payments_Subscription_Service::has_delayed_payment()` function being passed an older subscription object which didn't have the synced meta saved on it (happens during the checkout create subscription process) and so calling `$subscription->get_meta( '_contains_synced_subscription' )` was returning incorrect information.

To fix this issue in WC Payments and any other third-party code that is hooked onto `woocommerce_checkout_subscription_created`, this PR fetches a new instance of the subscription at the end of `create_subscription()` function.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure WC Subscriptions plugin is disabled and WCPay Subscriptions is enabled.
2. While on trunk of Subscriptions Core, purchase a synced subscription with WC Payments. In my tests, I purchased a subscription that is synced to the 1st of the month.
3. Check the subscription in Stripe Billing and confirm there's no trial period and the next payment date is not set correctly.
![image](https://user-images.githubusercontent.com/2275145/201841167-82ee290d-fe60-442b-bf51-5df00cd723bb.png)
4. Checkout this branch
5. Purchase a synced subscription with WC Payments again
6. Check the subscription in Stripe Billing and confirm there's a trial end period and the next payment date aligns with the sync date.

![image](https://user-images.githubusercontent.com/2275145/201848407-d3e44c3f-7c8f-49e0-8739-b4161b45c595.png)


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes https://github.com/Automattic/woocommerce-payments/issues/5131
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
