### PR TITLE
[HPOS] Fix filtering the Amin Orders table by subscription related orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Check whether the order actually exists before accessing order properties in wcs_order_contains_subscription()
 * Fix - Replace the get_posts() used in get_subscriptions_from_token() to support HPOS stores.
 * Fix - Merge any custom meta_query args passed to wcs_get_orders_with_meta_query() to avoid overriding WC core args that map onto meta_query.
+* Fix - When HPOS is enabled, clicking the related orders link on the Subscriptions Table now filters the table with the related orders (previously all orders were shown).
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1484,7 +1484,6 @@ class WC_Subscriptions_Admin {
 	 * @see self::filter_orders()
 	 */
 	public static function display_renewal_filter_notice() {
-		$query_arg      = '_subscription_related_orders';
 		$is_hpos_in_use = wcs_is_custom_order_tables_usage_enabled();
 
 		// When HPOS is enabled, we can't use the $found_related_orders static variable to determine if the list is filtered or not.
@@ -1492,17 +1491,16 @@ class WC_Subscriptions_Admin {
 			return;
 		}
 
-		if ( isset( $_GET[ $query_arg ] ) && $_GET[ $query_arg ] > 0 ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-			$initial_order = wc_get_order( absint( $_GET[ $query_arg ] ) );
+		if ( isset( $_GET['_subscription_related_orders'] ) && $_GET['_subscription_related_orders'] > 0 ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$initial_order = wc_get_order( absint( $_GET['_subscription_related_orders'] ) ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			echo '<div class="updated dismiss-subscriptions-search"><p>';
 			// translators: placeholders are opening link tag, ID of sub, and closing link tag
-			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( get_edit_post_link( absint( $_GET[ $query_arg ] ) ) ) . '">', esc_html( $initial_order->get_order_number() ), '</a>' );
+			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( get_edit_post_link( absint( $_GET['_subscription_related_orders'] ) ) ) . '">', esc_html( $initial_order->get_order_number() ), '</a>' ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			echo '</p>';
 			printf(
 				'<a href="%1$s" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></a>',
-				esc_url( remove_query_arg( $query_arg ) )
+				esc_url( remove_query_arg( '_subscription_related_orders' ) )
 			);
 
 			echo '</div>';

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1484,9 +1484,15 @@ class WC_Subscriptions_Admin {
 	 * @see self::filter_orders()
 	 */
 	public static function display_renewal_filter_notice() {
-		$query_arg = '_subscription_related_orders';
+		$query_arg      = '_subscription_related_orders';
+		$is_hpos_in_use = wcs_is_custom_order_tables_usage_enabled();
 
-		if ( isset( $_GET[ $query_arg ] ) && $_GET[ $query_arg ] > 0 && true === self::$found_related_orders ) {
+		// When HPOS is enabled, we can't use the $found_related_orders static variable to determine if the list is filtered or not.
+		if ( ! $is_hpos_in_use && ! self::$found_related_orders ) {
+			return;
+		}
+
+		if ( isset( $_GET[ $query_arg ] ) && $_GET[ $query_arg ] > 0 ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			$initial_order = wc_get_order( absint( $_GET[ $query_arg ] ) );
 

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1484,34 +1484,20 @@ class WC_Subscriptions_Admin {
 	 * @see self::filter_orders()
 	 */
 	public static function display_renewal_filter_notice() {
-
-		global $wp_version;
-
 		$query_arg = '_subscription_related_orders';
 
 		if ( isset( $_GET[ $query_arg ] ) && $_GET[ $query_arg ] > 0 && true === self::$found_related_orders ) {
 
 			$initial_order = wc_get_order( absint( $_GET[ $query_arg ] ) );
 
-			if ( version_compare( $wp_version, '4.2', '<' ) ) {
-				echo '<div class="updated"><p>';
-				printf(
-					'<a href="%1$s" class="close-subscriptions-search">&times;</a>',
-					esc_url( remove_query_arg( $query_arg ) )
-				);
-				// translators: placeholders are opening link tag, ID of sub, and closing link tag
-				printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( get_edit_post_link( absint( $_GET[ $query_arg ] ) ) ) . '">', esc_html( $initial_order->get_order_number() ), '</a>' );
-				echo '</p>';
-			} else {
-				echo '<div class="updated dismiss-subscriptions-search"><p>';
-				// translators: placeholders are opening link tag, ID of sub, and closing link tag
-				printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( get_edit_post_link( absint( $_GET[ $query_arg ] ) ) ) . '">', esc_html( $initial_order->get_order_number() ), '</a>' );
-				echo '</p>';
-				printf(
-					'<a href="%1$s" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></a>',
-					esc_url( remove_query_arg( $query_arg ) )
-				);
-			}
+			echo '<div class="updated dismiss-subscriptions-search"><p>';
+			// translators: placeholders are opening link tag, ID of sub, and closing link tag
+			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( get_edit_post_link( absint( $_GET[ $query_arg ] ) ) ) . '">', esc_html( $initial_order->get_order_number() ), '</a>' );
+			echo '</p>';
+			printf(
+				'<a href="%1$s" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></a>',
+				esc_url( remove_query_arg( $query_arg ) )
+			);
 
 			echo '</div>';
 		}

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1492,11 +1492,21 @@ class WC_Subscriptions_Admin {
 		}
 
 		if ( isset( $_GET['_subscription_related_orders'] ) && $_GET['_subscription_related_orders'] > 0 ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$initial_order = wc_get_order( absint( $_GET['_subscription_related_orders'] ) ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$subscription_id = absint( $_GET['_subscription_related_orders'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$subscription    = wcs_get_subscription( $subscription_id );
+
+			// Display an error notice if we can't find the subscription.
+			if ( ! $subscription ) {
+				echo '<div id="moderated" class="error"><p>';
+				// translators: placeholder is a subscription ID.
+				printf( esc_html__( 'We can\'t find a subscription with ID #%d. Perhaps it was deleted?', 'woocommerce-subscriptions' ), esc_html( $subscription_id ) );
+				echo '</p></div>';
+				return;
+			}
 
 			echo '<div class="updated dismiss-subscriptions-search"><p>';
 			// translators: placeholders are opening link tag, ID of sub, and closing link tag
-			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( wcs_get_edit_post_link( absint( $_GET['_subscription_related_orders'] ) ) ) . '">', esc_html( $subscription->get_order_number() ), '</a>' ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( wcs_get_edit_post_link( $subscription ) ) . '">', esc_html( $subscription->get_order_number() ), '</a>' );
 			echo '</p>';
 			printf(
 				'<a href="%1$s" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></a>',

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1486,7 +1486,7 @@ class WC_Subscriptions_Admin {
 	public static function display_renewal_filter_notice() {
 		$is_hpos_in_use = wcs_is_custom_order_tables_usage_enabled();
 
-		// When HPOS is enabled, we can't use the $found_related_orders static variable to determine if the list is filtered or not.
+		// When HPOS is disabled, use the $found_related_orders static variable to determine if the Orders list is filtered or not.
 		if ( ! $is_hpos_in_use && ! self::$found_related_orders ) {
 			return;
 		}

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1356,15 +1356,20 @@ class WC_Subscriptions_Admin {
 	}
 
 	/**
-	 * Filter the Orders Table in HPOS to show only orders associated with a specific subscription.
+	 * Filters the Orders Table in HPOS to display_renewal_filter_noticehow only orders associated with a specific subscription.
 	 *
 	 * @since 5.2.0
 	 *
-	 * @param array $query_vars
+	 * @param array $query_vars The query variables.
 	 *
-	 * @return array
+	 * @return array The query variables.
 	 */
 	public static function filter_orders_table_by_related_orders( $query_vars ) {
+		/**
+		 * Exit early if the request is not to filter the order list table.
+		 *
+		 * Note this request isn't nonced as we're only filtering an admin list table and not modifying data.
+		 */
 		if ( ! ( is_admin() && isset( $_GET['_subscription_related_orders'] ) && $_GET['_subscription_related_orders'] > 0 ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $query_vars;
 		}
@@ -1489,6 +1494,9 @@ class WC_Subscriptions_Admin {
 			return;
 		}
 
+		/**
+		 * This request URL isn't nonced because it's only used to display a notice to the user.
+		 */
 		if ( isset( $_GET['_subscription_related_orders'] ) && $_GET['_subscription_related_orders'] > 0 ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$subscription_id = absint( $_GET['_subscription_related_orders'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$subscription    = wcs_get_subscription( $subscription_id );

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1484,10 +1484,8 @@ class WC_Subscriptions_Admin {
 	 * @see self::filter_orders()
 	 */
 	public static function display_renewal_filter_notice() {
-		$is_hpos_in_use = wcs_is_custom_order_tables_usage_enabled();
-
 		// When HPOS is disabled, use the $found_related_orders static variable to determine if the Orders list is filtered or not.
-		if ( ! $is_hpos_in_use && ! self::$found_related_orders ) {
+		if ( ! wcs_is_custom_order_tables_usage_enabled() && ! self::$found_related_orders ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1496,7 +1496,7 @@ class WC_Subscriptions_Admin {
 
 			echo '<div class="updated dismiss-subscriptions-search"><p>';
 			// translators: placeholders are opening link tag, ID of sub, and closing link tag
-			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( get_edit_post_link( absint( $_GET['_subscription_related_orders'] ) ) ) . '">', esc_html( $initial_order->get_order_number() ), '</a>' ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( wcs_get_edit_post_link( absint( $_GET['_subscription_related_orders'] ) ) ) . '">', esc_html( $subscription->get_order_number() ), '</a>' ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			echo '</p>';
 			printf(
 				'<a href="%1$s" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></a>',

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -978,11 +978,11 @@ class WCS_Admin_Post_Types {
 	 * @return string the link string
 	 */
 	public function get_related_orders_link( $the_subscription ) {
-		$orders_table_url = wcs_is_custom_order_tables_usage_enabled() ? 'admin.php?page=wc-orders' : 'edit.php?post_type=shop_order';
+		$orders_table_url = wcs_is_custom_order_tables_usage_enabled() ? 'admin.php?page=wc-orders&status=all' : 'edit.php?post_type=shop_order&post_status=all';
 
 		return sprintf(
 			'<a href="%s">%s</a>',
-			admin_url( $orders_table_url . '&post_status=all&_subscription_related_orders=' . absint( $the_subscription->get_id() ) ),
+			admin_url( $orders_table_url . '&_subscription_related_orders=' . absint( $the_subscription->get_id() ) ),
 			count( $the_subscription->get_related_orders() )
 		);
 	}

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -978,9 +978,11 @@ class WCS_Admin_Post_Types {
 	 * @return string the link string
 	 */
 	public function get_related_orders_link( $the_subscription ) {
+		$orders_table_url = wcs_is_custom_order_tables_usage_enabled() ? 'admin.php?page=wc-orders' : 'edit.php?post_type=shop_order';
+
 		return sprintf(
 			'<a href="%s">%s</a>',
-			admin_url( 'edit.php?post_status=all&post_type=shop_order&_subscription_related_orders=' . absint( $the_subscription->get_id() ) ),
+			admin_url( $orders_table_url . '&post_status=all&_subscription_related_orders=' . absint( $the_subscription->get_id() ) ),
 			count( $the_subscription->get_related_orders() )
 		);
 	}


### PR DESCRIPTION
Fixes #199 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

When you have HPOS enabled, clicking on a subscriptions related orders link on the Subscriptions table page (see below) would send you to the orders table but every order was being loaded (it should only list the order that relate to the subscription)

![image](https://user-images.githubusercontent.com/2275145/210685432-742449e0-b5cc-4378-800b-0c8c654766f7.png)

This PR fixes this issue as well as addresses some extra changes to improve HPOS compatibility.


To filter the orders table, we previously hooked onto the `posts_where` which doesn't work in HPOS therefore we need to use an equivalent hook found in the `Automattic\WooCommerce\Internal\Admin\Orders\ListTable` class.

```
woocommerce_shop_order_list_table_prepare_items_query_args
```

This hook is used to filter the List Orders table by modifying the args sent to `wc_get_orders( $args )` so I created a new `filter_orders_table_by_related_orders()` function instead of trying to repurpose the existing function attached to the `posts_where` filter.

Because this new hook occurs at a different time, we can't add admin notices so I had to update `display_renewal_filter_notice()` to handle displaying the appropriate admin notices.

In this PR I also updated `get_related_orders_link()` to return the HPOS and non-HPOS Orders List table urls.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPOS on your store
2. Purchase two or more subscriptions and process a bunch of renewals for one of the subscriptions
3. From the **WooCommerce > Subscriptions**, click on one of the Related Order count link
4. Make sure the Orders table is filtered to only show orders that belong to the subscription you clicked.
5. On `trunk`, this table isn't filtered and all orders are being shown

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
