### PR TITLE
Backfill our related orders meta saved on orders when HPOS and data syncing is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Refactor `WCS_Meta_Box_Schedule::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.
 * Fix - Return a fresh instance of the renewal order after creating it. Fixes caching issues on HPOS sites where the returned order has no line items.
 * Fix - Processing a manual renewal order with HPOS and data syncing enabled correctly saves the related order cache metadata on the subscription and prevents the post and order meta data getting out of sync.
+* Fix - With HPOS and data syncing enabled, updating the status of a pending manual renewal order to a paid status correctly activates the related subscription.
 * Update - Refactor the `wcs_is_subscription` helper function to support HPOS.
 * Update - Refactor our Related Orders data store classes (WCS_Related_Order_Store_Cached_CPT and WCS_Related_Order_Store_CPT) to use CRUD methods to support subscriptions and orders stored in HPOS.
 * Update - Display related orders table when viewing the new "Edit Order" page (HPOS enabled stores).
@@ -20,6 +21,7 @@
         wcs_subscriptions_for_switch_order
         wcs_subscriptions_for_resubscribe_order
 * Dev - Introduce a WC_Subscription::set_status() function to handle subscriptions set with a draft or auto-draft status. Replaces the need for the overriding WC_Subscription::get_status() which has been deleted.
+* Dev - Manual renewal orders created with HPOS and data syncing enabled are properly linked to the subscription by its `_subscription_renewal` meta and backfilled to posts table.
 
 = 5.0.0 - 2022-11-14 =
 * Dev - The library has been bumped to version to 5.0.0 to reduce confusion with the version of WooCommerce Subscriptions.

--- a/includes/data-stores/class-wcs-related-order-store-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cpt.php
@@ -101,7 +101,7 @@ class WCS_Related_Order_Store_CPT extends WCS_Related_Order_Store {
 
 		if ( empty( $existing_relations ) || ! in_array( $subscription_id, $existing_related_ids, true ) ) {
 			$order->add_meta_data( $related_order_meta_key, $subscription_id, false );
-			$order->save_meta_data();
+			$order->save();
 		}
 	}
 
@@ -123,7 +123,7 @@ class WCS_Related_Order_Store_CPT extends WCS_Related_Order_Store {
 			}
 		}
 
-		$order->save_meta_data();
+		$order->save();
 	}
 
 	/**
@@ -135,7 +135,7 @@ class WCS_Related_Order_Store_CPT extends WCS_Related_Order_Store {
 	public function delete_relations( WC_Order $order, $relation_type ) {
 		$related_order_meta_key = $this->get_meta_key( $relation_type );
 		$order->delete_meta_data( $related_order_meta_key );
-		$order->save_meta_data();
+		$order->save();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #302

## Description

When HPOS is enabled and data syncing is turned on, processing a manual renewal order doesn't properly save and backfill the related orders metadata in the orders and posts table.

This data being out-of-sync between posts and orders results in the related order metadata being cleared from the order metatable. This issue causes the following flows to break when HPOS + DataSyncing is enabled:

 - When viewing the order on the My Account page, the Related Subscriptions table isn't loaded.
 - Setting the status of the on-hold renewal order to processing or completed wasn't activating the subscription
 - Renewal order doesn't have a related order table on the Edit Order admin page.

After investigating the problem, I found that calling `$order->save_meta_data()` doesn't backfill the meta data when HPOS + Syncing is enabled, so this PR replaces `save_meta_data()` with just `save()`.

## How to test this PR

1. Turn on HPOS and turn on syncing data between tables
2. Set the authoritative data store to COT
3. In **WooCommerce > Settings > Subscriptions**, turn on the "Accept Manual Renewals" setting
4. Purchase a subscription product with a BACs gateway
5. While on `trunk`, activate the subscription and process a renewal order (either using action scheduler or the code snippet below)
6. Navigate to **My Account > Orders**, view your new renewal order
7. Scroll down and notice no Related Subscriptions table is shown :x:
8. Mark the order has processing/completed status and notice the related subscription is still on-hold :x:
9. Check out this branch and process another renewal
10. Navigate to **My Account > Orders**, again and confirm that the Related Subscriptions table is loading
11. Mark the order has processing/completed status and confirm the related subscription is active

**Snippet to process subscription renewal via code:**
```
$subscription = wcs_get_subscription( 813 );
$subscription->update_status( 'active' );
do_action( 'woocommerce_scheduled_subscription_payment', $subscription->get_id() );
```

![image](https://user-images.githubusercontent.com/2275145/203491677-ed22a724-b071-4f7b-9fdd-bc19202a4307.png)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
