### PR TITLE
Merge meta queries as part of wcs_get_orders_with_meta_query() rather than override them

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
 * Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
 * Fix - Replace the get_posts() used in get_subscriptions_from_token() to support HPOS stores.
+* Fix - Merge any custom meta_query args passed to wcs_get_orders_with_meta_query() to avoid overriding WC core args that map onto meta_query.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -391,7 +391,7 @@ function wcs_get_orders_with_meta_query( $args ) {
 			}
 
 			if ( ! isset( $query['meta_query'] ) ) {
-				$query['meta_query'] = $meta;
+				$query['meta_query'] = $meta; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			} else {
 				$query['meta_query'] = array_merge( $query['meta_query'], $meta ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			}

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -390,7 +390,7 @@ function wcs_get_orders_with_meta_query( $args ) {
 				return $query;
 			}
 
-			$query['meta_query'] = $meta; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			$query['meta_query'] = array_merge( $query['meta_query'], $meta ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 
 			return $query;
 		};

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -390,7 +390,11 @@ function wcs_get_orders_with_meta_query( $args ) {
 				return $query;
 			}
 
-			$query['meta_query'] = array_merge( $query['meta_query'], $meta ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			if ( ! isset( $query['meta_query'] ) ) {
+				$query['meta_query'] = $meta;
+			} else {
+				$query['meta_query'] = array_merge( $query['meta_query'], $meta ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			}
 
 			return $query;
 		};


### PR DESCRIPTION
Fixes #346

## Description

I'm not aware of a user flow that directly leads to this issue however, given our documented APIs are broken and its an easy fix, we should fix with priority. This does mean the testing instructions will be dev in nature.

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/171 we introduced a helper function for fetching orders or subscriptions with a meta query in a HPOS and CPT compatible way. 

This resulted in the function `wcs_get_orders_with_meta_query()` which will map a custom `meta_query` onto WC core's `wc_get_orders()` query via the `woocommerce_order_data_store_cpt_get_orders_query` hook on CPT stores. 

In our approach however, any pre-existing meta query value that WC core set, would be overridden. 

In CPT, WC core will map `wc_get_orders()` args onto the `meta_query` arg when querying by any internal meta key (eg `order_currency`, `order_total`), or a handful of other keys like `customer` or `anonymized`. 

This means that when you call `wcs_get_orders_with_meta_query()` with a custom meta query with any key that WC core maps to `meta_query`, you'll get incorrect results.

This PR fixes that by making sure we merge the custom meta query with WC core one, if it exists.

## How to test this PR

1. Set your store to CPT (not HPOS)
1. Purchase at least 1 subscription using 1 account. 
2. Purchase at least 1 subscription using a different account.
3. Run the following code on your site. 
    - On `trunk` you'll get both customer subscriptions returned even though you're filtering by a specific customer.
    - On this branch you'll get only get 1 customer subscription. 

```php
// Get a customer's subscriptions without a trial
$subscription_query_args = [
    'customer_id'            => 1, // <- change this customer ID if you have a different one
    'subscription_status'    => 'active',
    'subscriptions_per_page' => -1,
    'meta_query'             => [
        [
            'key'     => '_schedule_trial_end',
            'compare' => '=',
            'value'   => 0,
        ],
    ],
];

echo count( wcs_get_subscriptions( $subscription_query_args ) );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
