### PR TITLE
[HPOS] Update CSS/JS to work with new admin screens

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -5,10 +5,10 @@
 .woocommerce-subscriptions-activated a.button-primary:hover {
 	background: #bb77ae;
 	border-color: #aa559a;
-	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25),
-		0 1px 0 rgba(0, 0, 0, 0.15);
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25),
-		0 1px 0 rgba(0, 0, 0, 0.15);
+	-webkit-box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.25 ),
+		0 1px 0 rgba( 0, 0, 0, 0.15 );
+	box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.25 ),
+		0 1px 0 rgba( 0, 0, 0, 0.15 );
 }
 .woocommerce-subscriptions-activated a.button-primary:active,
 .woocommerce-subscriptions-activated a.button-primary:active {
@@ -87,7 +87,7 @@ a.close-subscriptions-search {
 	display: block;
 	width: 50%;
 }
-@media only screen and (max-width: 1280px) {
+@media only screen and ( max-width: 1280px ) {
 	.woocommerce_options_panel ._subscription_price_fields .wrap,
 	.woocommerce_options_panel ._subscription_trial_length_field .wrap,
 	.woocommerce_options_panel
@@ -396,7 +396,7 @@ a.close-subscriptions-search {
 	.wc_input_subscription_payment_sync_month {
 	max-width: 86%;
 }
-@media screen and (max-width: 1190px) {
+@media screen and ( max-width: 1190px ) {
 	#variable_product_options
 		.variable_subscription_pricing_2_3
 		p._subscription_price_field,
@@ -691,7 +691,7 @@ table.wp-list-table .subscription_renewal_order::after {
 	left: 0;
 }
 
-@media only screen and (max-width: 782px) {
+@media only screen and ( max-width: 782px ) {
 	table.wp-list-table .subscription_parent_order,
 	table.wp-list-table .subscription_resubscribe_order,
 	table.wp-list-table .subscription_renewal_order {
@@ -757,7 +757,7 @@ body.post-type-shop_subscription .add-items .description.tips,
 body.post-type-shop_subscription .add-items .button.refund-items {
 	display: none;
 }
-@media only screen and (max-width: 782px) {
+@media only screen and ( max-width: 782px ) {
 	#woocommerce-subscription-schedule
 		.wcs-date-input
 		input[type='text']:first-of-type {
@@ -765,7 +765,7 @@ body.post-type-shop_subscription .add-items .button.refund-items {
 	}
 	#woocommerce-subscription-schedule
 		.wcs-date-input
-		input[type='text']:not(:first-of-type) {
+		input[type='text']:not( :first-of-type ) {
 		width: 19%;
 	}
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -5,10 +5,10 @@
 .woocommerce-subscriptions-activated a.button-primary:hover {
 	background: #bb77ae;
 	border-color: #aa559a;
-	-webkit-box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.25 ),
-		0 1px 0 rgba( 0, 0, 0, 0.15 );
-	box-shadow: inset 0 1px 0 rgba( 255, 255, 255, 0.25 ),
-		0 1px 0 rgba( 0, 0, 0, 0.15 );
+	-webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25),
+		0 1px 0 rgba(0, 0, 0, 0.15);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25),
+		0 1px 0 rgba(0, 0, 0, 0.15);
 }
 .woocommerce-subscriptions-activated a.button-primary:active,
 .woocommerce-subscriptions-activated a.button-primary:active {
@@ -30,15 +30,21 @@
 	vertical-align: middle;
 	margin: 1px 6px 4px 1px;
 }
-.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-selection--single,
+.woocommerce_page_wc-orders--shop_subscription
+	.tablenav
+	.select2-selection--single,
 .post-type-shop_subscription .tablenav .select2-selection--single {
 	height: 32px;
 }
-.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-selection__rendered,
+.woocommerce_page_wc-orders--shop_subscription
+	.tablenav
+	.select2-selection__rendered,
 .post-type-shop_subscription .tablenav .select2-selection__rendered {
 	line-height: 29px;
 }
-.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-selection__arrow,
+.woocommerce_page_wc-orders--shop_subscription
+	.tablenav
+	.select2-selection__arrow,
 .post-type-shop_subscription .tablenav .select2-selection__arrow {
 	height: 30px;
 }
@@ -81,7 +87,7 @@ a.close-subscriptions-search {
 	display: block;
 	width: 50%;
 }
-@media only screen and ( max-width: 1280px ) {
+@media only screen and (max-width: 1280px) {
 	.woocommerce_options_panel ._subscription_price_fields .wrap,
 	.woocommerce_options_panel ._subscription_trial_length_field .wrap,
 	.woocommerce_options_panel
@@ -390,7 +396,7 @@ a.close-subscriptions-search {
 	.wc_input_subscription_payment_sync_month {
 	max-width: 86%;
 }
-@media screen and ( max-width: 1190px ) {
+@media screen and (max-width: 1190px) {
 	#variable_product_options
 		.variable_subscription_pricing_2_3
 		p._subscription_price_field,
@@ -685,7 +691,7 @@ table.wp-list-table .subscription_renewal_order::after {
 	left: 0;
 }
 
-@media only screen and ( max-width: 782px ) {
+@media only screen and (max-width: 782px) {
 	table.wp-list-table .subscription_parent_order,
 	table.wp-list-table .subscription_resubscribe_order,
 	table.wp-list-table .subscription_renewal_order {
@@ -735,15 +741,23 @@ table.wc_gateways .renewals .tips {
 }
 
 /* Hide irrelevant sections on Edit Subscription screen */
-body.woocommerce_page_wc-orders--shop_subscription .order_actions #actions optgroup[label='Resend order emails'],
+body.woocommerce_page_wc-orders--shop_subscription
+	.order_actions
+	#actions
+	optgroup[label='Resend order emails'],
 body.woocommerce_page_wc-orders--shop_subscription .add-items .description.tips,
-body.woocommerce_page_wc-orders--shop_subscription .add-items .button.refund-items,
-body.post-type-shop_subscription .order_actions #actions optgroup[label='Resend order emails'],
+body.woocommerce_page_wc-orders--shop_subscription
+	.add-items
+	.button.refund-items,
+body.post-type-shop_subscription
+	.order_actions
+	#actions
+	optgroup[label='Resend order emails'],
 body.post-type-shop_subscription .add-items .description.tips,
 body.post-type-shop_subscription .add-items .button.refund-items {
 	display: none;
 }
-@media only screen and ( max-width: 782px ) {
+@media only screen and (max-width: 782px) {
 	#woocommerce-subscription-schedule
 		.wcs-date-input
 		input[type='text']:first-of-type {
@@ -751,28 +765,37 @@ body.post-type-shop_subscription .add-items .button.refund-items {
 	}
 	#woocommerce-subscription-schedule
 		.wcs-date-input
-		input[type='text']:not( :first-of-type ) {
+		input[type='text']:not(:first-of-type) {
 		width: 19%;
 	}
 
-	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-status,
+	.woocommerce_page_wc-orders--shop_subscription
+		.wp-list-table
+		.column-status,
 	.post-type-shop_subscription .wp-list-table .column-status {
 		display: none;
 		text-align: left;
 		padding-bottom: 0;
 	}
 
-	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-status mark,
+	.woocommerce_page_wc-orders--shop_subscription
+		.wp-list-table
+		.column-status
+		mark,
 	.post-type-shop_subscription .wp-list-table .column-status mark {
 		margin: 0;
 	}
 
-	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-status::before,
+	.woocommerce_page_wc-orders--shop_subscription
+		.wp-list-table
+		.column-status::before,
 	.post-type-shop_subscription .wp-list-table .column-status::before {
 		display: none !important;
 	}
 
-	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-orders,
+	.woocommerce_page_wc-orders--shop_subscription
+		.wp-list-table
+		.column-orders,
 	.post-type-shop_subscription .wp-list-table .column-orders {
 		text-align: left !important;
 	}

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -17,28 +17,37 @@
 }
 
 /* Subscriptions Admin Page */
+.woocommerce_page_wc-orders--shop_subscription .tablenav input,
+.woocommerce_page_wc-orders--shop_subscription .tablenav select,
 .post-type-shop_subscription .tablenav input,
 .post-type-shop_subscription .tablenav select {
 	height: 32px;
 }
+.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-container,
 .post-type-shop_subscription .tablenav .select2-container {
 	width: 240px !important;
 	font-size: 14px;
 	vertical-align: middle;
 	margin: 1px 6px 4px 1px;
 }
+.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-selection--single,
 .post-type-shop_subscription .tablenav .select2-selection--single {
 	height: 32px;
 }
+.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-selection__rendered,
 .post-type-shop_subscription .tablenav .select2-selection__rendered {
 	line-height: 29px;
 }
+.woocommerce_page_wc-orders--shop_subscription .tablenav .select2-selection__arrow,
 .post-type-shop_subscription .tablenav .select2-selection__arrow {
 	height: 30px;
 }
+.woocommerce_page_wc-orders--shop_subscription .wp-list-table,
 .post-type-shop_subscription .wp-list-table {
 	margin-top: 1em;
 }
+.woocommerce_page_wc-orders--shop_subscription .widefat .column-status,
+.woocommerce_page_wc-orders--shop_subscription .widefat .column-order_title,
 .post-type-shop_subscription .widefat .column-status,
 .post-type-shop_subscription .widefat .column-order_title {
 	width: 160px;
@@ -726,10 +735,10 @@ table.wc_gateways .renewals .tips {
 }
 
 /* Hide irrelevant sections on Edit Subscription screen */
-body.post-type-shop_subscription
-	.order_actions
-	#actions
-	optgroup[label='Resend order emails'],
+body.woocommerce_page_wc-orders--shop_subscription .order_actions #actions optgroup[label='Resend order emails'],
+body.woocommerce_page_wc-orders--shop_subscription .add-items .description.tips,
+body.woocommerce_page_wc-orders--shop_subscription .add-items .button.refund-items,
+body.post-type-shop_subscription .order_actions #actions optgroup[label='Resend order emails'],
 body.post-type-shop_subscription .add-items .description.tips,
 body.post-type-shop_subscription .add-items .button.refund-items {
 	display: none;
@@ -746,20 +755,24 @@ body.post-type-shop_subscription .add-items .button.refund-items {
 		width: 19%;
 	}
 
+	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-status,
 	.post-type-shop_subscription .wp-list-table .column-status {
 		display: none;
 		text-align: left;
 		padding-bottom: 0;
 	}
 
+	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-status mark,
 	.post-type-shop_subscription .wp-list-table .column-status mark {
 		margin: 0;
 	}
 
+	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-status::before,
 	.post-type-shop_subscription .wp-list-table .column-status::before {
 		display: none !important;
 	}
 
+	.woocommerce_page_wc-orders--shop_subscription .wp-list-table .column-orders,
 	.post-type-shop_subscription .wp-list-table .column-orders {
 		text-align: left !important;
 	}

--- a/assets/js/admin/meta-boxes-subscription.js
+++ b/assets/js/admin/meta-boxes-subscription.js
@@ -340,7 +340,7 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	$( 'body.post-type-shop_subscription #post,body.woocommerce_page_wc-orders--shop_subscription #order' ).on( 'submit', function () {
+	$( 'body.post-type-shop_subscription #post, body.woocommerce_page_wc-orders--shop_subscription #order' ).on( 'submit', function () {
 		if (
 			typeof wcs_admin_meta_boxes.change_payment_method_warning !=
 				'undefined' &&

--- a/assets/js/admin/meta-boxes-subscription.js
+++ b/assets/js/admin/meta-boxes-subscription.js
@@ -331,7 +331,7 @@ jQuery( function ( $ ) {
 		if (
 			'wcs_process_renewal' ==
 			$(
-				"body.post-type-shop_subscription select[name='wc_order_action'], body.woocommerce_page_wc-orders--shop_subscription select[name='wc_order_action']"
+				'body.post-type-shop_subscription select[name="wc_order_action"], body.woocommerce_page_wc-orders--shop_subscription select[name="wc_order_action"]'
 			).val()
 		) {
 			return confirm(

--- a/assets/js/admin/meta-boxes-subscription.js
+++ b/assets/js/admin/meta-boxes-subscription.js
@@ -327,11 +327,11 @@ jQuery( function ( $ ) {
 		return false;
 	}
 
-	$( 'body.post-type-shop_subscription #post' ).on( 'submit', function () {
+	$( 'body.post-type-shop_subscription #post, body.woocommerce_page_wc-orders--shop_subscription #order' ).on( 'submit', function () {
 		if (
 			'wcs_process_renewal' ==
 			$(
-				"body.post-type-shop_subscription select[name='wc_order_action']"
+				"body.post-type-shop_subscription select[name='wc_order_action'], body.woocommerce_page_wc-orders--shop_subscription select[name='wc_order_action']"
 			).val()
 		) {
 			return confirm(
@@ -340,7 +340,7 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	$( 'body.post-type-shop_subscription #post' ).on( 'submit', function () {
+	$( 'body.post-type-shop_subscription #post,body.woocommerce_page_wc-orders--shop_subscription #order' ).on( 'submit', function () {
 		if (
 			typeof wcs_admin_meta_boxes.change_payment_method_warning !=
 				'undefined' &&


### PR DESCRIPTION
Fixes #322

> **Note**
> This PR is targeting the `hpos-admin-ui-support` branch due to the changes required for admin screens in HPOS environments awaiting merge

## Description

When HPOS is enabled the default WP admin screens for custom post types can no longer be used. WooCommerce has introduced new admin screens which have changed some of the underlying functionality that we rely on.

For javascript and CSS, we relied on the class `post-type-shop_subscription` being added to the `<body>` tag. With HPOS enabled this no longer happens. Instead we can use the `woocommerce_page_wc-orders--shop_subscription` class.

This PR adds this class as an additional rule anywhere the old class was used.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
**Before**
![image](https://user-images.githubusercontent.com/57298/205544132-da9e6215-72a2-4870-96b5-1ad807f80e41.png)

**After**
![image](https://user-images.githubusercontent.com/57298/205544084-405db69a-7815-4b7c-b400-1e5660b9d0ae.png)


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * **CSS:** Go to Subscriptions listing admin page with HPOS enabled and disabled and check for differences. 
   * Status & Subscription columns
   * Filter select boxes 
* **JS** When viewing a Subscription in admin.
  * Check  the `Process renewal` action on a subscription brings up the confirmation alert.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply) - This will be rolled up into one changelog entry for admin screens working under HPOS.
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
