### PR TITLE
Fix function deprecation warning in PHP >= 8.1

### DIFF
--- a/includes/wcs-time-functions.php
+++ b/includes/wcs-time-functions.php
@@ -629,8 +629,8 @@ function wcs_is_datetime_mysql_format( $time ) {
 		return false;
 	}
 
-	if ( function_exists( 'strptime' ) && PHP_VERSION_ID < 80100 ) {
-		// strptime is deprecated since PHP 8.1
+	if ( function_exists( 'strptime' ) && ( ! defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80100 ) ) {
+		// use strptime if it exists and PHP < 8.1, as this function was deprecated in that version
 		$valid_time = $match = ( false !== strptime( $time, '%Y-%m-%d %H:%M:%S' ) );
 	} else {
 		// parses for the pattern of YYYY-MM-DD HH:MM:SS, but won't check whether it's a valid timedate

--- a/includes/wcs-time-functions.php
+++ b/includes/wcs-time-functions.php
@@ -629,7 +629,8 @@ function wcs_is_datetime_mysql_format( $time ) {
 		return false;
 	}
 
-	if ( function_exists( 'strptime' ) ) {
+	if ( function_exists( 'strptime' ) && PHP_VERSION_ID < 80100 ) {
+		// strptime is deprecated since PHP 8.1
 		$valid_time = $match = ( false !== strptime( $time, '%Y-%m-%d %H:%M:%S' ) );
 	} else {
 		// parses for the pattern of YYYY-MM-DD HH:MM:SS, but won't check whether it's a valid timedate


### PR DESCRIPTION
Fixes #212

## Description

This PR fixes the problem that causes a deprecation warning in PHP 8.1 due to the usage of function strptime.

As the method already includes a fallback for the cases where strptime is not available (like Windows), I've simply added a check so in PHP >= 8.1 we use the alternative implementation.


## How to test this PR

Function "wcs_is_datetime_mysql_format()" should keep working as it does until now, but without generating a warning in PHP >= 8.1.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
