### PR TITLE
Use supported CRUD apis to determine if subscriptions are present on store (`wcs_do_subscriptions_exist()`)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
+* Fix - Use supported CRUD apis to determine if subscriptions are present on store (`wcs_do_subscriptions_exist`)
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -646,4 +646,15 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 
 		$wpdb->delete( self::get_meta_table_name(), [ 'meta_key' => $meta_key ], [ '%s' ] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 	}
+
+	/**
+	 * Return true if there are any subscriptions in the database (active or inactive).
+	 *
+	 * @return boolean $subscriptions_exist True if there are any subscriptions (in HPOS / custom orders tables).
+	 */
+	public function do_subscriptions_exist() {
+		$subscriptions_exist = false;
+
+		return $subscriptions_exist;
+	}
 }

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -646,15 +646,4 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 
 		$wpdb->delete( self::get_meta_table_name(), [ 'meta_key' => $meta_key ], [ '%s' ] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 	}
-
-	/**
-	 * Return true if there are any subscriptions in the database (active or inactive).
-	 *
-	 * @return boolean $subscriptions_exist True if there are any subscriptions (in HPOS / custom orders tables).
-	 */
-	public function do_subscriptions_exist() {
-		$subscriptions_exist = false;
-
-		return $subscriptions_exist;
-	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Subscription Data Store: Stored in CPT.
+ * Subscription Data Store: Stored in CPT (posts table).
  *
  * Extends WC_Order_Data_Store_CPT to make sure subscription related meta data is read/updated.
  *
@@ -590,5 +590,16 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		$meta_value = null; // Delete any values.
 		$delete_all = true;
 		delete_metadata( 'post', $id, $meta_key, $meta_value, $delete_all );
+	}
+
+	/**
+	 * Return true if there are any subscriptions in the database (active or inactive).
+	 *
+	 * @return boolean $subscriptions_exist True if there are any subscriptions (in wp_posts table).
+	 */
+	public function do_subscriptions_exist() {
+		$subscriptions_exist = false;
+
+		return $subscriptions_exist;
 	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -591,23 +591,4 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		$delete_all = true;
 		delete_metadata( 'post', $id, $meta_key, $meta_value, $delete_all );
 	}
-
-	/**
-	 * Return true if there are any subscriptions in the database (active or inactive).
-	 *
-	 * @return boolean $subscriptions_exist True if there are any subscriptions (in wp_posts table).
-	 */
-	public function do_subscriptions_exist() {
-		$subscriptions_exist = false;
-
-		$results             = wc_get_orders(
-			array(
-				'type'  => 'shop_subscription',
-				'limit' => 1,
-			)
-		);
-		$subscriptions_exist = count( $results ) > 0;
-
-		return $subscriptions_exist;
-	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -600,6 +600,14 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	public function do_subscriptions_exist() {
 		$subscriptions_exist = false;
 
+		$results             = wc_get_orders(
+			array(
+				'type'  => 'shop_subscription',
+				'limit' => 1,
+			)
+		);
+		$subscriptions_exist = count( $results ) > 0;
+
 		return $subscriptions_exist;
 	}
 }

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -52,7 +52,7 @@ function wcs_is_subscription( $subscription ) {
  * Return true if there are any subscriptions in the database (active or inactive).
  *
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
- * @return boolean $subscriptions_exist True if there are any subscriptions (in wp_posts table).
+ * @return boolean $subscriptions_exist True if the store has any subscriptions.
  */
 function wcs_do_subscriptions_exist() {
 	$subscriptions_exist = false;

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -49,20 +49,23 @@ function wcs_is_subscription( $subscription ) {
 }
 
 /**
- * A very simple check. Basically if we have ANY subscriptions in the database, then the user has probably set at
- * least one up, so we can give them the standard message. Otherwise
+ * Return true if there are any subscriptions in the database (active or inactive).
  *
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
- * @return boolean true if anything is found
+ * @return boolean $subscriptions_exist True if there are any subscriptions (in wp_posts table).
  */
 function wcs_do_subscriptions_exist() {
-	global $wpdb;
-	$sql = $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = %s LIMIT 1;", 'shop_subscription' );
+	$subscriptions_exist = false;
 
-	// query is the fastest, every other built in method uses this. Plus, the return value is the number of rows found
-	$num_rows_found = $wpdb->query( $sql );
+	$results             = wc_get_orders(
+		array(
+			'type'  => 'shop_subscription',
+			'limit' => 1,
+		)
+	);
+	$subscriptions_exist = count( $results ) > 0;
 
-	return 0 !== $num_rows_found;
+	return $subscriptions_exist;
 }
 
 /**

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -55,11 +55,10 @@ function wcs_is_subscription( $subscription ) {
  * @return bool True if the store has any subscriptions, otherwise false.
  */
 function wcs_do_subscriptions_exist() {
-	$subscriptions_exist = false;
-
 	$results             = wc_get_orders(
 		array(
 			'type'   => 'shop_subscription',
+			'status' => 'all',
 			'limit'  => 1,
 			'return' => 'ids',
 		)

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -59,8 +59,9 @@ function wcs_do_subscriptions_exist() {
 
 	$results             = wc_get_orders(
 		array(
-			'type'  => 'shop_subscription',
-			'limit' => 1,
+			'type'   => 'shop_subscription',
+			'limit'  => 1,
+			'return' => 'ids',
 		)
 	);
 	$subscriptions_exist = count( $results ) > 0;

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -49,10 +49,10 @@ function wcs_is_subscription( $subscription ) {
 }
 
 /**
- * Return true if there are any subscriptions in the database (active or inactive).
+ * Determines if there are any subscriptions in the database (active or inactive).
  *
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
- * @return boolean $subscriptions_exist True if the store has any subscriptions.
+ * @return bool True if the store has any subscriptions, otherwise false.
  */
 function wcs_do_subscriptions_exist() {
 	$subscriptions_exist = false;


### PR DESCRIPTION
Fixes #251

## Description

Subscriptions has a utility function for determining if the store has any subscriptions (in the database). It uses a direct database query, which is not recommended, and will break if store enables HPOS. 

This PR switches the function to use [recommended CRUD order API wc_get_orders](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query), which will work consistently in stores using HPOS or legacy/posts orders. 

### Potential impact 

I searched subscriptions-core, WCPay, and WC Subscriptions for uses of `wcs_do_subscriptons_exist`. Ideally we can test each of these flows/use cases.

Summarising what I see below, `wcs_do_subscriptons_exist` might not actually be used in any critical merchant functionality (which is surprising); it's mostly used for UI and settings tweaks. It might be important for third party devs or other extensions though.

#### `subscriptions-core`
##### `register_order_types`
Registering order type `register_order_types`, [customising UI messages based on whether store has subs yet](https://github.com/Automattic/woocommerce-subscriptions-core/blob/12518bb30c5c163fa3042e86b3ef2b6899c3d094/includes/class-wc-subscriptions-core-plugin.php#L329-L339). Should be relatively straightforward to test, though low impact if this breaks.

https://github.com/Automattic/woocommerce-subscriptions-core/blob/12518bb30c5c163fa3042e86b3ef2b6899c3d094/includes/class-wc-subscriptions-core-plugin.php#L329-L339

##### `WCS_PayPal::set_enabled_for_subscriptions_default`
In our PayPal integration, `set_enabled_for_subscriptions_default`. PayPal is enabled by default for subscriptions if site has subscriptions. (Curious, why is this so specific!)

Again, low impact; if this breaks, the default will not get applied, I assume merchant can opt-in manually. 

https://github.com/Automattic/woocommerce-subscriptions-core/blob/5a136b267524e782db36c24dddabebbdf77f6756/includes/gateways/paypal/class-wcs-paypal.php#L656-L661

##### Unit tests
There is existing unit test `test_wcs_do_subscriptions_exist` (passing). It's only testing a couple of trivial cases (null case, `WCS_Helper_Subscription::create_subscription()` to create).

We could potentially look at expanding the coverage of this test to give us more protection in future, and refine the expectations for `wcs_do_subscriptions_exist`. For example, test subscriptions in different states, or different create paths, or creating with different order storage (HPOS vs. posts).


https://github.com/Automattic/woocommerce-subscriptions-core/blob/67a921ed93e648215e2fd2d4a36a7184a988ebdd/tests/unit/test-wcs-functions.php#L95-L101 

#### WC Subscriptions
##### `WCS_Early_Renewal_Manager::is_early_renewal_enabled`
Early renewal getter `is_early_renewal_enabled` has a side effect of forcing a default (enable), but only for “new” stores with no subs. I'm unclear on the risk/impact of this, it is interesting to see the getter forcing a default (i.e. getter changes data).

#### WC Pay
##### WCPay Subscriptions empty state
WCPay Subscriptions has a custom React empty state UI to guide merchants to set up subscriptions. The front end assets for this are only enqueued of site has no subscriptions. 

https://github.com/Automattic/woocommerce-payments/blob/400142062aeb835faf40befcdefa8fbc49a5c29b/includes/subscriptions/class-wc-payments-subscriptions-empty-state-manager.php#L40-L49

And there's a React placeholder element rendered, only if store has no subscriptions.

https://github.com/Automattic/woocommerce-payments/blob/400142062aeb835faf40befcdefa8fbc49a5c29b/includes/subscriptions/class-wc-payments-subscriptions-empty-state-manager.php#L85-L99

## How to test this PR

Run the unit tests.

Test one of the flow areas mentioned above, for example:

#### WCPay Subscriptions empty state (not in critical flows)
- [Set up a store with WCPay onboarded, in US, so can use WCPay Subscriptions](https://github.com/Automattic/woocommerce-payments/wiki/WC-Pay-Subscriptions-critical-flows-testing-instructions#base) (ensure WC Subscriptions is not active)
- Ensure store has no subscriptions (active or inactive)
- Go to `Dashboard > WooCommerce > Subscriptions`

Should see an empty state similar to this:
![new-tab-3](https://user-images.githubusercontent.com/4167300/203654447-2abbb6f3-6eb4-4e3e-ae1e-04cd11ee1c62.jpg)

- [Create a subscription product.](https://github.com/Automattic/woocommerce-payments/wiki/WC-Pay-Subscriptions-critical-flows-testing-instructions#create-a-subscription-product)
- [Purchase a subscription.](https://github.com/Automattic/woocommerce-payments/wiki/WC-Pay-Subscriptions-critical-flows-testing-instructions#purchase-a-subscription-product) ideally as a shopper
- Go to `Dashboard > WooCommerce > Subscriptions` (as admin/merchant)

Should see a list of subscriptions (the one you just bought).

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) not applicable, no deprecations
