### PR TITLE
When HPOS enabled, fix issue with not being able to view subscriptions list on my account page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
+* Fix - When viewing My Account > Subscriptions, fix an issue where no subscriptions were listed when HPOS is enabled.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/includes/data-stores/class-wcs-customer-store-cpt.php
+++ b/includes/data-stores/class-wcs-customer-store-cpt.php
@@ -4,13 +4,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Customer data store for subscriptions stored in Custom Post Types.
+ * Customer data store for subscriptions.
  *
- * Gets subscriptions for users via the '_customer_user' post meta value.
+ * This class is responsible for getting subscriptions for users.
  *
  * @version  1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
- * @category Class
- * @author   Prospress
  */
 class WCS_Customer_Store_CPT extends WCS_Customer_Store {
 
@@ -31,7 +29,7 @@ class WCS_Customer_Store_CPT extends WCS_Customer_Store {
 	}
 
 	/**
-	 * Get the IDs for a given user's subscriptions by querying post meta.
+	 * Get the IDs for a given user's subscriptions.
 	 *
 	 * @param int $user_id The id of the user whose subscriptions you want.
 	 * @return array
@@ -42,25 +40,16 @@ class WCS_Customer_Store_CPT extends WCS_Customer_Store {
 			return array();
 		}
 
-		$query = new WP_Query();
-
-		return $query->query( array(
-			'post_type'           => 'shop_subscription',
-			'posts_per_page'      => -1,
-			'post_status'         => 'any',
-			'orderby'             => array(
-				'date' => 'DESC',
-				'ID'   => 'DESC',
-			),
-			'fields'              => 'ids',
-			'no_found_rows'       => true,
-			'ignore_sticky_posts' => true,
-			'meta_query'          => array(
-				array(
-					'key'   => $this->get_meta_key(),
-					'value' => $user_id,
-				),
-			),
-		) );
+		return wcs_get_orders_with_meta_query(
+			[
+				'type'        => 'shop_subscription',
+				'customer_id' => $user_id,
+				'limit'       => -1,
+				'status'      => 'any',
+				'return'      => 'ids',
+				'orderby'     => 'date',
+				'order'       => 'DESC',
+			]
+		);
 	}
 }

--- a/includes/data-stores/class-wcs-customer-store-cpt.php
+++ b/includes/data-stores/class-wcs-customer-store-cpt.php
@@ -47,7 +47,7 @@ class WCS_Customer_Store_CPT extends WCS_Customer_Store {
 				'limit'       => -1,
 				'status'      => 'any',
 				'return'      => 'ids',
-				'orderby'     => 'date',
+				'orderby'     => 'ID',
 				'order'       => 'DESC',
 			]
 		);


### PR DESCRIPTION
Fixes #283 

## Description

When HPOS is enabled, navigating to **My Account > Subscriptions** shows an empty list of subscriptions. This is because in our `get_users_subscription_ids()` function we're querying for `shop_subscription`'s posts using a direct DB query on thewp-posts table.

In this PR, I've updated this DB query to fetch subscriptions using our new `wcs_get_orders_with_meta_query()`. With this change, navigating to My Account > Subscriptions shows a list of your subscriptions:

![image](https://user-images.githubusercontent.com/2275145/202961767-a6603343-fda7-4dcd-b4d8-b0584ac177f5.png)

### Changes/Differences
There are some differences between the old query and this new query but they're very minor:
 - there are no alternatives for `'no_found_rows' => true, 'ignore_sticky_posts' => true,` query params (these aren't relevant)
 - you cannot order by multiple columns (previously we ordered by date, then ID)

Out of these two differences, the only one that stands out for me is not being able to order by multiple columns, however, I don't think this is really an issue.

Previously we ordered by the date of the subscription first and then if there were two subscriptions at the same time, we ordered by the ID. With these new changes, we're only going to order by ID now.

> **Note**
> This PR does not get rid of the `private $meta_key;` now that we're not using it because this is still being used by the class that extends this one (`WCS_Customer_Store_Cached_CPT`)
>
> This will be addressed in a much bigger change when we refactor how we manage and update our `'_wcs_subscription_ids_cache'` usermeta. Currently we use our `WCS_Post_Meta_Cache_Manager_Many_To_One` class and watch for changes to `_customer_user` meta to update our cache, but with HPOS enabled, the order/subscription user ID is not stored in order metadata anymore, it's in the main order table.
>
> I will create a separate issue to address this one.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**With HPOS enabled on your store.**

1. Purchase any number of subscriptions.
2. Go My Account > Subscriptions
3. On `trunk` you'll see a notice saying "You have no active subscriptions."
4. Switch to this branch and delete any rows in usermeta with key `_wcs_subscription_ids_cache`
5. Refresh the My Account > Subscriptions page and your subscriptions will be loaded.

**Without HPOS**

1. Purchase any number of subscriptions.
2. Go My Account > Subscriptions
3. Make sure the subscriptions list is still loading

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
