### PR TITLE
[HPOS] Fix PHP notices that occur when updating/saving an order via the Edit Order page

### DIFF
--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -33,7 +33,7 @@ class WCS_Admin_Meta_Boxes {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles_scripts' ), 20 );
 
-		// We need to hook to the 'shop_order' rather than 'shop_subscription' because we declared that the 'shop_susbcription' order type supports 'order-meta-boxes'
+		// We need to hook to the 'shop_order' rather than 'shop_subscription' because we declared that the 'shop_subscription' order type supports 'order-meta-boxes'.
 		add_action( 'woocommerce_process_shop_order_meta', 'WCS_Meta_Box_Schedule::save', 10, 2 );
 		add_action( 'woocommerce_process_shop_order_meta', 'WCS_Meta_Box_Subscription_Data::save', 10, 2 );
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -55,7 +55,7 @@ class WCS_Admin_Meta_Boxes {
 		// Parent order line item price lock option.
 		add_action( 'woocommerce_order_item_add_action_buttons', array( __CLASS__, 'output_price_lock_html' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( __CLASS__, 'save_increased_price_lock' ) );
-		add_action( 'wp_ajax_wcs_order_price_lock' , array( __CLASS__, 'save_increased_price_lock' ) );
+		add_action( 'wp_ajax_wcs_order_price_lock', array( __CLASS__, 'save_increased_price_lock' ) );
 
 		// After calculating subscription/renewal order line item taxes, update base location tax item meta.
 		add_action( 'woocommerce_ajax_add_order_item_meta', array( __CLASS__, 'store_item_base_location_tax' ), 10, 3 );

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -98,11 +98,15 @@ class WCS_Admin_Meta_Boxes {
 	}
 
 	/**
-	 * Don't save save some order related meta boxes
+	 * Don't save some order related meta boxes.
+	 *
+	 * @see woocommerce_process_shop_order_meta
+	 *
+	 * @param int $order_id
+	 * @param WC_Order $order
 	 */
-	public function remove_meta_box_save( $post_id, $post ) {
-
-		if ( 'shop_subscription' == $post->post_type ) {
+	public function remove_meta_box_save( $order_id, $order ) {
+		if ( 'shop_subscription' === $order->get_type() ) {
 			remove_action( 'woocommerce_process_shop_order_meta', 'WC_Meta_Box_Order_Data::save', 40 );
 		}
 	}

--- a/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
@@ -60,7 +60,7 @@ class WCS_Meta_Box_Schedule {
 
 				// A subscription needs a created date, even if it wasn't set or is empty
 				if ( 'date_created' === $date_key && empty( $_POST[ $utc_timestamp_key ] ) ) {
-					$datetime = current_time( 'timestamp', true );
+					$datetime = time();
 				} elseif ( isset( $_POST[ $utc_timestamp_key ] ) ) {
 					$datetime = $_POST[ $utc_timestamp_key ];
 				} else { // No date to set

--- a/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
@@ -32,10 +32,15 @@ class WCS_Meta_Box_Schedule {
 
 	/**
 	 * Save meta box data
+	 *
+	 * @see woocommerce_process_shop_order_meta
+	 *
+	 * @param int $order_id
+	 * @param WC_Order $order
 	 */
-	public static function save( $post_id, $post ) {
+	public static function save( $order_id, $order ) {
 
-		if ( 'shop_subscription' == $post->post_type && ! empty( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+		if ( 'shop_subscription' === $order->get_type() && ! empty( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
 
 			if ( isset( $_POST['_billing_interval'] ) ) {
 				update_post_meta( $post_id, '_billing_interval', $_POST['_billing_interval'] );
@@ -45,7 +50,7 @@ class WCS_Meta_Box_Schedule {
 				update_post_meta( $post_id, '_billing_period', $_POST['_billing_period'] );
 			}
 
-			$subscription = wcs_get_subscription( $post_id );
+			$subscription = wcs_get_subscription( $order );
 
 			$dates = array();
 
@@ -73,7 +78,7 @@ class WCS_Meta_Box_Schedule {
 			try {
 				$subscription->update_dates( $dates, 'gmt' );
 
-				wp_cache_delete( $post_id, 'posts' );
+				wp_cache_delete( $order_id, 'posts' );
 			} catch ( Exception $e ) {
 				wcs_add_admin_notice( $e->getMessage(), 'error' );
 			}

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -312,18 +312,18 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 	/**
 	 * Save meta box data
 	 *
-	 * @param int     $post_id
-	 * @param WP_Post $post
+	 * @param int      $order_id
+	 * @param WC_Order $order
 	 */
-	public static function save( $post_id, $post = null ) {
-		if ( 'shop_subscription' != $post->post_type || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+	public static function save( $order_id, $order = null ) {
+		if ( 'shop_subscription' !== $order->get_type() || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
 			return;
 		}
 
 		self::init_address_fields();
 
 		// Get subscription object.
-		$subscription = wcs_get_subscription( $post_id );
+		$subscription = wcs_get_subscription( $order );
 		$props        = array();
 
 		// Ensure there is an order key.
@@ -414,6 +414,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 			do_action( 'woocommerce_admin_created_subscription', $subscription );
 		}
 
-		do_action( 'woocommerce_process_shop_subscription_meta', $post_id, $post );
+		// TODO: deprecate this hook
+		do_action( 'woocommerce_process_shop_subscription_meta', $order_id, $order );
 	}
 }


### PR DESCRIPTION
Fixes #196

Merge #280 first to reduce commit noise in this PR.

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to …
2. Click on …

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
