### PR TITLE
[HPOS] Bulk actions missing from Subscriptions listing in wp-admin

### DIFF
--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -261,7 +261,7 @@ class WCS_Admin_Post_Types {
 		 */
 		$post_status = sanitize_key( wp_unslash( $_GET['post_status'] ) ) ?? sanitize_key( wp_unslash( $_GET['status'] ) ) ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		// List of actions to remove that are irrelevant for subscriptions.
+		// List of actions to remove that are irrelevant to subscriptions.
 		$actions_to_remove = [
 			'edit',
 			'mark_processing',

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1269,7 +1269,7 @@ class WCS_Admin_Post_Types {
 	 */
 	public function print_bulk_actions_script() {
 		wcs_deprecated_function( __METHOD__, '5.3.0' );
-		$post_status = ( isset( $_GET['post_status'] ) ) ? $_GET['post_status'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_status = ( isset( $_GET['post_status'] ) ) ? sanitize_key( wp_unslash( $_GET['post_status'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$subscription_id = ( ! empty( $GLOBALS['post']->ID ) ) ? $GLOBALS['post']->ID : '';
 		if ( ! $subscription_id ) {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -270,13 +270,7 @@ class WCS_Admin_Post_Types {
 		 *
 		 * Note: The nonce check is ignored below as there is no nonce value provided on status filter requests.
 		 */
-		if ( isset( $_GET['status'] ) ) {
-			$post_status = sanitize_key( wp_unslash( $_GET['status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		} elseif ( isset( $_GET['post_status'] ) ) {
-			$post_status = sanitize_key( wp_unslash( $_GET['post_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		} else {
-			$post_status = '';
-		}
+		$post_status = sanitize_key( wp_unslash( $_GET['post_status'] ?? $_GET['status'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// List of actions to remove that are irrelevant to subscriptions.
 		$actions_to_remove = [
@@ -1275,7 +1269,7 @@ class WCS_Admin_Post_Types {
 	 */
 	public function print_bulk_actions_script() {
 		wcs_deprecated_function( __METHOD__, '5.3.0' );
-		$post_status = ( isset( $_GET['post_status'] ) ) ? $_GET['post_status'] : '';
+		$post_status = ( isset( $_GET['post_status'] ) ) ? $_GET['post_status'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$subscription_id = ( ! empty( $GLOBALS['post']->ID ) ) ? $GLOBALS['post']->ID : '';
 		if ( ! $subscription_id ) {
@@ -1287,11 +1281,14 @@ class WCS_Admin_Post_Types {
 		}
 
 		// Make it filterable in case extensions want to change this
-		$bulk_actions = apply_filters( 'woocommerce_subscription_bulk_actions', array(
-			'active'    => _x( 'Activate', 'an action on a subscription', 'woocommerce-subscriptions' ),
-			'on-hold'   => _x( 'Put on-hold', 'an action on a subscription', 'woocommerce-subscriptions' ),
-			'cancelled' => _x( 'Cancel', 'an action on a subscription', 'woocommerce-subscriptions' ),
-		) );
+		$bulk_actions = apply_filters(
+			'woocommerce_subscription_bulk_actions',
+			array(
+				'active'    => _x( 'Activate', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'on-hold'   => _x( 'Put on-hold', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'cancelled' => _x( 'Cancel', 'an action on a subscription', 'woocommerce-subscriptions' ),
+			)
+		);
 
 		// No need to display certain bulk actions if we know all the subscriptions on the page have that status already
 		switch ( $post_status ) {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -254,12 +254,18 @@ class WCS_Admin_Post_Types {
 	 */
 	public function filter_bulk_actions( $actions ) {
 		/**
-		 * Get the status the list table is being filtered by.
+		 * Get the status that the list table is being filtered by.
 		 * The 'post_status' key is used for CPT datastores, 'status' is used for HPOS datastores.
 		 *
 		 * Note: The nonce check is ignored below as there is no nonce value provided on status filter requests.
 		 */
-		$post_status = sanitize_key( wp_unslash( $_GET['post_status'] ) ) ?? sanitize_key( wp_unslash( $_GET['status'] ) ) ?? ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['status'] ) ) {
+			$post_status = sanitize_key( wp_unslash( $_GET['status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} elseif ( isset( $_GET['post_status'] ) ) {
+			$post_status = sanitize_key( wp_unslash( $_GET['post_status'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} else {
+			$post_status = '';
+		}
 
 		// List of actions to remove that are irrelevant to subscriptions.
 		$actions_to_remove = [


### PR DESCRIPTION
Fixes #321

> **Note**
> This PR is targeting the `hpos-admin-ui-support` branch due to the changes required for admin screens in HPOS environments awaiting merge

## Description

Bulk actions are missing from the Subscriptions listing page in wp-admin when HPOS is enabled.

NB: Bulk actions will not work with this PR, there is an open issue for this  https://github.com/woocommerce/woocommerce/issues/35750.


<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

There was a small refactor to go along with this change. Previously, the function `print_bulk_actions_script()` appends the Subscription bulk actions to the dropdown list using jquery. 
This was due to the `bulk_actions-edit-shop_subscription` previously not allowing the addition of items but only the removal. This restriction [was dropped](https://developer.wordpress.org/reference/hooks/bulk_actions-this-screen-id/#more-information) in WP 4.7.0 (2016-12-06.)

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
**CPT**
![image](https://user-images.githubusercontent.com/57298/204417543-11bf31f6-7577-403b-b009-92db2c7d98a4.png)
**HPOS**
![image](https://user-images.githubusercontent.com/57298/204417600-a6a3ef6a-2ed2-4222-b679-d1aa63da6255.png)


## How to test this PR
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->
With HPOS enabled and using [HPOS Admin UI support](https://github.com/Automattic/woocommerce-subscriptions-core/pull/297) and associated [WooCommerce PR](https://github.com/woocommerce/woocommerce/pull/35658) 

1. With HPOS enabled, Go to 'Subscriptions' in wp-admin.
2. Click on the 'Bulk actions' drop down and compare the options when the store is in CPT mode.
## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply) - This will be rolled up into one changelog entry for admin screens working under HPOS.
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
