### PR TITLE
[HPOS] Use WC functions to set download permissions on a subscription in a data store agnostic way

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 5.2.0 - 2022-xx-xx =
+* Fix - Set the `download_permissions_granted` value when purchasing a downloadable subscription product when HPOS is enabled.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
 

--- a/includes/class-wcs-download-handler.php
+++ b/includes/class-wcs-download-handler.php
@@ -72,7 +72,8 @@ class WCS_Download_Handler {
 					}
 				}
 			}
-			update_post_meta( $subscription->get_id(), '_download_permissions_granted', 1 );
+
+			$subscription->get_data_store()->set_download_permissions_granted( $subscription, true );
 		}
 	}
 


### PR DESCRIPTION
Fixes #314 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

While testing some Customer management flows I noticed a few issues with download permission meta when HPOS is enabled:
1. The `_download_permissions_granted` were still being saved in `wp_postmeta` tables even though HPOS and data syncing are disabled
2. the `download_permissions_granted` column in the new `wp_wc_order_operational_data` table was still set to `0` on my subscription even after download permissions were granted.

How do these issues impact customers?

There are not many ways to negatively impact customers because whenever we regenerate download permissions for a subscription, we always clear all existing permissions, however, there is one way to produce a bug caused by this issue..

If you manually call `wc_downloadable_product_permissions( $subscription_id );` this function checks if permissions have been granted, if not, it then adds new permissions. Because we're not setting the permissions granted meta on the subscription, you end up with duplicate download permissions for the same item.

The changes in this PR are very simple however I wanted to confirm that I have checked:
 - these functions exist in older versions of WC Core (checked back to WC 5.0)
 - `get_data_store()->set_download_permissions_granted()` runs the same code as `update_post_meta()` in a CPT environment so it's fully backwards compatibile.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPOS
2. While on `trunk` purchase a downloadable subscription product
3. Check in the `wp_wc_order_operational_data` table and confirm the `download_permissions_granted` column for the subscription is set to `0` :x:
4. In the `wp_postmeta` confirm that `_download_permissions_granted` is set to `1` for the subscription ID :x:
5. Run the`wc_downloadable_product_permissions( 123, false );` code snippet and replace `123` with your subscription ID.
6. Confirm you have duplicate download permissions when viewing your **My Account > Downloads** page
7. Checkout this branch and purchase another downloadable subscription product
9. Check in the `wp_wc_order_operational_data` table and confirm the `download_permissions_granted` column for the subscription is set to `1`
10.  In the `wp_postmeta` confirm no `_download_permissions_granted` metadata is set when HPOS is enabled with data syncing off.
11. Run the`wc_downloadable_product_permissions( 123, false );` code snippet and replace `123` with your subscription ID.
12. Confirm there's still only one download permission for this product/subscription.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
