### PR TITLE
Fix renewal orders on HPOS having no items on the returned order instance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,6 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
-* Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
+* Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@
 * Fix - On HPOS stores, when querying for subscriptions with wcs_get_orders_with_meta_query() with status 'any', ensure that wc_get_orders() queries for subscription statuses.
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
-* Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
+* Fix - Return a fresh instance of the renewal order after creating it. Fixes caching issues on HPOS sites where the returned order has no line items.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -214,7 +214,17 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		// If we got here, the subscription was created without problems
 		$transaction->commit();
 
-		return apply_filters( 'wcs_new_order_created', $new_order, $subscription, $type );
+		/**
+		 * Filters the new order created from the subscription.
+		 *
+		 * Fetches a fresh instance of the the order because the current order instance has an empty line item cache generated before we copied the line items.
+		 * Fetching a new instance will ensure the line items are available.
+		 *
+		 * @param WC_Order        $new_order    The new order created from the subscription.
+		 * @param WC_Subscription $subscription The subscription the order was created from.
+		 * @param string          $type         The type of order being created. Either 'renewal_order' or 'resubscribe_order'.
+		 */
+		return apply_filters( 'wcs_new_order_created', wc_get_order( $new_order->get_id() ), $subscription, $type );
 
 	} catch ( Exception $e ) {
 		// There was an error adding the subscription

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -217,8 +217,8 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		/**
 		 * Filters the new order created from the subscription.
 		 *
-		 * Fetches a fresh instance of the the order because the current order instance has an empty line item cache generated before we copied the line items.
-		 * Fetching a new instance will ensure the line items are available.
+		 * Fetches a fresh instance of the order because the current order instance has an empty line item cache generated before we had copied the line items.
+		 * Fetching a new instance will ensure the line items are available via $new_order->get_items().
 		 *
 		 * @param WC_Order        $new_order    The new order created from the subscription.
 		 * @param WC_Subscription $subscription The subscription the order was created from.


### PR DESCRIPTION
fixes #291

## Description

This PR fixes a complicated caching issue that only impacts HPOS sites. 

When we create a renewal order via `wcs_create_order_from_subscription()` we create a basic order, copy the meta data and then the line items. 

On HPOS sites WC when they save the order they call `$order->get_data()` which calls `$order->get_items()`. Calling `get_items()` before we've copied the line items over results in the order generating a `$order->items` cache that is empty. This cache isn't cleared when we copy the items over and therefore any function which uses the order instance returned from the `wcs_create_order_from_subscription()` and calls `$order->get_items()` (like the `payment_completed()` → `needs_processing()` functions) would incorrectly think the order has no items. This can result in the order being auto-completed, for example. 

This PR fixes that by returning a fresh instance of the order object after the items have been copied so the order's `items` instance cache isn't populated with invalid data.

<details>
  <summary><code>get_items</code> trace</summary>

The `WC_Order::get_items()` call that results in an empty items cache being set on HPOS sites.
  
```
#0 wp-content/plugins/woocommerce/includes/class-wc-order.php(473): WC_Abstract_Order->get_items(Array)
#1 wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(1685): WC_Order->get_data()
#2 wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(1609): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->get_db_row_from_order(Object(WC_Order), Array, false)
#3 wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(1570): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->get_db_rows_for_order(Object(WC_Order), 'create', false)
#4 wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(1993): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->persist_order_to_db(Object(WC_Order), false)
#5 wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(1959): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->persist_save(Object(WC_Order))
#6 wp-content/plugins/woocommerce/includes/class-wc-data-store.php(186): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->create(Object(WC_Order))
#7 wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php(212): WC_Data_Store->create(Object(WC_Order))
#8 wp-content/plugins/woocommerce/includes/class-wc-order.php(244): WC_Abstract_Order->save()
#9 wp-content/plugins/woocommerce/includes/wc-core-functions.php(133): WC_Order->save()
#10 wp-content/plugins/woocommerce-subscriptions-core/includes/wcs-order-functions.php(183): wc_create_order(Array)
#11 wp-content/plugins/woocommerce-subscriptions-core/includes/wcs-renewal-functions.php(29): wcs_create_order_from_subscription(Object(WC_Subscription), 'renewal_order')
```

</details>

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Via early renewal flow:**

1. Prerequisite: 
    1. HPOS tables enabled
    3. WC Payments
    4. WC Subscriptions (extension)
    5. Early renewal via modal enabled (see screenshot of **WC → Settings → Subscriptions** settings below)
6. Purchase a subscription using WC payments.
7. Go to the **My Account → View subscription** and click the **Renew now** button. 
8. Click the **Pay now** button
    - On `trunk` the renewal order will have a completed status.
    - On this branch the renewal order will have a processing status.

**Via code**

1. With HPOS tables enabled
1. Using a plugin like WP Console, run the following code snippet:

```php
$subscription = wcs_get_subscription( 711 ); 

$renewal_order = wcs_create_order_from_subscription( $subscription, 'renewal_order' );

echo count( $renewal_order->get_items() ); 
```

On `trunk` that will output `0` on this branch it will output the number of items on the renewal order.

<img width="1034" alt="Screen Shot 2022-11-21 at 4 38 21 pm" src="https://user-images.githubusercontent.com/8490476/202993137-ab5c5ffe-ee93-410d-b43c-fc74e2512091.png">

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
