### PR TITLE
Check if the order actually exists before accessing order properties.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
 * Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
+* Fix - Check whether the order actually exists before accessing order properties in wcs_order_contains_subscription()
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -344,6 +344,10 @@ function wcs_order_contains_subscription( $order, $order_type = array( 'parent',
 
 	if ( ! is_a( $order, 'WC_Abstract_Order' ) ) {
 		$order = wc_get_order( $order );
+
+		if ( ! $order ) {
+			return false;
+		}
 	}
 
 	$contains_subscription = false;


### PR DESCRIPTION
Fixes #344 

## Description
Check whether the order actually exists before accessing order properties in `wcs_order_contains_subscription()`.
