### PR TITLE
Update WCS_Related_Order_Store_Cached_CPT to use an object cache manager on HPOS environments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - Prevent erroneously resyncing a subscription every time it is loaded from the database on HPOS environments.
 * Fix - Fix "Trying to get property 'ID' of non-object" errors on the edit subscription screen when HPOS is enabled.
 * Fix - When HPOS is enabled, clicking the related orders link on the Subscriptions Table now filters the table with the related orders (previously all orders were shown).
+* Fix - On HPOS environments, ensure subscription related order caches are updated when relationship order meta (eg `_subscription_renewal` or `_subscription_switch`) is updated.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -203,6 +203,10 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	 * }
 	 */
 	protected function trigger_update_cache_hook_from_change( $object, $key, $change ) {
-		$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'] );
+		if ( 'update' === $change['type'] ) {
+			$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'], $change['previous'] );
+		} else {
+			$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'] );
+		}
 	}
 }

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -88,6 +88,11 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		$base_data        = $object->get_base_data();
 		$meta_data        = $object->get_meta_data();
 
+		// Deleted meta won't be included in the changes, so we need to fetch the previous value via the raw meta data.
+		$data_store       = $object->get_data_store();
+		$raw_meta_data    = $data_store->read_meta( $object );
+		$raw_meta_key_map = wp_list_pluck( $raw_meta_data, 'meta_key' );
+
 		// Record the object ID so we know that it has been handled in $this->action_object_cache_changes().
 		$this->object_changes[ $object->get_id() ] = [];
 
@@ -120,16 +125,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 
 				$previous_meta = $meta->get_data();
 
-				// If the value is being deleted.
-				if ( is_null( $meta->value ) ) {
-					if ( ! empty( $meta->id ) ) {
-						$this->object_changes[ $object->get_id() ][ $data_key ] = [
-							'new'      => $meta->value,
-							'previous' => isset( $previous_meta['value'] ) ? $previous_meta['value'] : null,
-							'type'     => 'delete',
-						];
-					}
-				} elseif ( empty( $meta->id ) ) {
+				if ( empty( $meta->id ) ) {
 					// If the value is being added.
 					$this->object_changes[ $object->get_id() ][ $data_key ] = [
 						'new'  => $meta->value,
@@ -150,7 +146,18 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 					];
 				}
 
-				break;
+				// We've found the meta data for this data key, so we can move on to the next data key.
+				break 2;
+			}
+
+			// If we got this far, then the data key is stored as meta and has been deleted.
+			// When meta is deleted it won't be returned by $object->get_meta_data(). So we need to check the raw meta data.
+			if ( in_array( $data_key, $raw_meta_key_map, true ) ) {
+				$previous_meta = $raw_meta_data[ array_search( $data_key, $raw_meta_key_map, true ) ]->meta_value;
+				$this->object_changes[ $object->get_id() ][ $data_key ] = [
+					'previous' => $previous_meta,
+					'type'     => 'delete',
+				];
 			}
 		}
 	}
@@ -203,10 +210,16 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	 * }
 	 */
 	protected function trigger_update_cache_hook_from_change( $object, $key, $change ) {
-		if ( 'update' === $change['type'] ) {
-			$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'], $change['previous'] );
-		} else {
-			$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'] );
+		switch ( $change['type'] ) {
+			case 'update':
+				$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'], $change['previous'] );
+				break;
+			case 'delete':
+				$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['previous'] );
+				break;
+			default:
+				$this->trigger_update_cache_hook( $change['type'], $object->get_id(), $key, $change['new'] );
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #339

## Description

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/304 I introduced a new cache manager that works with CRUD objects rather than hooking onto post related hooks. 

As brief explainer, the cache managers essentially listen for changes to specific objects (posts or crud objects) for changes to specific meta keys or properties. When a relevant change occurs, the cache manager's job is to trigger a hook to let the cache's know that the cache needs to be updated.

Prior to this PR the `WCS_Related_Order_Store_Cached_CPT` cache still used the old `WCS_Post_Meta_Cache_Manager` which meant changes to related order meta flags (eg `subscription_renewal`) on HPOS environments wouldn't be picked up by the `WCS_Post_Meta_Cache_Manager`, and so the subscription's related order cache wouldn't be updated.

This PR fixes that. 

> **Note**
> This PR mostly impacts 3rd parties who set or change related order meta via `update_meta()` rather than use the related order APIs like `WCS_Related_Order_Store::instance()->add_relation()` 

## How to test this PR

1. Enable **HPOS** tables. 
2. Run the following code snippets.
3. After running each snippet, observe the subscription related order in the UI and in the database to ensure the expected outcome is achieved. 
4. Enable **CPT** tables. 
2. Run the following code snippets.
3. After running each snippet, observe the subscription related order in the UI and in the database to ensure the expected outcome is achieved. 

### Code snippets for testing

**New order**

```php
$order = new WC_Order();
$order->update_meta_data( '_subscription_renewal', 925 ); // <- Where 925 is a subscription ID.
$order->save();
```
Expectation: A newly created order is created. The subscription 925 has the new order in its renewal order related cache.

**Change order**
```php
$order = wc_get_order( 123 ); // <- where 123 is the order you created in the last test (a renewal order).
$order->update_meta_data( '_subscription_renewal', 100 ); // <- Where 925 is a different subscription ID.
$order->save();
```

Expectation: The order (123) changes from being a renewal order for 925, to being a renewal order for 927. Subscription 925 shouldn't have the renewal order 123 in its cache, 927 should. 

**Delete relation**
```php
$order = wc_get_order( 123 ); // <- where 123 is the order you created in the last test (a renewal order).
$order->delete_meta_data( '_subscription_renewal' ); // <- Where 925 is a different subscription ID.
$order->save();
```

Expectation: The order (123) changes from being a renewal order for 925, to no longer being a renewal order at all. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
