### PR TITLE
Fix PHPCS errors and warnings in metabox-related files to improve code quality

### DIFF
--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -125,21 +125,28 @@ class WCS_Admin_Meta_Boxes {
 
 			wp_enqueue_script( 'wcs-admin-meta-boxes-subscription', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/meta-boxes-subscription.js' ), array( 'wc-admin-meta-boxes', 'jstz', 'momentjs' ), WC_VERSION );
 
-			wp_localize_script( 'wcs-admin-meta-boxes-subscription', 'wcs_admin_meta_boxes', apply_filters( 'woocommerce_subscriptions_admin_meta_boxes_script_parameters', array(
-				'i18n_start_date_notice'         => __( 'Please enter a start date in the past.', 'woocommerce-subscriptions' ),
-				'i18n_past_date_notice'          => WCS_Staging::is_duplicate_site() ? __( 'Please enter a date at least 2 minutes into the future.', 'woocommerce-subscriptions' ) : __( 'Please enter a date at least one hour into the future.', 'woocommerce-subscriptions' ),
-				'i18n_next_payment_start_notice' => __( 'Please enter a date after the trial end.', 'woocommerce-subscriptions' ),
-				'i18n_next_payment_trial_notice' => __( 'Please enter a date after the start date.', 'woocommerce-subscriptions' ),
-				'i18n_trial_end_start_notice'    => __( 'Please enter a date after the start date.', 'woocommerce-subscriptions' ),
-				'i18n_trial_end_next_notice'     => __( 'Please enter a date before the next payment.', 'woocommerce-subscriptions' ),
-				'i18n_end_date_notice'           => __( 'Please enter a date after the next payment.', 'woocommerce-subscriptions' ),
-				'process_renewal_action_warning' => __( "Are you sure you want to process a renewal?\n\nThis will charge the customer and email them the renewal order (if emails are enabled).", 'woocommerce-subscriptions' ),
-				'payment_method'                 => wcs_get_subscription( $post )->get_payment_method(),
-				'search_customers_nonce'         => wp_create_nonce( 'search-customers' ),
-				'get_customer_orders_nonce'      => wp_create_nonce( 'get-customer-orders' ),
-				'is_duplicate_site'              => WCS_Staging::is_duplicate_site(),
-			) ) );
-		} else if ( 'shop_order' == $screen_id ) {
+			wp_localize_script(
+				'wcs-admin-meta-boxes-subscription',
+				'wcs_admin_meta_boxes',
+				apply_filters(
+					'woocommerce_subscriptions_admin_meta_boxes_script_parameters',
+					array(
+						'i18n_start_date_notice'         => __( 'Please enter a start date in the past.', 'woocommerce-subscriptions' ),
+						'i18n_past_date_notice'          => WCS_Staging::is_duplicate_site() ? __( 'Please enter a date at least 2 minutes into the future.', 'woocommerce-subscriptions' ) : __( 'Please enter a date at least one hour into the future.', 'woocommerce-subscriptions' ),
+						'i18n_next_payment_start_notice' => __( 'Please enter a date after the trial end.', 'woocommerce-subscriptions' ),
+						'i18n_next_payment_trial_notice' => __( 'Please enter a date after the start date.', 'woocommerce-subscriptions' ),
+						'i18n_trial_end_start_notice'    => __( 'Please enter a date after the start date.', 'woocommerce-subscriptions' ),
+						'i18n_trial_end_next_notice'     => __( 'Please enter a date before the next payment.', 'woocommerce-subscriptions' ),
+						'i18n_end_date_notice'           => __( 'Please enter a date after the next payment.', 'woocommerce-subscriptions' ),
+						'process_renewal_action_warning' => __( "Are you sure you want to process a renewal?\n\nThis will charge the customer and email them the renewal order (if emails are enabled).", 'woocommerce-subscriptions' ),
+						'payment_method'                 => wcs_get_subscription( $post )->get_payment_method(),
+						'search_customers_nonce'         => wp_create_nonce( 'search-customers' ),
+						'get_customer_orders_nonce'      => wp_create_nonce( 'get-customer-orders' ),
+						'is_duplicate_site'              => WCS_Staging::is_duplicate_site(),
+					)
+				)
+			);
+		} elseif ( 'shop_order' == $screen_id ) {
 
 			wp_enqueue_script( 'wcs-admin-meta-boxes-order', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/wcs-meta-boxes-order.js' ) );
 
@@ -189,7 +196,7 @@ class WCS_Admin_Meta_Boxes {
 					$actions['wcs_create_pending_parent'] = esc_html__( 'Create pending parent order', 'woocommerce-subscriptions' );
 				}
 			}
-		} else if ( self::can_renewal_order_be_retried( $theorder ) ) {
+		} elseif ( self::can_renewal_order_be_retried( $theorder ) ) {
 			$actions['wcs_retry_renewal_payment'] = esc_html__( 'Retry Renewal Payment', 'woocommerce-subscriptions' );
 		}
 
@@ -317,7 +324,7 @@ class WCS_Admin_Meta_Boxes {
 
 			foreach ( wcs_get_subscriptions_for_renewal_order( $order ) as $subscription ) {
 				$supports_date_changes = $subscription->payment_method_supports( 'subscription_date_changes' );
-				$is_automatic = ! $subscription->is_manual();
+				$is_automatic          = ! $subscription->is_manual();
 				break;
 			}
 
@@ -639,7 +646,6 @@ class WCS_Admin_Meta_Boxes {
 				'posts_per_page' => '-1',
 			)
 		);
-
 
 		foreach ( $orders as $order ) {
 			$customer_orders[ $order->get_id() ] = $order->get_order_number();

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -397,7 +397,8 @@ class WCS_Admin_Meta_Boxes {
 				'<div id="wcs_order_price_lock"><label for="wcs-order-price-lock">%s</label>%s<input id="wcs-order-price-lock" type="checkbox" name="wcs_order_price_lock" value="yes" %s></div>',
 				esc_html__( 'Lock manual price increases', 'woocommerce-subscriptions' ),
 				// So the help tip is initialized when the line items are reloaded, we need to add the 'tips' class to the element.
-				wcs_help_tip( $help_tip, false, 'woocommerce-help-tip tips' ),
+				// PHPCS warning ignored since escaping is handled by wc_help_tip().
+				wcs_help_tip( $help_tip, false, 'woocommerce-help-tip tips' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				checked( $order->get_meta( '_manual_price_increases_locked' ), 'true', false )
 			);
 		}

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -101,7 +101,7 @@ class WCS_Admin_Meta_Boxes {
 	 */
 	public function remove_meta_box_save( $post_id, $post ) {
 
-		if ( 'shop_subscription' == $post->post_type ) {
+		if ( 'shop_subscription' === $post->post_type ) {
 			remove_action( 'woocommerce_process_shop_order_meta', 'WC_Meta_Box_Order_Data::save', 40 );
 		}
 	}
@@ -117,7 +117,7 @@ class WCS_Admin_Meta_Boxes {
 		$screen    = get_current_screen();
 		$screen_id = isset( $screen->id ) ? $screen->id : '';
 
-		if ( 'shop_subscription' == $screen_id ) {
+		if ( 'shop_subscription' === $screen_id ) {
 
 			wp_register_script( 'jstz', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/jstz.min.js' ), [], $ver, false );
 
@@ -146,7 +146,7 @@ class WCS_Admin_Meta_Boxes {
 					)
 				)
 			);
-		} elseif ( 'shop_order' == $screen_id ) {
+		} elseif ( 'shop_order' === $screen_id ) {
 
 			wp_enqueue_script( 'wcs-admin-meta-boxes-order', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/wcs-meta-boxes-order.js' ), [], $ver, false );
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -160,7 +160,7 @@ class WCS_Admin_Meta_Boxes {
 		}
 
 		// Enqueue the metabox script for coupons.
-		if ( ! wcs_is_woocommerce_pre( '3.2' ) && in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ) ) ) {
+		if ( ! wcs_is_woocommerce_pre( '3.2' ) && in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ), true ) ) {
 			wp_enqueue_script(
 				'wcs-admin-coupon-meta-boxes',
 				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/meta-boxes-coupon.js' ),

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -640,7 +640,7 @@ class WCS_Admin_Meta_Boxes {
 		}
 
 		$customer_orders = array();
-		$user_id         = absint( $_POST['user_id'] );
+		$user_id         = isset( $_POST['user_id'] ) ?? absint( $_POST['user_id'] );
 		$orders          = wc_get_orders(
 			array(
 				'customer'       => $user_id,

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -33,7 +33,7 @@ class WCS_Admin_Meta_Boxes {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles_scripts' ), 20 );
 
-		// We need to hook to the 'shop_order' rather than 'shop_subscription' because we declared that the 'shop_susbcription' order type supports 'order-meta-boxes'
+		// We need to hook to the 'shop_order' rather than 'shop_subscription' because we declared that the 'shop_subscription' order type supports 'order-meta-boxes'.
 		add_action( 'woocommerce_process_shop_order_meta', 'WCS_Meta_Box_Schedule::save', 10, 2 );
 		add_action( 'woocommerce_process_shop_order_meta', 'WCS_Meta_Box_Subscription_Data::save', 10, 2 );
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -412,7 +412,7 @@ class WCS_Admin_Meta_Boxes {
 	 */
 	public static function save_increased_price_lock( $order_id = '' ) {
 
-		if ( empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+		if ( empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wc_clean( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -318,7 +318,7 @@ class WCS_Admin_Meta_Boxes {
 
 		$can_be_retried = false;
 
-		if ( wcs_order_contains_renewal( $order ) && $order->needs_payment() && '' != wcs_get_objects_property( $order, 'payment_method' ) ) {
+		if ( wcs_order_contains_renewal( $order ) && $order->needs_payment() && '' != wcs_get_objects_property( $order, 'payment_method' ) ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 			$supports_date_changes          = false;
 			$order_payment_gateway          = wc_get_payment_gateway_by_order( $order );
 			$order_payment_gateway_supports = ( isset( $order_payment_gateway->id ) ) ? has_action( 'woocommerce_scheduled_subscription_payment_' . $order_payment_gateway->id ) : false;

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -346,7 +346,7 @@ class WCS_Admin_Meta_Boxes {
 	public static function override_stock_management( $manage_stock ) {
 
 		// Override stock management while adding line items to a subscription via AJAX.
-		if ( isset( $_POST['order_id'], $_REQUEST['security'] ) && wp_verify_nonce( $_REQUEST['security'], 'order-item' ) && doing_action( 'wp_ajax_woocommerce_add_order_item' ) && wcs_is_subscription( absint( wp_unslash( $_POST['order_id'] ) ) ) ) {
+		if ( isset( $_POST['order_id'], $_REQUEST['security'] ) && wp_verify_nonce( wc_clean( wp_unslash( $_REQUEST['security'] ) ), 'order-item' ) && doing_action( 'wp_ajax_woocommerce_add_order_item' ) && wcs_is_subscription( absint( wp_unslash( $_POST['order_id'] ) ) ) ) {
 			$manage_stock = 'no';
 		}
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -111,6 +111,7 @@ class WCS_Admin_Meta_Boxes {
 	 */
 	public function enqueue_styles_scripts() {
 		global $post;
+		$ver = WC_Subscriptions_Core_Plugin::instance()->get_library_version();
 
 		// Get admin screen id
 		$screen    = get_current_screen();
@@ -118,11 +119,11 @@ class WCS_Admin_Meta_Boxes {
 
 		if ( 'shop_subscription' == $screen_id ) {
 
-			wp_register_script( 'jstz', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/jstz.min.js' ) );
+			wp_register_script( 'jstz', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/jstz.min.js' ), [], $ver, false );
 
-			wp_register_script( 'momentjs', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/moment.min.js' ) );
+			wp_register_script( 'momentjs', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/moment.min.js' ), [], $ver, false );
 
-			wp_enqueue_script( 'wcs-admin-meta-boxes-subscription', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/meta-boxes-subscription.js' ), array( 'wc-admin-meta-boxes', 'jstz', 'momentjs' ), WC_VERSION );
+			wp_enqueue_script( 'wcs-admin-meta-boxes-subscription', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/meta-boxes-subscription.js' ), array( 'wc-admin-meta-boxes', 'jstz', 'momentjs' ), $ver, false );
 
 			wp_localize_script(
 				'wcs-admin-meta-boxes-subscription',
@@ -147,7 +148,7 @@ class WCS_Admin_Meta_Boxes {
 			);
 		} elseif ( 'shop_order' == $screen_id ) {
 
-			wp_enqueue_script( 'wcs-admin-meta-boxes-order', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/wcs-meta-boxes-order.js' ) );
+			wp_enqueue_script( 'wcs-admin-meta-boxes-order', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/wcs-meta-boxes-order.js' ), [], $ver, false );
 
 			wp_localize_script(
 				'wcs-admin-meta-boxes-order',
@@ -164,7 +165,8 @@ class WCS_Admin_Meta_Boxes {
 				'wcs-admin-coupon-meta-boxes',
 				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/meta-boxes-coupon.js' ),
 				array( 'jquery', 'wc-admin-meta-boxes' ),
-				WC_Subscriptions_Core_Plugin::instance()->get_library_version()
+				$ver,
+				false
 			);
 		}
 	}

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -640,7 +640,7 @@ class WCS_Admin_Meta_Boxes {
 		}
 
 		$customer_orders = array();
-		$user_id         = isset( $_POST['user_id'] ) ?? absint( $_POST['user_id'] );
+		$user_id         = absint( $_POST['user_id'] ?? null );
 		$orders          = wc_get_orders(
 			array(
 				'customer'       => $user_id,

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -48,7 +48,7 @@ class WCS_Admin_Meta_Boxes {
 
 		add_action( 'woocommerce_order_action_wcs_retry_renewal_payment', array( __CLASS__, 'process_retry_renewal_payment_action_request' ), 10, 1 );
 
-		// Disable stock managment while adding line items to a subscription via AJAX.
+		// Disable stock management while adding line items to a subscription via AJAX.
 		add_action( 'option_woocommerce_manage_stock', array( __CLASS__, 'override_stock_management' ) );
 
 		// Parent order line item price lock option.
@@ -97,7 +97,7 @@ class WCS_Admin_Meta_Boxes {
 	}
 
 	/**
-	 * Don't save save some order related meta boxes
+	 * Don't save some order related meta boxes
 	 */
 	public function remove_meta_box_save( $post_id, $post ) {
 
@@ -334,7 +334,7 @@ class WCS_Admin_Meta_Boxes {
 	}
 
 	/**
-	 * Disables stock managment while adding items to a subscription via the edit subscription screen.
+	 * Disables stock management while adding items to a subscription via the edit subscription screen.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.6
 	 *

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -423,7 +423,7 @@ class WCS_Admin_Meta_Boxes {
 			return;
 		}
 
-		if ( isset( $_POST['wcs_order_price_lock'] ) && 'yes' === wc_clean( $_POST['wcs_order_price_lock'] ) ) {
+		if ( isset( $_POST['wcs_order_price_lock'] ) && 'yes' === wc_clean( wp_unslash( $_POST['wcs_order_price_lock'] ) ) ) {
 			$order->update_meta_data( '_manual_price_increases_locked', 'true' );
 			$order->save();
 		} elseif ( $order->meta_exists( '_manual_price_increases_locked' ) ) {

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -55,7 +55,7 @@ class WCS_Admin_Meta_Boxes {
 		// Parent order line item price lock option.
 		add_action( 'woocommerce_order_item_add_action_buttons', array( __CLASS__, 'output_price_lock_html' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( __CLASS__, 'save_increased_price_lock' ) );
-		add_action( 'wp_ajax_wcs_order_price_lock' , array( __CLASS__, 'save_increased_price_lock' ) );
+		add_action( 'wp_ajax_wcs_order_price_lock', array( __CLASS__, 'save_increased_price_lock' ) );
 
 		// After calculating subscription/renewal order line item taxes, update base location tax item meta.
 		add_action( 'woocommerce_ajax_add_order_item_meta', array( __CLASS__, 'store_item_base_location_tax' ), 10, 3 );

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -4,7 +4,6 @@
  *
  * Sets up the write panels used by the subscription custom order/post type
  *
- * @author   Prospress
  * @category Admin
  * @package  WooCommerce Subscriptions/Admin
  * @version  1.0.0 - Migrated from WooCommerce Subscriptions v2.0

--- a/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
@@ -34,14 +34,14 @@ class WCS_Meta_Box_Schedule {
 	 */
 	public static function save( $post_id, $post ) {
 
-		if ( 'shop_subscription' === $post->post_type && ! empty( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+		if ( 'shop_subscription' === $post->post_type && ! empty( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( wc_clean( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) {
 
 			if ( isset( $_POST['_billing_interval'] ) ) {
-				update_post_meta( $post_id, '_billing_interval', $_POST['_billing_interval'] );
+				update_post_meta( $post_id, '_billing_interval', wc_clean( wp_unslash( $_POST['_billing_interval'] ) ) );
 			}
 
 			if ( ! empty( $_POST['_billing_period'] ) ) {
-				update_post_meta( $post_id, '_billing_period', $_POST['_billing_period'] );
+				update_post_meta( $post_id, '_billing_period', wc_clean( wp_unslash( $_POST['_billing_period'] ) ) );
 			}
 
 			$subscription = wcs_get_subscription( $post_id );
@@ -61,7 +61,7 @@ class WCS_Meta_Box_Schedule {
 				if ( 'date_created' === $date_key && empty( $_POST[ $utc_timestamp_key ] ) ) {
 					$datetime = time();
 				} elseif ( isset( $_POST[ $utc_timestamp_key ] ) ) {
-					$datetime = $_POST[ $utc_timestamp_key ];
+					$datetime = wc_clean( wp_unslash( $_POST[ $utc_timestamp_key ] ) );
 				} else { // No date to set
 					continue;
 				}

--- a/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
@@ -34,7 +34,7 @@ class WCS_Meta_Box_Schedule {
 	 */
 	public static function save( $post_id, $post ) {
 
-		if ( 'shop_subscription' == $post->post_type && ! empty( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+		if ( 'shop_subscription' === $post->post_type && ! empty( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
 
 			if ( isset( $_POST['_billing_interval'] ) ) {
 				update_post_meta( $post_id, '_billing_interval', $_POST['_billing_interval'] );
@@ -51,7 +51,7 @@ class WCS_Meta_Box_Schedule {
 			foreach ( wcs_get_subscription_date_types() as $date_type => $date_label ) {
 				$date_key = wcs_normalise_date_type_key( $date_type );
 
-				if ( 'last_order_date_created' == $date_key ) {
+				if ( 'last_order_date_created' === $date_key ) {
 					continue;
 				}
 

--- a/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
@@ -27,7 +27,7 @@ class WCS_Meta_Box_Schedule {
 			$the_subscription = wcs_get_subscription( $post->ID );
 		}
 
-		include( dirname( __FILE__ ) . '/views/html-subscription-schedule.php' );
+		include dirname( __FILE__ ) . '/views/html-subscription-schedule.php';
 	}
 
 	/**
@@ -60,7 +60,7 @@ class WCS_Meta_Box_Schedule {
 
 				// A subscription needs a created date, even if it wasn't set or is empty
 				if ( 'date_created' === $date_key && empty( $_POST[ $utc_timestamp_key ] ) ) {
-					$datetime = current_time( 'timestamp', true );
+					$datetime = time();
 				} elseif ( isset( $_POST[ $utc_timestamp_key ] ) ) {
 					$datetime = $_POST[ $utc_timestamp_key ];
 				} else { // No date to set

--- a/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-schedule.php
@@ -2,7 +2,6 @@
 /**
  * Subscription Billing Schedule
  *
- * @author   Prospress
  * @category Admin
  * @package  WooCommerce Subscriptions/Admin/Meta Boxes
  * @version  1.0.0 - Migrated from WooCommerce Subscriptions v2.0

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -4,7 +4,6 @@
  *
  * Functions for displaying the order data meta box.
  *
- * @author   Prospress
  * @category Admin
  * @package  WooCommerce Subscriptions/Admin/Meta Boxes
  * @version  1.0.0 - Migrated from WooCommerce Subscriptions v3.0.0

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -402,11 +402,12 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 
 		try {
 			WCS_Change_Payment_Method_Admin::save_meta( $subscription );
+			$order_status = isset( $_POST['order_status'] ) ?? wc_clean( wp_unslash( $_POST['order_status'] ) );
 
-			if ( 'cancelled' === wc_clean( wp_unslash( $_POST['order_status'] ) ) ) {
+			if ( 'cancelled' === $order_status ) {
 				$subscription->cancel_order();
 			} else {
-				$subscription->update_status( wc_clean( wp_unslash( $_POST['order_status'] ) ), '', true );
+				$subscription->update_status( $order_status, '', true );
 			}
 		} catch ( Exception $e ) {
 			// translators: placeholder is error message from the payment gateway or subscriptions when updating the status

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -179,10 +179,10 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							echo '<p><strong>' . esc_html( $field['label'] ) . ':</strong> ' . wp_kses_post( make_clickable( esc_html( $field_value ) ) ) . '</p>';
 						}
 
-						echo '<p' . ( ( '' != $subscription->get_payment_method() ) ? ' class="' . esc_attr( $subscription->get_payment_method() ) . '"' : '' ) . '><strong>' . esc_html__( 'Payment Method', 'woocommerce-subscriptions' ) . ':</strong>' . wp_kses_post( nl2br( $subscription->get_payment_method_to_display() ) );
+						echo '<p' . ( ( '' != $subscription->get_payment_method() ) ? ' class="' . esc_attr( $subscription->get_payment_method() ) . '"' : '' ) . '><strong>' . esc_html__( 'Payment Method', 'woocommerce-subscriptions' ) . ':</strong>' . wp_kses_post( nl2br( $subscription->get_payment_method_to_display() ) ); // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 
 						// Display help tip
-						if ( '' != $subscription->get_payment_method() && ! $subscription->is_manual() ) {
+						if ( '' != $subscription->get_payment_method() && ! $subscription->is_manual() ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 							// translators: %s: gateway ID.
 							echo wcs_help_tip( sprintf( _x( 'Gateway ID: [%s]', 'The gateway ID displayed on the Edit Subscriptions screen when editing payment method.', 'woocommerce-subscriptions' ), $subscription->get_payment_method() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						}
@@ -328,7 +328,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 	 * @param WP_Post $post
 	 */
 	public static function save( $post_id, $post = null ) {
-		if ( 'shop_subscription' != $post->post_type || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+		if ( 'shop_subscription' != $post->post_type || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 			return;
 		}
 

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -43,23 +43,27 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 			<input name="post_status" type="hidden" value="<?php echo esc_attr( 'wc-' . $subscription->get_status() ); ?>" />
 			<div id="order_data" class="panel">
 
-				<h2><?php
+				<h2>
+				<?php
 				// translators: placeholder is the ID of the subscription
-				printf( esc_html_x( 'Subscription #%s details', 'edit subscription header', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) ); ?></h2>
+				printf( esc_html_x( 'Subscription #%s details', 'edit subscription header', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) );
+				?>
+				</h2>
 
 				<div class="order_data_column_container">
 					<div class="order_data_column">
 						<h3><?php esc_html_e( 'General', 'woocommerce-subscriptions' ); ?></h3>
 
 						<p class="form-field form-field-wide wc-customer-user">
-							<label for="customer_user"><?php esc_html_e( 'Customer:', 'woocommerce-subscriptions' ) ?> <?php
+							<label for="customer_user"><?php esc_html_e( 'Customer:', 'woocommerce-subscriptions' ); ?> <?php
 							if ( $subscription->get_user_id() ) {
 								$args = array(
 									'post_status'    => 'all',
 									'post_type'      => 'shop_subscription',
 									'_customer_user' => absint( $subscription->get_user_id() ),
 								);
-								printf( '<a href="%s">%s</a>',
+								printf(
+									'<a href="%s">%s</a>',
 									esc_url( add_query_arg( $args, admin_url( 'edit.php' ) ) ),
 									esc_html__( 'View other subscriptions &rarr;', 'woocommerce-subscriptions' )
 								);
@@ -69,7 +73,8 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 									esc_html__( 'Profile &rarr;', 'woocommerce-subscriptions' )
 								);
 							}
-							?></label>
+							?>
+							</label>
 							<?php
 							$user_string = '';
 							$user_id     = '';
@@ -78,14 +83,16 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 								$user        = get_user_by( 'id', $user_id );
 								$user_string = esc_html( $user->display_name ) . ' (#' . absint( $user->ID ) . ' &ndash; ' . esc_html( $user->user_email ) . ')';
 							}
-							WCS_Select2::render( array(
-								'class'       => 'wc-customer-search',
-								'name'        => 'customer_user',
-								'id'          => 'customer_user',
-								'placeholder' => esc_attr__( 'Search for a customer&hellip;', 'woocommerce-subscriptions' ),
-								'selected'    => $user_string,
-								'value'       => $user_id,
-							) );
+							WCS_Select2::render(
+								array(
+									'class'       => 'wc-customer-search',
+									'name'        => 'customer_user',
+									'id'          => 'customer_user',
+									'placeholder' => esc_attr__( 'Search for a customer&hellip;', 'woocommerce-subscriptions' ),
+									'selected'    => $user_string,
+									'value'       => $user_id,
+								)
+							);
 							?>
 						</p>
 
@@ -105,31 +112,37 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 						</p>
 						<?php
 						$parent_order = $subscription->get_parent();
-						if ( $parent_order ) { ?>
+						if ( $parent_order ) {
+							?>
 						<p class="form-field form-field-wide">
-						<?php echo esc_html__( 'Parent order: ', 'woocommerce-subscriptions' ) ?>
+							<?php echo esc_html__( 'Parent order: ', 'woocommerce-subscriptions' ); ?>
 						<a href="<?php echo esc_url( get_edit_post_link( $subscription->get_parent_id() ) ); ?>">
-						<?php
-						// translators: placeholder is an order number.
-						echo sprintf( esc_html__( '#%1$s', 'woocommerce-subscriptions' ), esc_html( $parent_order->get_order_number() ) );
-						?>
+							<?php
+							// translators: placeholder is an order number.
+							echo sprintf( esc_html__( '#%1$s', 'woocommerce-subscriptions' ), esc_html( $parent_order->get_order_number() ) );
+							?>
 						</a>
 						</p>
-						<?php } else {
-						?>
+							<?php
+						} else {
+							?>
 						<p class="form-field form-field-wide">
 							<label for="parent-order-id"><?php esc_html_e( 'Parent order:', 'woocommerce-subscriptions' ); ?> </label>
 							<?php
-							WCS_Select2::render( array(
-								'class'       => 'wc-enhanced-select',
-								'name'        => 'parent-order-id',
-								'id'          => 'parent-order-id',
-								'placeholder' => esc_attr__( 'Select an order&hellip;', 'woocommerce-subscriptions' ),
-							) );
+							WCS_Select2::render(
+								array(
+									'class'       => 'wc-enhanced-select',
+									'name'        => 'parent-order-id',
+									'id'          => 'parent-order-id',
+									'placeholder' => esc_attr__( 'Select an order&hellip;', 'woocommerce-subscriptions' ),
+								)
+							);
 							?>
 						</p>
-						<?php }
-						do_action( 'woocommerce_admin_order_data_after_order_details', $subscription ); ?>
+							<?php
+						}
+						do_action( 'woocommerce_admin_order_data_after_order_details', $subscription );
+						?>
 
 					</div>
 					<div class="order_data_column">
@@ -192,10 +205,10 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							switch ( $field['type'] ) {
 								case 'select':
 									woocommerce_wp_select( $field );
-								break;
+									break;
 								default:
 									woocommerce_wp_text_input( $field );
-								break;
+									break;
 							}
 						}
 
@@ -281,17 +294,17 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 								switch ( $field['type'] ) {
 									case 'select':
 										woocommerce_wp_select( $field );
-									break;
+										break;
 									default:
 										woocommerce_wp_text_input( $field );
-									break;
+										break;
 								}
 							}
 						}
 
 						if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) {
 							?>
-							<p class="form-field form-field-wide"><label for="excerpt"><?php esc_html_e( 'Customer Provided Note', 'woocommerce-subscriptions' ) ?>:</label>
+							<p class="form-field form-field-wide"><label for="excerpt"><?php esc_html_e( 'Customer Provided Note', 'woocommerce-subscriptions' ); ?>:</label>
 								<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer\'s notes about the order', 'woocommerce-subscriptions' ); ?>"><?php echo wp_kses_post( $post->post_excerpt ); ?></textarea>
 							</p>
 							<?php

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -272,7 +272,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							}
 						}
 
-						if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
+						if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
 							echo '<p><strong>' . esc_html__( 'Customer Provided Note', 'woocommerce-subscriptions' ) . ':</strong> ' . wp_kses_post( nl2br( $post->post_excerpt ) ) . '</p>';
 						}
 
@@ -301,7 +301,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							}
 						}
 
-						if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) {
+						if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) {
 							?>
 							<p class="form-field form-field-wide"><label for="excerpt"><?php esc_html_e( 'Customer Provided Note', 'woocommerce-subscriptions' ); ?>:</label>
 								<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer\'s notes about the order', 'woocommerce-subscriptions' ); ?>"><?php echo wp_kses_post( $post->post_excerpt ); ?></textarea>
@@ -403,7 +403,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 		try {
 			WCS_Change_Payment_Method_Admin::save_meta( $subscription );
 
-			if ( 'cancelled' == $_POST['order_status'] ) {
+			if ( 'cancelled' === $_POST['order_status'] ) {
 				$subscription->cancel_order();
 			} else {
 				$subscription->update_status( $_POST['order_status'], '', true );

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -402,7 +402,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 
 		try {
 			WCS_Change_Payment_Method_Admin::save_meta( $subscription );
-			$order_status = isset( $_POST['order_status'] ) ?? wc_clean( wp_unslash( $_POST['order_status'] ) );
+			$order_status = wc_clean( wp_unslash( $_POST['order_status'] ?? '' ) );
 
 			if ( 'cancelled' === $order_status ) {
 				$subscription->cancel_order();

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -328,7 +328,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 	 * @param WP_Post $post
 	 */
 	public static function save( $post_id, $post = null ) {
-		if ( 'shop_subscription' != $post->post_type || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+		if ( 'shop_subscription' != $post->post_type || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( wc_clean( wp_unslash( $_POST['woocommerce_meta_nonce'] ) ), 'woocommerce_save_data' ) ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 			return;
 		}
 
@@ -389,12 +389,12 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 		// Save the linked parent order id
 		if ( ! empty( $_POST['parent-order-id'] ) ) {
 			// if the parent order to be set is a renewal order
-			if ( wcs_order_contains_renewal( $_POST['parent-order-id'] ) ) {
+			if ( wcs_order_contains_renewal( wc_clean( wp_unslash( $_POST['parent-order-id'] ) ) ) ) {
 				// remove renewal meta
-				$parent = wc_get_order( $_POST['parent-order-id'] );
+				$parent = wc_get_order( wc_clean( wp_unslash( $_POST['parent-order-id'] ) ) );
 				wcs_delete_objects_property( $parent, 'subscription_renewal' );
 			}
-			$subscription->set_parent_id( wc_clean( $_POST['parent-order-id'] ) );
+			$subscription->set_parent_id( wc_clean( wp_unslash( $_POST['parent-order-id'] ) ) );
 			// translators: %s: parent order number (linked to its details screen).
 			$subscription->add_order_note( sprintf( _x( 'Subscription linked to parent order %s via admin.', 'subscription note after linking to a parent order', 'woocommerce-subscriptions' ), sprintf( '<a href="%1$s">#%2$s</a> ', esc_url( wcs_get_edit_post_link( $subscription->get_parent_id() ) ), $subscription->get_parent()->get_order_number() ) ), false, true );
 			$subscription->save();
@@ -403,10 +403,10 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 		try {
 			WCS_Change_Payment_Method_Admin::save_meta( $subscription );
 
-			if ( 'cancelled' === $_POST['order_status'] ) {
+			if ( 'cancelled' === wc_clean( wp_unslash( $_POST['order_status'] ) ) ) {
 				$subscription->cancel_order();
 			} else {
-				$subscription->update_status( $_POST['order_status'], '', true );
+				$subscription->update_status( wc_clean( wp_unslash( $_POST['order_status'] ) ), '', true );
 			}
 		} catch ( Exception $e ) {
 			// translators: placeholder is error message from the payment gateway or subscriptions when updating the status

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -184,7 +184,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 						// Display help tip
 						if ( '' != $subscription->get_payment_method() && ! $subscription->is_manual() ) {
 							// translators: %s: gateway ID.
-							echo wcs_help_tip( sprintf( _x( 'Gateway ID: [%s]', 'The gateway ID displayed on the Edit Subscriptions screen when editing payment method.', 'woocommerce-subscriptions' ), $subscription->get_payment_method() ) );
+							echo wcs_help_tip( sprintf( _x( 'Gateway ID: [%s]', 'The gateway ID displayed on the Edit Subscriptions screen when editing payment method.', 'woocommerce-subscriptions' ), $subscription->get_payment_method() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						}
 
 						echo '</p>';


### PR DESCRIPTION
Related to #196

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

This PR fixes code-quality issues in some files related to #279, such as PHPCS errors, spelling mistakes and potential security vulnerabilities.

This PR intends to separate these changes from other PRs that otherwise would add unnecessary cognitive load for code reviewers. This will also allow future devs to make changes to this file without fixing unrelated phpcs errors (or `git commit --no-verify`).

No changes to features or logic are expected.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this repo and run `composer install`.
2. Run the following terminal command:
   ```
   ./vendor/bin/phpcs includes/admin/class-wcs-admin-meta-boxes.php includes/admin/meta-boxes/class-wcs-meta-box-schedule.php includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
   ```
   - There should be no warnings or errors reported. (running `phpcs` directly from `./vendor/bin/` skips the "only changed LOC" rule that we use for PHPCS GH checks.
4. Conduct basic smoke-testing.
   - With HPOS disabled, you should see the related orders metabox in wp-admin for subscriptions and subscription-related orders.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry **does not apply**
- [x] Will this PR affect WooCommerce Subscriptions? **no**
- [x] Will this PR affect WooCommerce Payments? **no**
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **none**
