### PR TITLE
Add payment token when setting default payment method for all subscriptions

### DIFF
--- a/includes/class-wcs-payment-tokens.php
+++ b/includes/class-wcs-payment-tokens.php
@@ -45,6 +45,7 @@ class WCS_Payment_Tokens extends WC_Payment_Tokens {
 		}
 
 		$subscription->update_meta_data( $token_meta_key, $new_token->get_token() );
+		$subscription->add_payment_token( $new_token );
 		$subscription->save();
 
 		// Copy the new token to the last renewal order if it needs payment so the retry system will pick up the new method.


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-subscriptions-core/issues/128

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to …
2. Click on …

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
