### PR TITLE
Fix infinite loops on HPOS environments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 5.1.0 - 2022-xx-xx =
+* Fix - infinite loop that can occur with `WCS_Orders_Table_Subscription_Data_Store::read_multiple()` on HPOS-enabled stores.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -351,7 +351,12 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	public function read_multiple( &$subscriptions ) {
 		parent::read_multiple( $subscriptions );
 		foreach ( $subscriptions as $subscription ) {
+			// Flag the subscription as still being read so props we set aren't considered changes.
+			$subscription->set_object_read( false );
+
 			$this->set_subscription_props( $subscription );
+
+			$subscription->set_object_read( true );
 		}
 	}
 

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -344,16 +344,6 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	}
 
 	/**
-	 * Reads a subscription object from custom tables.
-	 *
-	 * @param \WC_Subscription $subscription Subscription object.
-	 */
-	public function read( &$subscription ) {
-		parent::read( $subscription );
-		$this->set_subscription_props( $subscription );
-	}
-
-	/**
 	 * Reads multiple subscription objects from custom tables.
 	 *
 	 * @param \WC_Order $subscriptions Subscription objects.


### PR DESCRIPTION
Fixes #265

Troubleshooting this issue has been a real team effort, thanks @brucealdridge, @Jinksi  and @mattallan on your brain cycles on understanding this problem. 

## Description

On HPOS environments, purchasing a subscription was causing infinite loops on checkout. 

After some digging and confirming that the issue wasn't present on `issue/257` we discovered that these two commits (originally on `issue/257`) fixed the issue. 

### What caused the loops and why does this fix it.

@brucealdridge dug into logs (using action/filter logs) and discovered that it was caused when attempting to get the subscription's paid date during a read (via `wcs_get_subscription()` and inside `validate_date_updates()`). After I recalled seeing a comment in the code about not wanting to get a subscription paid date during a read, I figured this had to do with the subscriptions `$this->object_read` property - this property indicates if the subscription object has been read. 

Separate to this infinite loop issue, while working on `issue/257` I noticed that when reading a subscription from the database, our subscription properties (subscription dates, billing interval, billing period etc) were appearing on the object as "changes", when nothing about those properties had changed. After looking into that, I realised that when a subscription is initialised via [`read_multiple()`](https://github.com/woocommerce/woocommerce/blob/7cd1a030430d7215b4548d6a7037f79abd0dcb72/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L973), WC sets the [objects read property to `true`](https://github.com/woocommerce/woocommerce/blob/7cd1a030430d7215b4548d6a7037f79abd0dcb72/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1031) and so any setting of properties we make after that are considered changes ([ref](https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/abstracts/abstract-wc-data.php#L739-L742)).

So now that we know a subscription has a object read set to true, when we call `$this->set_subscription_props();` ([here](https://github.com/automattic/woocommerce-subscriptions-core/blob/fix/infinite_loops_on_HPOS/includes/data-stores/class-wcs-orders-table-subscription-data-store.php#L357)). We set our subscription props [including dates](https://github.com/automattic/woocommerce-subscriptions-core/blob/fix/infinite_loops_on_HPOS/includes/data-stores/class-wcs-orders-table-subscription-data-store.php#L429), the true `read` flag causes [this condition](https://github.com/automattic/woocommerce-subscriptions-core/blob/fix/infinite_loops_on_HPOS/includes/class-wc-subscription.php#L2387-L2388) to be skipped, resulting in related order dates to be validated. That goes off and attempts to get the last subscription's order to get the paid date from. That flow eventually lands in `WCS_Related_Order_Store_Cached_CPT::get_related_order_ids()` which would eventually call `get_related_order_ids_from_cache()` and in there it would attempt to get the subscription object from the ID, and around it goes. 

```
get subscription -> validate paid date (because read was set) -> get related orders -> get related orders from cache -> get subscription
```

By setting the subscriptions read to `false` while setting the subscription props we circumvent subscriptions attempting to get the paid date, while it is being read, which in turn prevents it from attempting to get related orders, which in turn prevents the `WCS_Related_Order_Store_Cached_CPT` class from attempting to load a new subscription instance. 

## How to test this PR

1. Enable HPOS tables (see example settings below)
2. Attempt to purchase a subscription. 
   -  On `trunk` you get an error on checkout,
   - On this branch, checkout will be successful

```
CRITICAL Allowed memory size of 134217728 bytes exhausted (tried to allocate 1052672 bytes) in wp-content/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php on line 111
```

<img width="758" alt="Screen Shot 2022-11-17 at 9 44 59 am" src="https://user-images.githubusercontent.com/8490476/202319121-8c3f40be-b7a1-42d9-a237-bf30772c8a1f.png">

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
