### PR TITLE
[HPOS] Fix customers changing subscription addresses via My Account when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.2.0 - 2022-xx-xx =
 * Fix - Refactor `WCS_Meta_Box_Subscription_Data::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.
+* Fix - Set the `download_permissions_granted` value when purchasing a downloadable subscription product when HPOS is enabled.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 5.2.0 - 2022-xx-xx =
+* Add - New wcs_set_order_address() helper function to set an array of address fields on an order or subscription.
 * Fix - Refactor `WCS_Meta_Box_Subscription_Data::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.
 * Fix - Set the `download_permissions_granted` value when purchasing a downloadable subscription product when HPOS is enabled.
+* Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
 

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -159,7 +159,6 @@ class WC_Subscriptions_Addresses {
 		}
 
 		if ( isset( $_POST['update_all_subscriptions_addresses'] ) ) {
-
 			$users_subscriptions = wcs_get_users_subscriptions( $user_id );
 
 			foreach ( $users_subscriptions as $subscription ) {

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -163,7 +163,8 @@ class WC_Subscriptions_Addresses {
 
 			foreach ( $users_subscriptions as $subscription ) {
 				if ( $subscription->has_status( array( 'active', 'on-hold' ) ) ) {
-					$subscription->set_address( $address, $address_type );
+					wcs_set_order_address( $subscription, $address, $address_type );
+					$subscription->save();
 				}
 			}
 		} elseif ( isset( $_POST['update_subscription_address'] ) ) {

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -52,12 +52,11 @@ class WC_Subscriptions_Addresses {
 	 * Add a "Change Shipping Address" button to the "My Subscriptions" table for those subscriptions
 	 * which require shipping.
 	 *
-	 * @param array $all_actions The $subscription_id => $actions array with all actions that will be displayed for a subscription on the "My Subscriptions" table
-	 * @param array $subscriptions All of a given users subscriptions that will be displayed on the "My Subscriptions" table
+	 * @param array $actions The $subscription_id => $actions array with all actions that will be displayed for a subscription on the "My Subscriptions" table
+	 * @param \WC_Subscription $subscription the Subscription object that is being viewed.
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v1.3
 	 */
 	public static function add_edit_address_subscription_action( $actions, $subscription ) {
-
 		if ( $subscription->needs_shipping_address() && $subscription->has_status( array( 'active', 'on-hold' ) ) ) {
 			$actions['change_address'] = array(
 				'url'  => add_query_arg( array( 'subscription' => $subscription->get_id() ), wc_get_endpoint_url( 'edit-address', 'shipping' ) ),

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -168,12 +168,12 @@ class WC_Subscriptions_Addresses {
 				}
 			}
 		} elseif ( isset( $_POST['update_subscription_address'] ) ) {
-
 			$subscription = wcs_get_subscription( absint( $_POST['update_subscription_address'] ) );
 
+			// Update the address only if the user actually owns the subscription
 			if ( $subscription && self::can_user_edit_subscription_address( $subscription->get_id() ) ) {
-				// Update the address only if the user actually owns the subscription
-				$subscription->set_address( $address, $address_type );
+				wcs_set_order_address( $subscription, $address, $address_type );
+				$subscription->save();
 
 				wp_safe_redirect( $subscription->get_view_order_url() );
 				exit();

--- a/includes/class-wcs-download-handler.php
+++ b/includes/class-wcs-download-handler.php
@@ -72,7 +72,8 @@ class WCS_Download_Handler {
 					}
 				}
 			}
-			update_post_meta( $subscription->get_id(), '_download_permissions_granted', 1 );
+
+			$subscription->get_data_store()->set_download_permissions_granted( $subscription, true );
 		}
 	}
 

--- a/includes/wcs-compatibility-functions.php
+++ b/includes/wcs-compatibility-functions.php
@@ -624,3 +624,26 @@ function wcs_is_custom_order_tables_data_sync_enabled() {
 
 	return $data_synchronizer && $data_synchronizer->data_sync_is_enabled();
 }
+
+/**
+ * Sets the address on an order or subscription using WC 7.1 functions if they exist.
+ *
+ * For stores pre WC 7.1, use the individual addresss type and key setter i.e. `set_billing_address_1()` method.
+ *
+ * @since 5.2.0
+ *
+ * @param WC_Order|WC_Subscription $order        The order or subscription object to set the address on.
+ * @param string                   $address_type The address type to set. Either 'billing' or 'shipping'.
+ * @param array                    $address      The address to set.
+ */
+function wcs_set_order_address( $order, $address, $address_type = 'billing' ) {
+	if ( method_exists( $order, "set_{$address_type}" ) ) {
+		$order->{"set_{$address_type}"}( $address );
+	} else {
+		foreach ( $address as $key => $value ) {
+			if ( method_exists( $order, "set_{$address_type}_{$key}" ) ) {
+				$order->{"set_{$address_type}_{$key}"}( $value );
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #316 

## Description

Customers changing subscription addresses via the My Account flow is broken on stores that enable HPOS. This is because our `maybe_update_subscription_addresses()` function was using a [WC Order Legacy `set_address()`](https://github.com/woocommerce/woocommerce/blob/4cf10ad2174de8bde62fa1b753691e2f091db413/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php#L334) method which was saving/updating the address data using `update_post_meta().

This issue affects the following flows:
 - Updating a single subscription address via the My Account > Subscription > Change Address
 - Update all subscription addresses via the My Account > Addresses and then check "Update the X Address used for all future renewals of my active subscriptions (optional)"

![image](https://user-images.githubusercontent.com/2275145/204219733-0f225392-5e4a-4e8d-9adb-7bef042a2255.png)

This PR fixes all issues with customers not being able to save/update their subscription addresses.
To fix these issues we just needed to use newer WC Order APIs to set address data.

Changes in this PR:

 - New helper function `wcs_set_order_address( $order, $address, $type )`
   - The most efficient function in WC to set an order address is using `set_billing()` and `set_shipping()` however these weren't introduced until WC 7.1, therefore this helper function acts as a compatibility function in which it will use these methods if they exist, otherwise use the alternative which is to call each individual setter (ie. `set_billing_last_name()`)
 - Update `maybe_update_subscription_addresses()` to replace Order Legacy set address() with new `wcs_set_order_address()`

Another issue I discovered was when HPOS was enabled with data syncing off, we were still setting the address fields in postmeta:

![image](https://user-images.githubusercontent.com/2275145/204222019-7512e944-b628-4b86-bae2-750c30b2f8dc.png)

This issue has also been fixed in this PR.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Changing A Single Subscription Address**

1. Enable HPOS and purchase a non-virtual subscription (must need shipping to change the address)
2. Make sure to run `DELETE FROM wp_usermeta WHERE meta_key = '_wcs_subscription_ids_cache';` so that the cache is forced to update with the latest users subscriptions.
3. Go into **My Account > Subscriptions**
4. Click on the **Change Address** action on the View Subscription page
5. Change the shipping address
6. Scroll down on the My Account View Subscription page and confirm the subscription has the updated shipping address

**Updating the address of all the users active susbcriptions**

Similarly to the above steps:

1. Enable HPOS and purchase a non-virtual subscription (must need shipping to change the address)
2. Make sure to run `DELETE FROM wp_usermeta WHERE meta_key = '_wcs_subscription_ids_cache';` so that the cache is forced to update with the latest users subscriptions.
3. Go into **My Account > Addresses**
4. Click on the icons next to Shipping/Billing address to edit them
5. After updating the address, scroll to the bottom and click on "Update the X Address used for all future renewals of my active subscriptions (optional)"
6. Save the address and check your subscriptions have the latest chanegs.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
