### PR TITLE
[HPOS] Backfill related orders cache meta to prevent posts and orders have out-of-sync metadata when HPOS and data sync is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - On HPOS stores, when a subscription is loaded from the database, make sure all core subscription properties are read directly from meta.
 * Fix - On HPOS stores, ensure payment tokens are copied from the subscription to the renewal order.
 * Fix - Return a fresh instance of the renewal order after creating it. Fixes caching issues on HPOS sites where the returned order has no line items.
+* Fix - Processing a manual renewal order with HPOS and data syncing enabled correctly saves the related order cache metadata on the subscription and prevents the post and order meta data getting out of sync.
 * Update - Refactor the `wcs_is_subscription` helper function to support HPOS.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Update - Display related orders table when viewing the new "Edit Order" page (HPOS enabled stores).

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -563,13 +563,15 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	/**
 	 * Gets the subscription's related order cached stored in meta.
 	 *
-	 * @param WC_Subscription $subscription The subscription to get the cache meta for.
-	 * @param string $relation_type         The relation type to get the cache meta for.
+	 * @param WC_Subscription $subscription  The subscription to get the cache meta for.
+	 * @param string          $relation_type The relation type to get the cache meta for.
+	 * @param mixed           $data_store    The data store to use to get the meta. Defaults to the current subscription's data store.
 	 *
 	 * @return stdClass|bool The meta data object if it exists, or false if it doesn't.
 	 */
-	protected function get_related_order_metadata( WC_Subscription $subscription, $relation_type ) {
+	protected function get_related_order_metadata( WC_Subscription $subscription, $relation_type, $data_store = null ) {
 		$cache_meta_key = $this->get_cache_meta_key( $relation_type );
+		$data_store     = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
 
 		/**
 		 * Bypass the related order cache keys being ignored when fetching subscription meta.
@@ -581,7 +583,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		 * the function in all instances.
 		 */
 		self::$override_ignored_props = true;
-		$subscription_meta            = WC_Data_Store::load( 'subscription' )->read_meta( $subscription );
+		$subscription_meta            = $data_store->read_meta( $subscription );
 		self::$override_ignored_props = false;
 
 		foreach ( $subscription_meta as $meta ) {

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -272,17 +272,26 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			$updated_meta = $subscription_data_store->add_meta( $subscription, (object) $new_metadata );
 		}
 
+		// Check if HPOS and data syncing is enabled then manually backfill the related orders cache values to WP Posts table.
 		$this->maybe_backfill_related_order_cache( $subscription, $relation_type, $new_metadata );
 
 		return $updated_meta;
 	}
 
 	/**
-	 * Backfills the related order cache for a subscription if data sync is enabled.
+	 * Backfills the related order cache for a subscription when the "Keep the posts table and the orders tables synchronized"
+	 * setting is enabled.
 	 *
-	 * @param WC_Subscription $subscription
-	 * @param array           $metadata
-	 * @param string          $relation_type
+	 * In this class we update the related orders cache metadata directly to ensure the
+	 * proper value is written to the database. To do this we use the data store's update_meta() and
+	 * add_meta() functions.
+	 *
+	 * Using these functions bypasses the DataSynchronizer resulting in order and post data becoming out of sync.
+	 * To fix this, this function manually updates the post meta table with the new values.
+	 *
+	 * @param WC_Subscription $subscription  The subscription object to backfill.
+	 * @param array           $metadata      The metadata to set update/add in the CPT data store.
+	 * @param string          $relation_type The relationship between the subscription and the order.
 	 */
 	protected function maybe_backfill_related_order_cache( $subscription, $relation_type, $metadata ) {
 		if ( ! wcs_is_custom_order_tables_usage_enabled() || ! wcs_is_custom_order_tables_data_sync_enabled() || empty( $metadata['key'] ) ) {

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -264,18 +264,16 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			'value' => $related_order_ids,
 		);
 
-		// If there is metadata for this key, update it, otherwise add it.
-		if ( $current_metadata ) {
-			$new_metadata['id'] = $current_metadata->meta_id;
-			$updated_meta       = $subscription_data_store->update_meta( $subscription, (object) $new_metadata );
-		} else {
-			$updated_meta = $subscription_data_store->add_meta( $subscription, (object) $new_metadata );
-		}
-
 		// Check if HPOS and data syncing is enabled then manually backfill the related orders cache values to WP Posts table.
 		$this->maybe_backfill_related_order_cache( $subscription, $relation_type, $new_metadata );
 
-		return $updated_meta;
+		// If there is metadata for this key, update it, otherwise add it.
+		if ( $current_metadata ) {
+			$new_metadata['id'] = $current_metadata->meta_id;
+			return $subscription_data_store->update_meta( $subscription, (object) $new_metadata );
+		} else {
+			return $subscription_data_store->add_meta( $subscription, (object) $new_metadata );
+		}
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -288,8 +288,8 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 * To fix this, this function manually updates the post meta table with the new values.
 	 *
 	 * @param WC_Subscription $subscription  The subscription object to backfill.
-	 * @param array           $metadata      The metadata to set update/add in the CPT data store.
-	 * @param string          $relation_type The relationship between the subscription and the order.
+	 * @param string          $relation_type The related order relationship type. Can be 'renewal', 'switch' or 'resubscribe'.
+	 * @param array           $metadata      The metadata to set update/add in the CPT data store. Should be an array with 'key' and 'value' keys.
 	 */
 	protected function maybe_backfill_related_order_cache( $subscription, $relation_type, $metadata ) {
 		if ( ! wcs_is_custom_order_tables_usage_enabled() || ! wcs_is_custom_order_tables_data_sync_enabled() || empty( $metadata['key'] ) ) {

--- a/includes/wcs-compatibility-functions.php
+++ b/includes/wcs-compatibility-functions.php
@@ -592,7 +592,7 @@ function wcs_is_wc_feature_enabled( $feature_name ) {
 }
 
 /**
- * Helper function to determine whether custom orders table usage is enabled.
+ * Determines whether custom order tables usage is enabled.
  *
  * Custom order table feature can be enabled but the store is still using WP posts as the authoriative source of order data,
  * therefore this function will only return true if:
@@ -611,9 +611,9 @@ function wcs_is_custom_order_tables_usage_enabled() {
 }
 
 /**
- * Helper function to determine whether orders tables are synchronized with WP posts.
+ * Determines whether the order tables are synchronized with WP posts.
  *
- * @return bool
+ * @return bool True if the order tables are synchronized with WP posts, false otherwise.
  */
 function wcs_is_custom_order_tables_data_sync_enabled() {
 	if ( ! class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer' ) ) {

--- a/includes/wcs-compatibility-functions.php
+++ b/includes/wcs-compatibility-functions.php
@@ -609,3 +609,18 @@ function wcs_is_custom_order_tables_usage_enabled() {
 
 	return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
 }
+
+/**
+ * Helper function to determine whether orders tables are synchronized with WP posts.
+ *
+ * @return bool
+ */
+function wcs_is_custom_order_tables_data_sync_enabled() {
+	if ( ! class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer' ) ) {
+		return false;
+	}
+
+	$data_synchronizer = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer::class );
+
+	return $data_synchronizer && $data_synchronizer->data_sync_is_enabled();
+}


### PR DESCRIPTION
Fixes #294 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

While testing our manual renewal process flows, I discovered an issue where after processing the renewal order the new pending renewal order was not showing up in table found on **My Account > Subscriptions > View Subscription**, under the Related Orders section.

After some investigation, I found this problem only occurs when HPOS and the "Keep data in sync" setting is enabled and was effectively caused by the post and order tables being out of sync.
In other words, the subscription in the posts table didn't have any value set for the `_subscription_renewal_order_ids_cache` post meta and the Subscription in the orders table did have this meta set.

When the order and post data are out of sync, WC runs their `maybe_sync_order()` function which checks both the order and posts modified dates and if the post has a later or equal modified date, we migrate the post data over to the order data.

This is what was causing our HPOS order metadata to be overridden by an empty `_subscription_renewal_order_ids_cache` value.

To fix this problem, when HPOS and DataSynchronizer are enabled, when we update our related orders cache meta stored on a subscription, we now also manually backfill the data to keep it in sync.

**Changes in this PR:**
 - https://github.com/Automattic/woocommerce-subscriptions-core/pull/295/commits/6fea99c7fa28b8e5b265b867c3ec14f36d08809d - New `wcs_is_custom_order_tables_data_sync_enabled()` helper function 
 - https://github.com/Automattic/woocommerce-subscriptions-core/pull/295/commits/cf97db3633991c7b450bc3a2c23d45901bb003b6 - Update our `get_related_order_metadata()` function to accept a data store param to fetch metadata from
 - d8ef72c3cb7a485ce4bb299f2ca43122dedc3bcd - Backfill related order cache metadata when HPOS and data syncing is turned on

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Test using flows

1. Enable HPOS and turn on the "Keep the posts table and the orders tables synchronized" setting
2. Purchase a subscription product with a manual payment method (BACs)
3. Activate the subscription by setting the parent order status to processing or completed
4. Go **WP Admin > Tools > Scheduled Actions** and search for the new subscription ID
5. Under the `woocommerce_scheduled_subscription_payment` pending action press "Run"
6. Navigate to **My Account > Subscriptions** and view your new subscription
7. On `trunk` you will notice the subscription is now `on-hold` but there's no pending payment order in the related orders table
8. On this branch the subscription is still `on-hold` (expected as this is a manual payment method) and there will be a pending order in the related orders table.

#### Test using code

You can quickly set a subscription to active and process a renewal order using code:

```
$subscription = wcs_get_subscription( 123 );
$subscription->update_status( 'active' );

do_action( 'woocommerce_scheduled_subscription_payment', $subscription->get_id() );
```

Then reload the My Account View Subscription page

![image](https://user-images.githubusercontent.com/2275145/203240022-d1e804fe-7ecd-421e-8691-46741f5d53c5.png)


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? no - manual payment methods aren't available
- [x] Will this PR affect WooCommerce Payments? yes
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
