### PR TITLE
[HPOS] Refactor `wcs_is_subscription` helper function to support HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - On HPOS stores, when saving a subscription make sure subscription properties (ie `_requires_manual_renewal`) are saved to the database.
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
 * Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
+* Update - Refactor the `wcs_is_subscription` helper function to support HPOS.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Dev - Removed the deprecated "wcs_subscriptions_for_{$relation_type}_order" dynamic hook used to filter the list of related subscriptions for the given relation type. The following hooks have been removed with no alternative:
         wcs_subscriptions_for_renewal_order

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -30,9 +30,11 @@ if ( is_admin() ) {
 
 /**
  * Check if a given object is a WC_Subscription (or child class of WC_Subscription), or if a given ID
- * belongs to a post with the subscription post type ('shop_subscription')
+ * belongs to a post with the subscription post type ('shop_subscription').
  *
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+ *
+ * @param mixed $subscription A WC_Subscription object or post ID
  * @return boolean true if anything is found
  */
 function wcs_is_subscription( $subscription ) {

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -30,7 +30,7 @@ if ( is_admin() ) {
 
 /**
  * Check if a given object is a WC_Subscription (or child class of WC_Subscription), or if a given ID
- * belongs to a post with the subscription post type ('shop_subscription').
+ * belongs to a post or order with type ('shop_subscription').
  *
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
  *

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -39,7 +39,7 @@ function wcs_is_subscription( $subscription ) {
 
 	if ( is_object( $subscription ) && is_a( $subscription, 'WC_Subscription' ) ) {
 		$is_subscription = true;
-	} elseif ( is_numeric( $subscription ) && 'shop_subscription' == get_post_type( $subscription ) ) {
+	} elseif ( is_numeric( $subscription ) && 'shop_subscription' === WC_Data_Store::load( 'subscription' )->get_order_type( $subscription ) ) {
 		$is_subscription = true;
 	} else {
 		$is_subscription = false;

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -34,7 +34,7 @@ if ( is_admin() ) {
  *
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
  *
- * @param mixed $subscription A WC_Subscription object or post ID
+ * @param mixed $subscription A WC_Subscription object or an ID.
  * @return boolean true if anything is found
  */
 function wcs_is_subscription( $subscription ) {


### PR DESCRIPTION
Partially fixes #288

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR refactors the `wcs_is_subscription` helper function to support HPOS-enabled stores by replacing the usage of `get_post_type()` with `WC_Data_Store::load( 'subscription' )->get_order_type( $subscription )`.

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure PHP unit tests pass. ([See test for `wcs_is_subscription`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/f8d92df04d61d1e313f7020bc43d1eb629dfc4fe/tests/unit/test-wcs-functions.php#L61-L93) which covers various argument types)
2. This function is used in various places throughout subs-core. Therefore basic smoke-testing is encouraged with HPOS enabled & disabled.

We should lean on our intended pre-release testing of critical flows for broadly-impactful changes such as this.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **Not applicable**
