### PR TITLE
Reorder the subscription line items metabox on hpos environments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - Prevent erroneously resyncing a subscription every time it is loaded from the database on HPOS environments.
 * Fix - Fix "Trying to get property 'ID' of non-object" errors on the edit subscription screen when HPOS is enabled.
 * Fix - When HPOS is enabled, clicking the related orders link on the Subscriptions Table now filters the table with the related orders (previously all orders were shown).
+* Fix - Reorder the edit subscription meta boxes on HPOS environments so the line items meta box appears after the subscription data.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -102,6 +102,11 @@ class WCS_Admin_Meta_Boxes {
 		if ( $post_or_order_object && $current_screen && $current_screen->id === $order_screen_id && wcs_order_contains_subscription( $post_or_order_object, 'any' ) ) {
 			add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', $order_screen_id, 'normal', 'low' );
 		}
+
+		// On HPOS environments we need to remove and readd the line items metabox so it appears after the subscription data.
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			self::reorder_subscription_line_items_metabox();
+		}
 	}
 
 	/**
@@ -678,5 +683,43 @@ class WCS_Admin_Meta_Boxes {
 		}
 
 		wp_send_json( $customer_orders );
+	}
+
+	/**
+	 * Reorders the edit subscription screen metaboxes.
+	 *
+	 * Removes and readds the order items metabox so it appears after the subscription data.
+	 *
+	 * On HPOS environments, WC core registers the order-data and order-items metaboxes on a high priority before we've had a chance to add ours.
+	 * This means, on the edit subscription screen, when we remove the order-data metabox and add our own, it will appear after the line items.
+	 *
+	 * In order to keep the correct ordering of the metaboxes on the edit subscription screen, we need to remove the line items metabox and
+	 * readd it after we've added the subscription-data metabox.
+	 */
+	private static function reorder_subscription_line_items_metabox() {
+		global $wp_meta_boxes;
+		$subscriptions_screen_id = wcs_get_page_screen_id( 'shop_subscription' );
+
+		// If the line items metabox isn't registered, bail.
+		if ( empty( $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'] ) ) {
+			return;
+		}
+
+		// Get a copy of the line items metabox.
+		$items_metabox = $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'];
+
+		// Forcibly remove the line items metabox to reset its ordering in the list.
+		unset( $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'] );
+
+		// Readd it.
+		add_meta_box(
+			$items_metabox['id'],
+			$items_metabox['title'],
+			$items_metabox['callback'],
+			$subscriptions_screen_id,
+			'normal',
+			'high',
+			$items_metabox['args']
+		);
 	}
 }

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -103,9 +103,9 @@ class WCS_Admin_Meta_Boxes {
 			add_meta_box( 'subscription_renewal_orders', __( 'Related Orders', 'woocommerce-subscriptions' ), 'WCS_Meta_Box_Related_Orders::output', $order_screen_id, 'normal', 'low' );
 		}
 
-		// On HPOS environments we need to remove and readd the line items metabox so it appears after the subscription data.
+		// On HPOS environments we need to remove and readd the line items meta box so it appears after the subscription data.
 		if ( wcs_is_custom_order_tables_usage_enabled() ) {
-			self::reorder_subscription_line_items_metabox();
+			self::reorder_subscription_line_items_meta_box();
 		}
 	}
 
@@ -686,40 +686,40 @@ class WCS_Admin_Meta_Boxes {
 	}
 
 	/**
-	 * Reorders the edit subscription screen metaboxes.
+	 * Reorders the edit subscription screen meta boxes.
 	 *
-	 * Removes and readds the order items metabox so it appears after the subscription data.
+	 * Removes and readds the order items meta box so it appears after the subscription data.
 	 *
-	 * On HPOS environments, WC core registers the order-data and order-items metaboxes on a high priority before we've had a chance to add ours.
-	 * This means, on the edit subscription screen, when we remove the order-data metabox and add our own, it will appear after the line items.
+	 * On HPOS environments, WC core registers the order-data and order-items meta boxes on a high priority before we've had a chance to add ours.
+	 * This means, on the edit subscription screen, when we remove the order-data meta box and add our own, it will appear after the line items.
 	 *
-	 * In order to keep the correct ordering of the metaboxes on the edit subscription screen, we need to remove the line items metabox and
-	 * readd it after we've added the subscription-data metabox.
+	 * In order to keep the correct ordering of the meta boxes on the edit subscription screen, we need to remove the line items meta box and
+	 * readd it after we've added the subscription-data meta box.
 	 */
-	private static function reorder_subscription_line_items_metabox() {
+	private static function reorder_subscription_line_items_meta_box() {
 		global $wp_meta_boxes;
 		$subscriptions_screen_id = wcs_get_page_screen_id( 'shop_subscription' );
 
-		// If the line items metabox isn't registered, bail.
+		// If the line items meta box isn't registered, bail.
 		if ( empty( $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'] ) ) {
 			return;
 		}
 
-		// Get a copy of the line items metabox.
-		$items_metabox = $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'];
+		// Get a copy of the line items meta box.
+		$items_meta_box = $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'];
 
-		// Forcibly remove the line items metabox to reset its ordering in the list.
+		// Forcibly remove the line items meta box to reset its ordering in the list.
 		unset( $wp_meta_boxes[ $subscriptions_screen_id ]['normal']['high']['woocommerce-order-items'] );
 
 		// Readd it.
 		add_meta_box(
-			$items_metabox['id'],
-			$items_metabox['title'],
-			$items_metabox['callback'],
+			$items_meta_box['id'],
+			$items_meta_box['title'],
+			$items_meta_box['callback'],
 			$subscriptions_screen_id,
 			'normal',
 			'high',
-			$items_metabox['args']
+			$items_meta_box['args']
 		);
 	}
 }


### PR DESCRIPTION
Fixes #338 

## Description

On HPOS environments the edit subscription screen metaboxes were appearing in the incorrect order - the line items meta box appeared above the subscription data. The reason this happens is because of slight differences in how the metaboxes get registered on HPOS and CPT environments. 

On CPT the `add_meta_boxes` hook is triggered by WordPress core and we can register our metaboxes before WC do for our subscription data to appear first. 

On HPOS the `add_meta_boxes` hook is triggered by WooCommerce core after they have registered their metaboxes. This results in our metaboxes appearing after theirs.

![image](https://user-images.githubusercontent.com/8490476/211973411-213347af-7e70-406a-96ba-df98eb16bb30.png)

Unforunetly WP remembers the order that metaboxes are registered and so this PR fixes that by forcibly removing the order items metabox from the global and re-registers it after we've registered the subscriptions-related ones.  

## How to test this PR

1. Enable HPOS.
2. Purchase a subscription.
3. Go to the WooCommerce > Subscriptions list table. 
4. Click on a subscription to edit it.
    - On `trunk` you notice that the line items metabox appears at the top of the screen (see screenshot above). 
    - On this branch the metabox order is correct. Subscription-data -> line items -> downloads -> custom meta - related orders etc. 

> **Note**
> This change shouldn't impact CPT stores at all. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
