### PR TITLE
Restore missing filters on Subscriptions listing.

### DIFF
--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -75,10 +75,11 @@ class WCS_Admin_Post_Types {
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_by_product' ) );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_by_payment_method' ) );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_by_customer' ) );
+
 		// Add ListTable filters when HPOS is enabled
-		add_action( 'woocommerce_order_list_table_extra_tablenav', array( $this, 'restrict_by_product' ) );
-		add_action( 'woocommerce_order_list_table_extra_tablenav', array( $this, 'restrict_by_payment_method' ) );
-		add_action( 'woocommerce_order_list_table_extra_tablenav', array( $this, 'restrict_by_customer' ) );
+		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'restrict_by_product' ) );
+		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'restrict_by_payment_method' ) );
+		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'restrict_by_customer' ) );
 
 		add_action( 'list_table_primary_column', array( $this, 'list_table_primary_column' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'shop_subscription_row_actions' ), 10, 2 );

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1153,6 +1153,10 @@ class WCS_Admin_Post_Types {
 		if ( 'shop_subscription' !== $order_type || wcs_is_woocommerce_pre( '3.3' ) ) {
 			return;
 		}
+		// When HPOS is enabled WC displays the customer filter so this doesn't need to be duplicated.
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			return;
+		}
 
 		$user_string = '';
 		$user_id     = '';

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -71,9 +71,14 @@ class WCS_Admin_Post_Types {
 
 		add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
 
+		// Add ListTable filters when CPT is enabled
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_by_product' ) );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_by_payment_method' ) );
 		add_action( 'restrict_manage_posts', array( $this, 'restrict_by_customer' ) );
+		// Add ListTable filters when HPOS is enabled
+		add_action( 'woocommerce_order_list_table_extra_tablenav', array( $this, 'restrict_by_product' ) );
+		add_action( 'woocommerce_order_list_table_extra_tablenav', array( $this, 'restrict_by_payment_method' ) );
+		add_action( 'woocommerce_order_list_table_extra_tablenav', array( $this, 'restrict_by_customer' ) );
 
 		add_action( 'list_table_primary_column', array( $this, 'list_table_primary_column' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'shop_subscription_row_actions' ), 10, 2 );
@@ -200,12 +205,14 @@ class WCS_Admin_Post_Types {
 
 	/**
 	 * Displays the dropdown for the product filter
+	 *
+	 * @param string $order_type The type of order. This will be 'shop_subscription' for Subscriptions.
+	 *
 	 * @return string the html dropdown element
 	 */
-	public function restrict_by_product() {
-		global $typenow;
+	public function restrict_by_product( $order_type ) {
 
-		if ( 'shop_subscription' !== $typenow ) {
+		if ( 'shop_subscription' !== $order_type ) {
 			return;
 		}
 
@@ -989,12 +996,13 @@ class WCS_Admin_Post_Types {
 	/**
 	 * Displays the dropdown for the payment method filter.
 	 *
+	 * @param string $order_type The type of order. This will be 'shop_subscription' for Subscriptions.
+	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
-	public static function restrict_by_payment_method() {
-		global $typenow;
+	public static function restrict_by_payment_method( $order_type ) {
 
-		if ( 'shop_subscription' !== $typenow ) {
+		if ( 'shop_subscription' !== $order_type ) {
 			return;
 		}
 
@@ -1135,13 +1143,14 @@ class WCS_Admin_Post_Types {
 	/**
 	 * Renders the dropdown for the customer filter.
 	 *
+	 * @param string $order_type The type of order. This will be 'shop_subscription' for Subscriptions.
+	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.17
 	 */
-	public static function restrict_by_customer() {
-		global $typenow;
+	public static function restrict_by_customer( $order_type ) {
 
 		// Prior to WC 3.3 this was handled by WC core so exit early if an earlier version of WC is active.
-		if ( 'shop_subscription' !== $typenow || wcs_is_woocommerce_pre( '3.3' ) ) {
+		if ( 'shop_subscription' !== $order_type || wcs_is_woocommerce_pre( '3.3' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -210,7 +210,10 @@ class WCS_Admin_Post_Types {
 	 *
 	 * @return string the html dropdown element
 	 */
-	public function restrict_by_product( $order_type ) {
+	public function restrict_by_product( $order_type = '' ) {
+		if ( '' === $order_type ) {
+			$order_type = isset( $GLOBALS['typenow'] ) ? $GLOBALS['typenow'] : '';
+		}
 
 		if ( 'shop_subscription' !== $order_type ) {
 			return;
@@ -1000,7 +1003,10 @@ class WCS_Admin_Post_Types {
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
-	public static function restrict_by_payment_method( $order_type ) {
+	public static function restrict_by_payment_method( $order_type = '' ) {
+		if ( '' === $order_type ) {
+			$order_type = isset( $GLOBALS['typenow'] ) ? $GLOBALS['typenow'] : '';
+		}
 
 		if ( 'shop_subscription' !== $order_type ) {
 			return;
@@ -1147,7 +1153,10 @@ class WCS_Admin_Post_Types {
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.17
 	 */
-	public static function restrict_by_customer( $order_type ) {
+	public static function restrict_by_customer( $order_type = '' ) {
+		if ( '' === $order_type ) {
+			$order_type = isset( $GLOBALS['typenow'] ) ? $GLOBALS['typenow'] : '';
+		}
 
 		// Prior to WC 3.3 this was handled by WC core so exit early if an earlier version of WC is active.
 		if ( 'shop_subscription' !== $order_type || wcs_is_woocommerce_pre( '3.3' ) ) {


### PR DESCRIPTION
Fixes #323 

> **Note**
> This PR is targeting the `hpos-admin-ui-support` branch due to the changes required for admin screens in HPOS environments awaiting merge. 

## Description

The custom filters that we add to the Subscriptions list screen were not showing when HPOS is enabled. 

A [new filter has been added](https://github.com/woocommerce/woocommerce/issues/35753#issuecomment-1333835222) in HPOS environments for this purpose `woocommerce_order_list_table_extra_tablenav` additionally the usage of `global $typenow;` has been removed with checks against the order type instead.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

![Screenshot 2022-11-29 at 1 59 36 PM](https://user-images.githubusercontent.com/57298/204412644-f9857c59-57cd-44ec-949a-2fc6d05093d5.png "CPT ListTable screen showing filters")


## How to test this PR

1. On a HPOS enabled site, go to the Subscriptions listing screen in wp-admin.
2. The filters should be visible.

**NB:** The filters for product/customers are unreadable due to the width. There is [an open issue](https://github.com/Automattic/woocommerce-subscriptions-core/issues/322) for this.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)- This will be rolled up into one changelog entry for admin screens working under HPOS.
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
