### PR TITLE
Fix wcs_get_orders_with_meta_query() when the 'any' status passed on HPOS stores

### DIFF
--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -397,7 +397,7 @@ function wcs_get_orders_with_meta_query( $args ) {
 	 * If we're querying for subscriptions, we need to map 'any' to be all valid subscription statuses otherwise it would just search for order statuses.
 	 */
 	if ( isset( $args['status'], $args['type'] ) &&
-		[ 'any' ] === $args['status'] &&
+		[ 'any' ] === (array) $args['status'] &&
 		'shop_subscription' === $args['type'] &&
 		$is_hpos_in_use
 	) {


### PR DESCRIPTION
## Description

In `wcs_get_subscriptions()` we cast all statuses to an array, including the 'any' string ([see code](https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/wcs-functions.php#L435)). To fix issues with the 'any' string not working on stores with HPOS, we added some extra code to the `wcs_get_orders_with_meta_query()` to map the `[ 'any' ]` status to an array of all subscription statuses.

This mapping doesn't apply the fix to other areas of our code where we pass 'any' as a string (not an array).

This PR fixes this issue by always casting the value of `$args[ 'status' ]` to an array before comparing it to `[ 'any' ]`.

## Changelog

No changelog is needed for this PR as we already have:

```
* Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
```

This applies to this fix as well.