### PR TITLE
Avoid getting a new instance of the subscription in `get_related_order_ids()` removes infinite loop potential

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.2.0 - 2022-xx-xx =
+* - Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
+
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.
 * Fix - Infinite loop that can occur with `WCS_Orders_Table_Subscription_Data_Store::read_multiple()` on HPOS-enabled stores.

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -98,8 +98,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 * @return array An array of related order IDs.
 	 */
 	public function get_related_order_ids( WC_Order $subscription, $relation_type ) {
-		$subscription_id   = $subscription->get_id();
-		$related_order_ids = $this->get_related_order_ids_from_cache( $subscription_id, $relation_type );
+		$related_order_ids = $this->get_related_order_ids_from_cache( $subscription, $relation_type );
 
 		// get_related_order_ids_from_cache() returns false if the ID is invalid. This can arise when the subscription hasn't been created yet. In any case, the related IDs should be an empty array to avoid a boolean return from this function.
 		if ( false === $related_order_ids ) {
@@ -111,7 +110,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 
 			// If the cache is empty attempt to get the renewal order IDs from the old transient cache.
 			if ( 'renewal' === $relation_type ) {
-				$transient_key = "wcs-related-orders-to-{$subscription_id}"; // Despite the name, this transient only stores renewal orders, not all related orders, so we can only use it for finding renewal orders.
+				$transient_key = "wcs-related-orders-to-{$subscription->get_id()}"; // Despite the name, this transient only stores renewal orders, not all related orders, so we can only use it for finding renewal orders.
 
 				// We do this here rather than in get_related_order_ids_from_cache(), because we want to make sure the new persistent cache is updated too.
 				$related_order_ids = get_transient( $transient_key );


### PR DESCRIPTION
Fixes #311 

I've given this issue a low priority as I haven't seen reports of this issue, however this is a small change and a preemptive fix and slightly improves performance by avoiding getting a subscription object instance unnecessarily.
 
## Description

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/256, we changed `get_related_order_ids_from_cache()` so that it can accept both an ID or a subscription object, was necessary because before it use to only receive an ID and call `get_post_meta()`

<img width="876" alt="Screen Shot 2022-11-25 at 3 19 19 pm" src="https://user-images.githubusercontent.com/8490476/203906510-e6b1ea19-175b-451a-941b-e008db2767ed.png">

To make this function compatible with HPOS, while maintaining backwards compatible, `get_related_order_ids_from_cache()` was changed to support receiving a subscription ID or object. Now when an ID is passed, we need to get the object so we can pull the metadata out of it. 

In the process of that PR we tried to make sure we pass the subscription objects around instead of IDs to avoid having to get whole new instances which is ever so slightly less performance friendly and completely unnecessary. On top of that it turns out that getting a new instance where it is unnecessary may also lead to infinite loops if a third-party attempts to get a subscription's related orders while the subscription is being read (loaded).

`wcs_get_subscription() → get_related_order_ids_from_cache() → wcs_get_subscription() → get_related_order_ids_from_cache() → ...`

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To replicate the infinite loop you have to add code that attempts to get the subscription's related orders while the subscription is being read. I've included an example snippet below: 

```
// Example of 3rd party code attempting to get a subscription's related order IDs while the subscription is being loaded.
// The hook being used in this example is 'woocommerce_subscription_get_schedule_next_payment' which is triggered while the subscription is being read.
add_filter( 'woocommerce_subscription_get_schedule_next_payment', function ( $next_payment, $subscription ) {
    $subscription->get_related_orders( 'ids', ['renewal'] );
    return $next_payment;
}, 10, 2 );

wcs_get_subscription( 899 );
```

On `trunk` that will lead to an infinite loop, on this branch it wont. Because this changes the `get_related_order_ids()` function, related order related tests should also be ran, to make sure this doesn't have some secondary effect. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
