### PR TITLE
[HPOS] Replace remaining delete post code in subscriptions to use CRUD methods/hooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.
 * Dev - Introduced a new `untrash_order()` in the `WCS_Orders_Table_Subscription_Data_Store` class to fix untrashing subscriptions on stores that have HPOS enabled.
 * Dev - Moved the trash, untrash & delete related `add_actions()` in the `WC_Subscriptions_Manager` class to be added on the `woocommerce_loaded` action.
+* Dev - Update `wp_delete_post()` code that was used to delete a subscription to use CRUD methods to support HPOS.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -89,7 +89,7 @@ class WC_Subscriptions_Checkout {
 
 			remove_action( $action_hook, 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
 			foreach ( $subscriptions as $subscription ) {
-				$subscription->delete();
+				$subscription->delete( true );
 			}
 			add_action( $action_hook, 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
 		}

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -85,7 +85,7 @@ class WC_Subscriptions_Checkout {
 		$subscriptions = wcs_get_subscriptions_for_order( wcs_get_objects_property( $order, 'id' ), array( 'order_type' => 'parent' ) );
 
 		if ( ! empty( $subscriptions ) ) {
-			$action_hook = wcs_is_custom_order_tables_usage_enabled() ? 'woocommerce_before_trash_subscription' : 'before_delete_post';
+			$action_hook = wcs_is_custom_order_tables_usage_enabled() ? 'woocommerce_before_delete_subscription' : 'before_delete_post';
 
 			remove_action( $action_hook, 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
 			foreach ( $subscriptions as $subscription ) {

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -85,11 +85,13 @@ class WC_Subscriptions_Checkout {
 		$subscriptions = wcs_get_subscriptions_for_order( wcs_get_objects_property( $order, 'id' ), array( 'order_type' => 'parent' ) );
 
 		if ( ! empty( $subscriptions ) ) {
-			remove_action( 'before_delete_post', 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
+			$action_hook = wcs_is_custom_order_tables_usage_enabled() ? 'woocommerce_before_trash_subscription' : 'before_delete_post';
+
+			remove_action( $action_hook, 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
 			foreach ( $subscriptions as $subscription ) {
-				wp_delete_post( $subscription->get_id() );
+				$subscription->delete();
 			}
-			add_action( 'before_delete_post', 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
+			add_action( $action_hook, 'WC_Subscriptions_Manager::maybe_cancel_subscription' );
 		}
 
 		WC_Subscriptions_Cart::set_global_recurring_shipping_packages();

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -801,7 +801,7 @@ class WC_Subscriptions_Manager {
 	public static function clear_users_subscriptions_from_order( $order ) {
 
 		foreach ( wcs_get_subscriptions_for_order( $order, array( 'order_type' => 'parent' ) ) as $subscription_id => $subscription ) {
-			wp_delete_post( $subscription->get_id() );
+			$subscription->delete();
 		}
 
 		do_action( 'cleared_users_subscriptions_from_order', $order );

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -801,7 +801,7 @@ class WC_Subscriptions_Manager {
 	public static function clear_users_subscriptions_from_order( $order ) {
 
 		foreach ( wcs_get_subscriptions_for_order( $order, array( 'order_type' => 'parent' ) ) as $subscription_id => $subscription ) {
-			$subscription->delete();
+			$subscription->delete( true );
 		}
 
 		do_action( 'cleared_users_subscriptions_from_order', $order );

--- a/includes/class-wcs-download-handler.php
+++ b/includes/class-wcs-download-handler.php
@@ -43,7 +43,7 @@ class WCS_Download_Handler {
 	 */
 	public static function attach_wc_dependent_hooks() {
 		if ( wcs_is_custom_order_tables_usage_enabled() ) {
-			add_action( 'woocommerce_delete_subscription', [ __CLASS__, 'delete_subscription_permissions' ] );
+			add_action( 'woocommerce_delete_subscription', [ __CLASS__, 'delete_subscription_download_permissions' ] );
 		} else {
 			add_action( 'deleted_post', [ __CLASS__, 'delete_subscription_permissions' ] );
 		}
@@ -203,11 +203,21 @@ class WCS_Download_Handler {
 	 * @param $id The ID of the subscription whose downloadable product permission being deleted.
 	 */
 	public static function delete_subscription_permissions( $id ) {
-		global $wpdb;
-
 		if ( 'shop_subscription' === WC_Data_Store::load( 'subscription' )->get_order_type( $id ) ) {
-			$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE order_id = %d", $id ) );
+			self::delete_subscription_download_permissions_query( $id );
 		}
+	}
+
+	/**
+	 * Remove download permissions attached to a subscription when it is permenantly deleted.
+	 *
+	 * @since 5.2.0
+	 *
+	 * @param $id The ID of the subscription whose downloadable product permission being deleted.
+	 */
+	public static function delete_subscription_download_permissions( $id ) {
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE order_id = %d", $id ) );
 	}
 
 	/**

--- a/includes/class-wcs-download-handler.php
+++ b/includes/class-wcs-download-handler.php
@@ -31,9 +31,22 @@ class WCS_Download_Handler {
 
 		add_action( 'woocommerce_admin_created_subscription', array( __CLASS__, 'grant_download_permissions' ) );
 
-		add_action( 'deleted_post', __CLASS__ . '::delete_subscription_permissions' );
+		add_action( 'woocommerce_loaded', [ __CLASS__, 'attach_wc_dependent_hooks' ] );
 
 		add_action( 'woocommerce_process_product_file_download_paths', __CLASS__ . '::grant_new_file_product_permissions', 11, 3 );
+	}
+
+	/**
+	 * Attach hooks that depend on WooCommerce being loaded.
+	 *
+	 * @since 5.2
+	 */
+	public static function attach_wc_dependent_hooks() {
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			add_action( 'woocommerce_delete_subscription', [ __CLASS__, 'delete_subscription_permissions' ] );
+		} else {
+			add_action( 'deleted_post', [ __CLASS__, 'delete_subscription_permissions' ] );
+		}
 	}
 
 	/**

--- a/includes/class-wcs-download-handler.php
+++ b/includes/class-wcs-download-handler.php
@@ -204,7 +204,7 @@ class WCS_Download_Handler {
 	 */
 	public static function delete_subscription_permissions( $id ) {
 		if ( 'shop_subscription' === WC_Data_Store::load( 'subscription' )->get_order_type( $id ) ) {
-			self::delete_subscription_download_permissions_query( $id );
+			self::delete_subscription_download_permissions( $id );
 		}
 	}
 


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR replaces the remaining `wp_delete_post()` function calls and `deleted_post` hooks that was interacting with Subscription objects.

These instances have all been replaced with the `$subscription->delete()` equivalent and `woocommerce_delete_subscription` hooks.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should be sufficient here, however, to test these changes:

1. Purchase a downloadable subscription product.
2. Check the `woocommerce_downloadable_product_permissions` table for a row with the subscription ID in the `order_id` column
3. Run the following snippet below to force delete a subscription
4. Confirm the download permissions have also been removed.

```
$subscription = wcs_get_subscription( 123 );
$subscription->delete( true );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
