### PR TITLE
Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
+8 Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
 * Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
-8 Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
+* Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,8 +6,6 @@
 * Fix - Set the `download_permissions_granted` value when purchasing a downloadable subscription product when HPOS is enabled.
 * Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
-* Update - Replace `get_post_type()` calls in `WC_Subscriptions_Manager` for HPOS support.
-* Update - Replace `get_post_type()` calls in `WC_Subscriptions_Synchroniser` for HPOS support.
 * Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.

--- a/includes/class-wc-subscriptions-renewal-order.php
+++ b/includes/class-wc-subscriptions-renewal-order.php
@@ -58,7 +58,7 @@ class WC_Subscriptions_Renewal_Order {
 
 		// Get orders where order meta '_failed_order_replaced_by' = $renewal_order_id
 		$failed_orders = wcs_get_orders_with_meta_query(
-			array(
+			[
 				'limit'      => 1,
 				'return'     => 'ids',
 				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -68,7 +68,7 @@ class WC_Subscriptions_Renewal_Order {
 						'value'   => $renewal_order_id,
 					],
 				],
-			)
+			]
 		);
 
 		return $failed_orders[0] ?? false;

--- a/includes/class-wc-subscriptions-renewal-order.php
+++ b/includes/class-wc-subscriptions-renewal-order.php
@@ -55,11 +55,23 @@ class WC_Subscriptions_Renewal_Order {
 	 * @return mixed If the renewal order did replace a failed order, the ID of the fail order, else false
 	 */
 	public static function get_failed_order_replaced_by( $renewal_order_id ) {
-		global $wpdb;
 
-		$failed_order_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_failed_order_replaced_by' AND meta_value = %s", $renewal_order_id ) );
+		// Get orders where order meta '_failed_order_replaced_by' = $renewal_order_id
+		$failed_orders = wcs_get_orders_with_meta_query(
+			array(
+				'limit'      => 1,
+				'return'     => 'ids',
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => '_failed_order_replaced_by',
+						'compare' => '=',
+						'value'   => $renewal_order_id,
+					],
+				],
+			)
+		);
 
-		return ( null === $failed_order_id ) ? false : $failed_order_id;
+		return $failed_orders[0] ?? false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #143

## Description

This PR replaces a call to `$wpdb->prepare` with `wcs_get_orders_with_meta_query` to ensure `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` is compatible with HPOS stores.

PayPal Standard payment request handling is the only use-case of this function internally. However, this is a public static function, so 3rd party code may be using it.

As mentioned in the [issue thread](https://github.com/Automattic/woocommerce-subscriptions-core/issues/143#issuecomment-1333164770), this change is relatively low-risk, and testing by directly calling the function should suffice.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a renewal order for a subscription. Note the renewal order ID (aka `$sub_id` below).
2. Manually add `_failed_order_replaced_by` to a previous order ID, via the `_postmeta` table (HPOS disabled) or `_wc_orders_meta` table.
3. Run `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by( $sub_id );` in [WP Console](https://wordpress.org/plugins/wp-console/).
5. Confirm the ID of the manually mutated order is returned.
6. Run `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by( $another_order_id );` in [WP Console](https://wordpress.org/plugins/wp-console/). `$another_order_id` should be an order that does not have the `_failed_order_replaced_by` meta.
7. Confirm it's returning `false`.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **No deprecations**
