### PR TITLE
Fix HPOS renewal order payments - copy tokens between orders and subscriptions inside the copier class 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
+* Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
-* Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/includes/class-wc-subscriptions-data-copier.php
+++ b/includes/class-wc-subscriptions-data-copier.php
@@ -107,6 +107,15 @@ class WC_Subscriptions_Data_Copier {
 			$data += $this->get_operational_data();
 			$data += $this->get_address_data();
 
+			// Payment token meta isn't accounted from in the above methods, so we need to add it separately.
+			if ( ! isset( $data['_payment_tokens'] ) ) {
+				$tokens = $this->from_object->get_payment_tokens();
+
+				if ( ! empty( $tokens ) ) {
+					$data['_payment_tokens'] = $tokens;
+				}
+			}
+
 			// Remove any excluded meta keys.
 			$data = $this->filter_excluded_meta_keys_via_query( $data );
 		}

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -214,7 +214,17 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		// If we got here, the subscription was created without problems
 		$transaction->commit();
 
-		return apply_filters( 'wcs_new_order_created', $new_order, $subscription, $type );
+		/**
+		 * Filters the new order created from the subscription.
+		 *
+		 * Fetches a fresh instance of the the order because the current order instance has an empty line item cache generated before we copied the line items.
+		 * Fetching a new instance will ensure the line items are available.
+		 *
+		 * @param WC_Order        $new_order    The new order created from the subscription.
+		 * @param WC_Subscription $subscription The subscription the order was created from.
+		 * @param string          $type         The type of order being created. Either 'renewal_order' or 'resubscribe_order'.
+		 */
+		return apply_filters( 'wcs_new_order_created', wc_get_order( $new_order->get_id() ), $subscription, $type );
 
 	} catch ( Exception $e ) {
 		// There was an error adding the subscription

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -214,17 +214,7 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		// If we got here, the subscription was created without problems
 		$transaction->commit();
 
-		/**
-		 * Filters the new order created from the subscription.
-		 *
-		 * Fetches a fresh instance of the the order because the current order instance has an empty line item cache generated before we copied the line items.
-		 * Fetching a new instance will ensure the line items are available.
-		 *
-		 * @param WC_Order        $new_order    The new order created from the subscription.
-		 * @param WC_Subscription $subscription The subscription the order was created from.
-		 * @param string          $type         The type of order being created. Either 'renewal_order' or 'resubscribe_order'.
-		 */
-		return apply_filters( 'wcs_new_order_created', wc_get_order( $new_order->get_id() ), $subscription, $type );
+		return apply_filters( 'wcs_new_order_created', $new_order, $subscription, $type );
 
 	} catch ( Exception $e ) {
 		// There was an error adding the subscription


### PR DESCRIPTION
Fixes #285 

###  ~🟢  Blocked by https://github.com/Automattic/woocommerce-subscriptions-core/pull/275 🟢~

## Description

On HPOS environments WC Payment subscription renewals are currently failing, after some debugging I discovered that the cause is missing token meta. 

**Background:** when data is copied from the subscription to the renewal order during the renewal process, we generate an array of data to copy by calling a bunch or `WC_Order` getters (eg `get_billing_email()`) and then fetch all remaining custom meta data with `get_meta_data()`. 

This process doesn't include payment tokens because tokens are stored in post meta and not captured by any of the current getters. 

> **Note**
>  Payment tokens being saved in postmeta (even on HPOS sites) is a known WC core issue. https://github.com/woocommerce/woocommerce/issues/35612

This PR fixes this issue by making sure we add payment tokens as data copied on HPOS stores. 

## How to test this PR

> **Note**
> This only impacts HPOS stores, not wp posts.

1. Enable HPOS tables (see screenshot below)
2. Enable WC Payments + WC Subscriptions (extension)
3. Optional. Enable the early renewal order feature (see screenshot below)
4. Purchase a subscription product using WC Payments
5. From the my **Account → View Subscription** page click the early renewal button or process a renewal order manually via admin/action scheduler.
   6. On `trunk` an error that the payment was unsuccessful.
   7. On this branch the payment will be successful. 

![image](https://user-images.githubusercontent.com/8490476/202938724-6bebb65e-f15b-4fe7-a852-3728480c0bc0.png)

![image](https://user-images.githubusercontent.com/8490476/202938762-e656cc5d-0b8d-4172-819e-31d917c9aedf.png)

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
