### PR TITLE
Support for Collection in Block Checkout

### DIFF
--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1130,7 +1130,7 @@ class WC_Subscriptions_Cart {
 
 	/**
 	 * Updates all packages in the recurring cart to use a given shipping method if requested via Store API.
-	 * 
+	 *
 	 * @see woocommerce_store_api_cart_select_shipping_rate
 	 *
 	 * @param string|null $package_id The sanitized ID of the package being updated. Null if all packages are being updated.
@@ -1141,10 +1141,10 @@ class WC_Subscriptions_Cart {
 			return;
 		}
 		$chosen_shipping_methods = wc()->session->get( 'chosen_shipping_methods' ) ? wc()->session->get( 'chosen_shipping_methods' ) : [];
-		
+
 		foreach ( WC()->cart->recurring_carts as $recurring_cart_key => $recurring_cart ) {
 			foreach ( $recurring_cart->get_shipping_packages() as $package_index => $recurring_cart_package ) {
-				$recurring_cart_package_key = self::get_recurring_shipping_package_key( $recurring_cart_key, $package_index );
+				$recurring_cart_package_key                             = self::get_recurring_shipping_package_key( $recurring_cart_key, $package_index );
 				$chosen_shipping_methods[ $recurring_cart_package_key ] = $rate_id;
 			}
 		}


### PR DESCRIPTION
New Local Pickup functionality is being built in blocks: https://github.com/woocommerce/woocommerce-blocks/pull/7433

With this selected, packages are not shown individually which break Subscriptions. The current workaround is to support `woocommerce_store_api_cart_select_shipping_rate` and set the rate ID for all recurring packages when a package ID is not given.

cc @senadir 

## How to test this PR

Requires the https://github.com/woocommerce/woocommerce-blocks/pull/7433 branch.

1. Add various products and subscriptions to cart.
2. Go to checkout.
3. Choose "local pickup"
4. Select a pickup location
5. Confirm the selected pickup location applies to the cart and all recurring carts

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
