### PR TITLE
Add support for php8.2 in github action checks

### DIFF
--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
     steps:
       # clone the repository
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #324 

## Description

Adds support for php8.2 to the github action checks.
As php8.2 is not yet released, this is using a nightly build.

## How to test this PR

Review the output of github actions and verify that the unit tests are being run against php 8.2

## Product impact
<!-- What products will this PR ship in? -->

No product impact, development only change.