### PR TITLE
[HPOS] Replace missing variable in WCS_Admin_Meta_Boxes::add_meta_boxes()

### DIFF
--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -95,7 +95,8 @@ class WCS_Admin_Meta_Boxes {
 		}
 
 		// Get "Edit Order" screen ID, which differs if HPOS is enabled.
-		$screen = wcs_is_custom_order_tables_usage_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		$screen         = wcs_is_custom_order_tables_usage_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		$current_screen = get_current_screen();
 
 		// Only display the meta box if viewing an order that contains a subscription.
 		if ( $post_or_order_object && $current_screen->id === $screen && wcs_order_contains_subscription( $post_or_order_object, 'any' ) ) {

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -95,12 +95,12 @@ class WCS_Admin_Meta_Boxes {
 		}
 
 		// Get "Edit Order" screen ID, which differs if HPOS is enabled.
-		$screen         = wcs_is_custom_order_tables_usage_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
-		$current_screen = get_current_screen();
+		$order_screen_id = wcs_is_custom_order_tables_usage_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		$current_screen  = get_current_screen();
 
 		// Only display the meta box if viewing an order that contains a subscription.
-		if ( $post_or_order_object && $current_screen->id === $screen && wcs_order_contains_subscription( $post_or_order_object, 'any' ) ) {
-			add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', $screen, 'normal', 'low' );
+		if ( $post_or_order_object && $current_screen->id === $order_screen_id && wcs_order_contains_subscription( $post_or_order_object, 'any' ) ) {
+			add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', $order_screen_id, 'normal', 'low' );
 		}
 	}
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -99,7 +99,7 @@ class WCS_Admin_Meta_Boxes {
 		$current_screen  = get_current_screen();
 
 		// Only display the meta box if viewing an order that contains a subscription.
-		if ( $post_or_order_object && $current_screen->id === $order_screen_id && wcs_order_contains_subscription( $post_or_order_object, 'any' ) ) {
+		if ( $post_or_order_object && $current_screen && $current_screen->id === $order_screen_id && wcs_order_contains_subscription( $post_or_order_object, 'any' ) ) {
 			add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', $order_screen_id, 'normal', 'low' );
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/Automattic/woocommerce-subscriptions-core/pull/297#discussion_r1040509678

> **Note**
> This PR is targeting the `hpos-admin-ui-support` branch due to the changes required for admin screens in HPOS environments awaiting merge

## Description

A variable was inadvertently removed from the `hpos-admin-ui-support` branch from the `WCS_Admin_Meta_Boxes::add_meta_boxes()`, causing an error on the subscription edit page to appear (https://github.com/Automattic/woocommerce-subscriptions-core/pull/297#discussion_r1040509678).

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/3147296/207467735-39c4b9ee-aebc-41ed-b555-bed87a4d62a4.png">

This PR resolves this error by replacing the variable.

I have also renamed the `$screen` variable to `$order_screen_id` to help to distinguish it from [`$subscriptions_screen_id`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/bc374900654b55fda0d9b32810c9388da51cbd0d/includes/admin/class-wcs-admin-meta-boxes.php#L81).

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch and the https://github.com/woocommerce/woocommerce/pull/35658 WC branch
2. Enable HPOS.
3. View a subscription (WC → Subscriptions).
4. Ensure no `Undefined variable $current_screen` error occurs.
5. Ensure the related orders metabox is visible on both the Edit Order and Edit Subscription screen.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
