### PR TITLE
Replace trivial instances of `get_post_type()` usage (take 1)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.2.0 - 2022-xx-xx =
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
+* Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -1529,7 +1529,7 @@ class WC_Subscriptions_Synchroniser {
 	public static function get_sign_up_fee( $sign_up_fee, $order, $product_id, $non_subscription_total ) {
 		_deprecated_function( __METHOD__, '2.0', __CLASS__ . '::get_synced_sign_up_fee' );
 
-		if ( 'shop_order' === WC_Data_Store::load( 'subscription' )->get_order_type( $order ) && self::order_contains_synced_subscription( wcs_get_objects_property( $order, 'id' ) ) && WC_Subscriptions_Order::get_subscription_trial_length( $order ) < 1 ) {
+		if ( 'shop_order' === WC_Data_Store::load( 'order' )->get_order_type( $order ) && self::order_contains_synced_subscription( wcs_get_objects_property( $order, 'id' ) ) && WC_Subscriptions_Order::get_subscription_trial_length( $order ) < 1 ) {
 			$sign_up_fee = max( WC_Subscriptions_Order::get_total_initial_payment( $order ) - $non_subscription_total, 0 );
 		}
 

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -1529,7 +1529,7 @@ class WC_Subscriptions_Synchroniser {
 	public static function get_sign_up_fee( $sign_up_fee, $order, $product_id, $non_subscription_total ) {
 		_deprecated_function( __METHOD__, '2.0', __CLASS__ . '::get_synced_sign_up_fee' );
 
-		if ( 'shop_order' == get_post_type( $order ) && self::order_contains_synced_subscription( wcs_get_objects_property( $order, 'id' ) ) && WC_Subscriptions_Order::get_subscription_trial_length( $order ) < 1 ) {
+		if ( 'shop_order' === WC_Data_Store::load( 'subscription' )->get_order_type( $order ) && self::order_contains_synced_subscription( wcs_get_objects_property( $order, 'id' ) ) && WC_Subscriptions_Order::get_subscription_trial_length( $order ) < 1 ) {
 			$sign_up_fee = max( WC_Subscriptions_Order::get_total_initial_payment( $order ) - $non_subscription_total, 0 );
 		}
 

--- a/includes/class-wcs-cached-data-manager.php
+++ b/includes/class-wcs-cached-data-manager.php
@@ -110,7 +110,7 @@ class WCS_Cached_Data_Manager extends WCS_Cache_Manager {
 		wcs_deprecated_argument( __METHOD__, '2.3.0', sprintf( __( 'Customer subscription caching is now handled by %1$s and %2$s.', 'woocommerce-subscriptions' ), 'WCS_Customer_Store_Cached_CPT', 'WCS_Post_Meta_Cache_Manager' ) ); // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
 
 		// Ensure we're handling a meta key we actually care about.
-		if ( '_customer_user' !== $meta_key || 'shop_subscription' !== get_post_type( $object_id ) ) {
+		if ( '_customer_user' !== $meta_key || 'shop_subscription' !== WC_Data_Store::load( 'subscription' )->get_order_type( $object_id ) ) {
 			return;
 		}
 

--- a/includes/class-wcs-download-handler.php
+++ b/includes/class-wcs-download-handler.php
@@ -143,25 +143,31 @@ class WCS_Download_Handler {
 	 * Repairs a glitch in WordPress's save function. You cannot save a null value on update, see
 	 * https://github.com/woocommerce/woocommerce/issues/7861 for more info on this.
 	 *
-	 * @param integer $post_id The ID of the subscription
+	 * @param integer $id The ID of the subscription
 	 */
-	public static function repair_permission_data( $post_id ) {
-		if ( absint( $post_id ) !== $post_id ) {
+	public static function repair_permission_data( $id ) {
+		if ( absint( $id ) !== $id ) {
 			return;
 		}
 
-		if ( 'shop_subscription' !== get_post_type( $post_id ) ) {
+		if ( 'shop_subscription' !== WC_Data_Store::load( 'subscription' )->get_order_type( $id ) ) {
 			return;
 		}
 
 		global $wpdb;
 
-		$wpdb->query( $wpdb->prepare( "
-			UPDATE {$wpdb->prefix}woocommerce_downloadable_product_permissions
-			SET access_expires = null
-			WHERE order_id = %d
-			AND access_expires = %s
-		", $post_id, '0000-00-00 00:00:00' ) );
+		$wpdb->query(
+			$wpdb->prepare(
+				"
+				UPDATE {$wpdb->prefix}woocommerce_downloadable_product_permissions
+				SET access_expires = null
+				WHERE order_id = %d
+				AND access_expires = %s
+				",
+				$id,
+				'0000-00-00 00:00:00'
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Partially fixes https://github.com/Automattic/woocommerce-subscriptions-core/issues/288.

## Description

This PR replaces the usage of `get_post_type()` with `WC_Data_Store::load( 'subscription' )->get_order_type( $id )`. There are more `get_post_type()` to be replaced but in this PR, I just replaced ones that are trivial enough.

## How to test this PR

For `WC_Subscriptions_Synchroniser::get_sign_up_fee()`

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
