### PR TITLE
Add subscriptions-core version to SSR

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Refactor `WCS_Meta_Box_Subscription_Data::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
+* Dev - Add subscriptions-core library version to the system status report.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Fix - Refactor `WCS_Meta_Box_Subscription_Data::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
-* Dev - Add subscriptions-core library version to the system status report.
+* Dev - Add subscriptions-core library version to the WooCommerce system status report.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -130,9 +130,9 @@ class WCS_Admin_System_Status {
 	 */
 	private static function set_library_version( &$debug_data ) {
 		$debug_data['wcs_subs_core_version'] = array(
-			'name'      => _x( 'Subscriptions Library Version', 'Subscriptions-Core Version, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
-			'label'     => 'Subscriptions Library Version',
-			'note'      => WC_Subscriptions_Core_Plugin::instance()->get_plugin_version(),
+			'name'      => _x( 'Subscriptions-core Library Version', 'Subscriptions-core Version, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
+			'label'     => 'Subscriptions-core Library Version',
+			'note'      => WC_Subscriptions_Core_Plugin::instance()->get_library_version(),
 			'mark'      => '',
 			'mark_icon' => '',
 		);

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -38,6 +38,7 @@ class WCS_Admin_System_Status {
 		self::set_debug_mode( $subscriptions_data );
 		self::set_staging_mode( $subscriptions_data );
 		self::set_live_site_url( $subscriptions_data );
+		self::set_library_version( $subscriptions_data );
 		self::set_theme_overrides( $subscriptions_data );
 		self::set_subscription_statuses( $subscriptions_data );
 		self::set_woocommerce_account_data( $subscriptions_data );
@@ -119,6 +120,19 @@ class WCS_Admin_System_Status {
 			'name'      => _x( 'Subscriptions Live URL', 'Live URL, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
 			'label'     => 'Subscriptions Live URL',
 			'note'      => '<a href="' . esc_url( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '">' . esc_html( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '</a>',
+			'mark'      => '',
+			'mark_icon' => '',
+		);
+	}
+
+	/**
+	 * @param array $debug_data
+	 */
+	private static function set_library_version( &$debug_data ) {
+		$debug_data['wcs_subs_core_version'] = array(
+			'name'      => _x( 'Subscriptions Library Version', 'Subscriptions-Core Version, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
+			'label'     => 'Subscriptions Library Version',
+			'note'      => WC_Subscriptions_Core_Plugin::instance()->get_plugin_version(),
 			'mark'      => '',
 			'mark_icon' => '',
 		);


### PR DESCRIPTION
Fixes #328 

## Description

Especially when testing WCS vs WCPay and potentially developing on subscriptions-core it can be difficult to know what version of the subscriptions-core library is being loaded.

This PR adds the version of the subscriptions-core library to the SSR will help find the library version both in development and when debugging issues for merchants.


<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to WooCommerce -> Status
2. Scroll down to 'Subscriptions'
3. See 'Subscriptions Core Library Version'

![image](https://user-images.githubusercontent.com/57298/205199616-eb2ff487-a5d0-4511-bf02-ca8e7a006dee.png)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
