### PR TITLE
Remove all get_post_type() from WC_Subscriptions_Manager.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.2.0 - 2022-xx-xx =
+* Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
+
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.
 * Fix - Infinite loop that can occur with `WCS_Orders_Table_Subscription_Data_Store::read_multiple()` on HPOS-enabled stores.

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -851,7 +851,6 @@ class WC_Subscriptions_Manager {
 			return;
 		}
 
-		// Check its type because $subscription might be WC_Subscription's child class.
 		if ( $subscription->get_type() !== 'shop_subscription' ) {
 			return;
 		}
@@ -883,7 +882,6 @@ class WC_Subscriptions_Manager {
 			return;
 		}
 
-		// Check the object type is shop_subscription
 		if ( $subscription->get_type() !== 'shop_subscription' ) {
 			return;
 		}

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -892,8 +892,8 @@ class WC_Subscriptions_Manager {
 			return;
 		}
 
-		if ( ! in_array( get_post_meta( $post_id, '_wp_trash_meta_status', true ), array( 'wc-pending', 'wc-expired', 'wc-cancelled' ), true ) ) {
-			update_post_meta( $post_id, '_wp_trash_meta_status', 'wc-cancelled' );
+		if ( ! in_array( get_post_meta( $id, '_wp_trash_meta_status', true ), array( 'wc-pending', 'wc-expired', 'wc-cancelled' ), true ) ) {
+			update_post_meta( $id, '_wp_trash_meta_status', 'wc-cancelled' );
 		}
 	}
 

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -856,10 +856,6 @@ class WC_Subscriptions_Manager {
 			return;
 		}
 
-		if ( 'auto-draft' === $subscription->get_status() ) {
-			return;
-		}
-
 		if ( $subscription->can_be_updated_to( 'cancelled' ) ) {
 
 			$subscription->update_status( 'cancelled' );

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -883,7 +883,7 @@ class WC_Subscriptions_Manager {
 			return;
 		}
 
-		// Check its type because $subscription might be WC_Subscription's child class.
+		// Check the object type is shop_subscription
 		if ( $subscription->get_type() !== 'shop_subscription' ) {
 			return;
 		}


### PR DESCRIPTION
Partially fixes https://github.com/Automattic/woocommerce-subscriptions-core/issues/288.

## Description

Replace `get_post_type()` usage from `WC_Subscriptions_Manager`.

## How to test this PR

Not sure what's the best way to test but I use WP Console to call the affected function directly, eg `WC_Subscriptions_Manager::maybe_cancel_subscription( $id )`.
I tested with $id that belongs to a subscription and one that does not. Also, I tested with HPOS disabled and enabled and with WC version 6.8 (prior HPOS).

Note: I haven't added a changelog. Will add one after 5.1 is released.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
