### PR TITLE
[HPOS] Show Subscription status filters above list table when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,11 +18,8 @@
 * Fix - Prevent erroneously resyncing a subscription every time it is loaded from the database on HPOS environments.
 * Fix - Fix "Trying to get property 'ID' of non-object" errors on the edit subscription screen when HPOS is enabled.
 * Fix - When HPOS is enabled, clicking the related orders link on the Subscriptions Table now filters the table with the related orders (previously all orders were shown).
-<<<<<<< HEAD
 * Fix - Show subscription status filters/views above the subscriptions list table on stores with HPOS enabled.
-=======
 * Fix - Reorder the edit subscription meta boxes on HPOS environments so the line items meta box appears after the subscription data.
->>>>>>> trunk
 * Fix - On HPOS environments, prepopulate the subscription start date when creating a new subscription via the admin edit screen.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - Prevent erroneously resyncing a subscription every time it is loaded from the database on HPOS environments.
 * Fix - Fix "Trying to get property 'ID' of non-object" errors on the edit subscription screen when HPOS is enabled.
 * Fix - When HPOS is enabled, clicking the related orders link on the Subscriptions Table now filters the table with the related orders (previously all orders were shown).
+* Fix - Show subscription status filters/views above the subscriptions list table on stores with HPOS enabled.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Fix - Show subscription status filters/views above the subscriptions list table on stores with HPOS enabled.
 * Fix - Reorder the edit subscription meta boxes on HPOS environments so the line items meta box appears after the subscription data.
 * Fix - On HPOS environments, prepopulate the subscription start date when creating a new subscription via the admin edit screen.
+* Fix - On HPOS environments, handle the admin subscriptions list table bulk actions and row actions in a HPOS compatible way.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -83,8 +83,9 @@ class WCS_Admin_Post_Types {
 
 		add_action( 'list_table_primary_column', array( $this, 'list_table_primary_column' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'shop_subscription_row_actions' ), 10, 2 );
-	}
 
+		add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders--shop_subscription', [ $this, 'handle_subscription_bulk_actions' ], 10, 3 );
+	}
 
 	/**
 	 * Modifies the actual SQL that is needed to order by last payment date on subscriptions. Data is pulled from related
@@ -344,103 +345,84 @@ class WCS_Admin_Post_Types {
 			$action = wc_clean( wp_unslash( $_REQUEST['action2'] ) );
 		}
 
-		switch ( $action ) {
-			case 'active':
-			case 'on-hold':
-			case 'cancelled':
-				$new_status = $action;
-				break;
-			default:
-				return;
+		if ( ! in_array( $action, array( 'active', 'on-hold', 'cancelled' ), true ) ) {
+			return;
 		}
 
-		$report_action = 'marked_' . $new_status;
+		$subscription_ids  = array_map( 'absint', (array) $_REQUEST['post'] );
+		$base_redirect_url = wp_get_referer() ? wp_get_referer() : '';
+		$redirect_url      = $this->handle_subscription_bulk_actions( $base_redirect_url, $action, $subscription_ids );
 
-		$changed = 0;
-
-		$subscription_ids = array_map( 'absint', (array) $_REQUEST['post'] );
-
-		$sendback_args = array(
-			'post_type'    => 'shop_subscription',
-			$report_action => true,
-			'ids'          => join( ',', $subscription_ids ),
-			'error_count'  => 0,
-		);
-
-		foreach ( $subscription_ids as $subscription_id ) {
-			$subscription = wcs_get_subscription( $subscription_id );
-			$order_note   = _x( 'Subscription status changed by bulk edit:', 'Used in order note. Reason why status changed.', 'woocommerce-subscriptions' );
-
-			try {
-
-				if ( 'cancelled' === $action ) {
-					$subscription->cancel_order( $order_note );
-				} else {
-					$subscription->update_status( $new_status, $order_note, true );
-				}
-
-				// Fire the action hooks
-				switch ( $action ) {
-					case 'active':
-					case 'on-hold':
-					case 'cancelled':
-					case 'trash':
-						do_action( 'woocommerce_admin_changed_subscription_to_' . $action, $subscription_id );
-						break;
-				}
-
-				$changed++;
-
-			} catch ( Exception $e ) {
-				$sendback_args['error'] = urlencode( $e->getMessage() );
-				$sendback_args['error_count']++;
-			}
-		}
-
-		$sendback_args['changed'] = $changed;
-		$sendback                 = add_query_arg( $sendback_args, wp_get_referer() ? wp_get_referer() : '' );
-		wp_safe_redirect( esc_url_raw( $sendback ) );
-
+		wp_safe_redirect( $redirect_url );
 		exit();
 	}
 
 	/**
-	 * Show confirmation message that subscription status was changed
+	 * Shows confirmation message that subscription statuses were changed via bulk action.
 	 */
 	public function bulk_admin_notices() {
-		global $post_type, $pagenow;
+		$is_subscription_list_table = false;
 
-		// Bail out if not on shop order list page
-		if ( 'edit.php' !== $pagenow || 'shop_subscription' !== $post_type ) {
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			$current_screen             = get_current_screen();
+			$is_subscription_list_table = $current_screen && wcs_get_page_screen_id( 'shop_subscription' ) === $current_screen->id;
+		} else {
+			global $post_type, $pagenow;
+			$is_subscription_list_table = 'edit.php' === $pagenow && 'shop_subscription' === $post_type;
+		}
+
+		// Bail out if not on shop subscription list page.
+		if ( ! $is_subscription_list_table ) {
 			return;
 		}
 
-		$subscription_statuses = wcs_get_subscription_statuses();
-
-		// Check if any status changes happened
-		foreach ( $subscription_statuses as $slug => $name ) {
-
-			if ( isset( $_REQUEST[ 'marked_' . str_replace( 'wc-', '', $slug ) ] ) ) {
-
-				$number = isset( $_REQUEST['changed'] ) ? absint( $_REQUEST['changed'] ) : 0;
-
-				// translators: placeholder is the number of subscriptions updated
-				$message = sprintf( _n( '%s subscription status changed.', '%s subscription statuses changed.', $number, 'woocommerce-subscriptions' ), number_format_i18n( $number ) );
-				echo '<div class="updated"><p>' . esc_html( $message ) . '</p></div>';
-
-				if ( ! empty( $_REQUEST['error_count'] ) ) {
-					$error_msg = isset( $_REQUEST['error'] ) ? stripslashes( $_REQUEST['error'] ) : '';
-					$error_count = isset( $_REQUEST['error_count'] ) ? absint( $_REQUEST['error_count'] ) : 0;
-					// translators: 1$: is the number of subscriptions not updated, 2$: is the error message
-					$message = sprintf( _n( '%1$s subscription could not be updated: %2$s', '%1$s subscriptions could not be updated: %2$s', $error_count, 'woocommerce-subscriptions' ), number_format_i18n( $error_count ), $error_msg );
-					echo '<div class="error"><p>' . esc_html( $message ) . '</p></div>';
-				}
-
-				$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'error_count', 'marked_active' ), $_SERVER['REQUEST_URI'] );
-
-				break;
-			}
+		/**
+		 * If the action isn't set, return early.
+		 *
+		 * Note: Nonce verification is not required here because we're just displaying an admin notice after a verified request was made.
+		 */
+		if ( ! isset( $_REQUEST['bulk_action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
 		}
+
+		$number = isset( $_REQUEST['changed'] ) ? absint( $_REQUEST['changed'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$admin_notice = new WCS_Admin_Notice( 'updated' );
+		$admin_notice->set_simple_content(
+			sprintf(
+				// translators: placeholder is the number of subscriptions updated
+				_n( '%s subscription status changed.', '%s subscription statuses changed.', $number, 'woocommerce-subscriptions' ),
+				number_format_i18n( $number )
+			)
+		);
+		$admin_notice->display();
+
+		/**
+		 * Display an admin notice for any errors that occurred processing the bulk action
+		 *
+		 * Note: Nonce verification is ignored as we're not acting on any data from the request. We're simply displaying a message.
+		 */
+		if ( ! empty( $_REQUEST['error_count'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$error_message = isset( $_REQUEST['error'] ) ? wc_clean( wp_unslash( $_REQUEST['error'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$error_count   = isset( $_REQUEST['error_count'] ) ? absint( $_REQUEST['error_count'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			$admin_notice = new WCS_Admin_Notice( 'error' );
+			$admin_notice->set_simple_content(
+				sprintf(
+					// translators: 1$: is the number of subscriptions not updated, 2$: is the error message
+					_n( '%1$s subscription could not be updated: %2$s', '%1$s subscriptions could not be updated: %2$s', $error_count, 'woocommerce-subscriptions' ),
+					number_format_i18n( $error_count ),
+					$error_message
+				)
+			);
+			$admin_notice->display();
+		}
+
+		// Remove the query args which flags this bulk action request so WC doesn't duplicate the notice and so links generated on this page don't contain these flags.
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$_SERVER['REQUEST_URI'] = remove_query_arg( [ 'error_count', 'error', 'bulk_action', 'changed', 'ids' ], esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+		}
+		unset( $_REQUEST['ids'], $_REQUEST['bulk_action'], $_REQUEST['changed'], $_REQUEST['error_count'], $_REQUEST['error'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -1280,14 +1262,24 @@ class WCS_Admin_Post_Types {
 		// We need an instance of the post object type to be able to check user capabilities for status transition actions.
 		$post_type_object = get_post_type_object( $subscription->get_type() );
 
-		$action_url = add_query_arg(
-			array(
-				'post'     => $subscription->get_id(),
-				// Using the bulk actions nonce name as defined in WP core.
-				'_wpnonce' => wp_create_nonce( 'bulk-posts' ),
-			)
-		);
+		// Some actions URLS change depending on the environment.
+		$is_hpos_enabled = wcs_is_custom_order_tables_usage_enabled();
 
+		// On HPOS environments, WC expects a slightly different format for the bulk actions.
+		if ( $is_hpos_enabled ) {
+			$action_url_args = [
+				'order'    => [ $subscription->get_id() ],
+				'_wpnonce' => wp_create_nonce( 'bulk-orders' ),
+			];
+		} else {
+			$action_url_args = [
+				'post'     => $subscription->get_id(),
+				'_wpnonce' => wp_create_nonce( 'bulk-posts' ),
+			];
+		}
+
+		$action_url   = add_query_arg( $action_url_args );
+		$action_url   = remove_query_arg( [ 'changed', 'ids' ], $action_url );
 		$all_statuses = array(
 			'active'    => __( 'Reactivate', 'woocommerce-subscriptions' ),
 			'on-hold'   => __( 'Suspend', 'woocommerce-subscriptions' ),
@@ -1301,29 +1293,53 @@ class WCS_Admin_Post_Types {
 				continue;
 			}
 
-			if ( in_array( $status, array( 'trash', 'deleted' ), true ) ) {
-
-				if ( current_user_can( $post_type_object->cap->delete_post, $subscription->get_id() ) ) {
-
-					if ( 'trash' === $subscription->get_status() ) {
-						$actions['untrash'] = '<a title="' . esc_attr( __( 'Restore this item from the Trash', 'woocommerce-subscriptions' ) ) . '" href="' . wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $subscription->get_id() ) ), 'untrash-post_' . $subscription->get_id() ) . '">' . __( 'Restore', 'woocommerce-subscriptions' ) . '</a>';
-					} elseif ( EMPTY_TRASH_DAYS ) {
-						$actions['trash'] = '<a class="submitdelete" title="' . esc_attr( __( 'Move this item to the Trash', 'woocommerce-subscriptions' ) ) . '" href="' . get_delete_post_link( $subscription->get_id() ) . '">' . __( 'Trash', 'woocommerce-subscriptions' ) . '</a>';
-					}
-
-					if ( 'trash' === $subscription->get_status() || ! EMPTY_TRASH_DAYS ) {
-						$actions['delete'] = '<a class="submitdelete" title="' . esc_attr( __( 'Delete this item permanently', 'woocommerce-subscriptions' ) ) . '" href="' . get_delete_post_link( $subscription->get_id(), '', true ) . '">' . __( 'Delete Permanently', 'woocommerce-subscriptions' ) . '</a>';
-					}
-				}
-			} else {
-
-				if ( 'cancelled' === $status && 'pending-cancel' === $subscription->get_status() ) {
-					$label = __( 'Cancel Now', 'woocommerce-subscriptions' );
-				}
-
-				$actions[ $status ] = sprintf( '<a href="%s">%s</a>', add_query_arg( 'action', $status, $action_url ), $label );
-
+			// Trashing and deleting requires specific user capabilities.
+			if ( in_array( $status, array( 'trash', 'deleted' ), true ) && ! current_user_can( $post_type_object->cap->delete_post, $subscription->get_id() ) ) {
+				continue;
 			}
+
+			if ( 'trash' === $status ) {
+				// If the subscription is already trashed, add an untrash action instead.
+				if ( 'trash' === $subscription->get_status() ) {
+					$untrash_url        = $is_hpos_enabled ? add_query_arg( 'action', 'untrash', $action_url ) : wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $subscription->get_id() ) ), 'untrash-post_' . $subscription->get_id() );
+					$actions['untrash'] = sprintf(
+						'<a title="%s" href="%s">%s</a>',
+						esc_attr( __( 'Restore this item from the Trash', 'woocommerce-subscriptions' ) ),
+						$untrash_url,
+						__( 'Restore', 'woocommerce-subscriptions' )
+					);
+				} elseif ( EMPTY_TRASH_DAYS ) {
+					$actions['trash'] = sprintf(
+						'<a class="submitdelete" title="%s" href="%s">%s</a>',
+						esc_attr( __( 'Move this item to the Trash', 'woocommerce-subscriptions' ) ),
+						$this->get_trash_or_delete_subscription_link( $subscription->get_id(), $action_url, 'trash' ),
+						$label
+					);
+				}
+
+				// The trash action has been handled so continue to the next one.
+				continue;
+			}
+
+			// The delete action is only shown on already trashed subscriptions, or where there is no trash period.
+			if ( 'deleted' === $status && ( 'trash' === $subscription->get_status() || ! EMPTY_TRASH_DAYS ) ) {
+				$actions['delete'] = sprintf(
+					'<a class="submitdelete" title="%s" href="%s">%s</a>',
+					esc_attr( __( 'Delete this item permanently', 'woocommerce-subscriptions' ) ),
+					$this->get_trash_or_delete_subscription_link( $subscription->get_id(), $action_url, 'delete' ),
+					$label
+				);
+
+				// The delete action has been handled so continue to the next one.
+				continue;
+			}
+
+			// Modify the label for canceling if the subscription is pending cancel.
+			if ( 'cancelled' === $status && 'pending-cancel' === $subscription->get_status() ) {
+				$label = __( 'Cancel Now', 'woocommerce-subscriptions' );
+			}
+
+			$actions[ $status ] = sprintf( '<a href="%s">%s</a>', add_query_arg( 'action', $status, $action_url ), $label );
 		}
 
 		if ( 'pending' === $subscription->get_status() ) {
@@ -1374,7 +1390,6 @@ class WCS_Admin_Post_Types {
 				do_action( 'woocommerce_admin_changed_subscription_to_' . $action, $subscription_id );
 
 				$sendback_args['changed']++;
-
 			} catch ( Exception $e ) {
 				$sendback_args['error'] = rawurlencode( $e->getMessage() );
 				$sendback_args['error_count']++;
@@ -1470,6 +1485,24 @@ class WCS_Admin_Post_Types {
 			),
 			array_flip( get_post_stati( array( 'show_in_admin_status_list' => true ) ) )
 		);
+	}
+
+	/**
+	 * Generates an admin trash or delete subscription URL in a HPOS environment compatible way.
+	 *
+	 * @param int    $subscription_id The subscription to generate a trash or delete URL for.
+	 * @param string $base_action_url The base URL to add the query args to.
+	 * @param string $status          The status to generate the URL for. Should be 'trash' or 'delete'.
+	 *
+	 * @return string The admin trash or delete subscription URL.
+	 */
+	private function get_trash_or_delete_subscription_link( $subscription_id, $base_action_url, $status ) {
+
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			return add_query_arg( 'action', $status, $base_action_url );
+		}
+
+		return get_delete_post_link( $subscription_id, '', 'delete' === $status );
 	}
 
 	/** Deprecated Functions */

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1450,7 +1450,7 @@ class WCS_Admin_Post_Types {
 			esc_url( add_query_arg( 'status', $status_slug, $base_url ) ),
 			$current ? 'class="current"' : '',
 			esc_html( $status_name ),
-			absint( $status_count ),
+			absint( $status_count )
 		);
 	}
 

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -863,4 +863,18 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 
 		$wpdb->delete( self::get_meta_table_name(), [ 'meta_key' => $meta_key ], [ '%s' ] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 	}
+
+	/**
+	 * Count subscriptions by status.
+	 *
+	 * @return array
+	 */
+	public function get_subscriptions_count_by_status() {
+		global $wpdb;
+
+		$table   = self::get_orders_table_name();
+		$results = $wpdb->get_results( "SELECT status, COUNT(*) AS cnt FROM {$table} WHERE type = 'shop_subscription' GROUP BY status", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return $results ? array_combine( array_column( $results, 'status' ), array_map( 'absint', array_column( $results, 'cnt' ) ) ) : array();
+	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -591,4 +591,13 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		$delete_all = true;
 		delete_metadata( 'post', $id, $meta_key, $meta_value, $delete_all );
 	}
+
+	/**
+	 * Count subscriptions by status.
+	 *
+	 * @return array
+	 */
+	public function get_subscriptions_count_by_status() {
+		return (array) wp_count_posts( 'shop_subscription' );
+	}
 }


### PR DESCRIPTION
Fixes #370 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

With HPOS enabled, when you view the Subscriptions List Table, the status filters above the table only show WC Order statuses and not subscription statuses:

![image](https://user-images.githubusercontent.com/2275145/212210001-a916ce21-981a-471f-b9ad-a23fb7b2255d.png)

Issues in this screenshot:
 - The `all(1)` count is wrong (should be 3 not 1, isn't counting subscription statuses)
 - Status filters for `Active` and `Pending Cancellation` and all other subscription statuses are missing

To fix these issues, this PR uses the `views_woocommerce_page_wc-orders--shop_subscription` hook to attach the subscription status filters/views.

Changes in this PR:
 - New data store function (`get_subscriptions_count_by_status()`) to fetch subscriptions grouped by status along with the count
 - New function `filter_subscription_list_table_views()` which generates an array of [`{Subscription Status} (count)`]() links used to filter the subscriptions table

![image](https://user-images.githubusercontent.com/2275145/212212749-a1bd69d8-05a9-484c-84df-5a3a94c01eaf.png)

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPOS 
2. Purchase a subscription and make sure the subscription has a non-order status like 'active'.
3. While on `trunk`, visit the **WooCommerce > Subscriptions** table and notice the list of statuses at the top of the table says "All (0)"
4. Check out this branch and refresh the page. You should see the status filters properly loading above the subscriptions list table.
5. Purchase more subscriptions and change the statuses to pending-cancelled and or on-hold.
6. Use the status (count) links to filter the subscriptions table by status.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
