### PR TITLE
Refactor WC_Subscriptions_Tracker to support HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
 * Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
+* Fix - Refactor the `WC_Subscriptions_Tracker` class to support HPOS stores.
 * Fix - Check whether the order actually exists before accessing order properties in wcs_order_contains_subscription()
 * Fix - Replace the get_posts() used in get_subscriptions_from_token() to support HPOS stores.
 * Fix - On HPOS stores, when a subscription's parent order is trashed or deleted, make sure the related subscription is also trashed or deleted.

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -156,8 +156,8 @@ class WC_Subscriptions_Tracker {
 				0
 			);
 
-			$order_totals[ $relation_type . '_count' ] = $count;
 			$order_totals[ $relation_type . '_gross' ] = $total;
+			$order_totals[ $relation_type . '_count' ] = $count;
 		}
 
 		// Finally, get the initial revenue and count.

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -124,33 +124,20 @@ class WC_Subscriptions_Tracker {
 
 		// Get the subtotal and count for each subscription type.
 		foreach ( $relation_types as $relation_type ) {
-			$query_args = [
-				'type'       => 'shop_order',
-				'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-				'limit'      => -1,
-				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'     => '_subscription_' . $relation_type,
-						'compare' => 'EXISTS',
+			// Get orders with the given relation type.
+			$relation_orders = wcs_get_orders_with_meta_query(
+				[
+					'type'       => 'shop_order',
+					'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+					'limit'      => -1,
+					'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						[
+							'key'     => '_subscription_' . $relation_type,
+							'compare' => 'EXISTS',
+						],
 					],
-				],
-			];
-
-			// Prepare the handler for the query to get the orders for this relation type.
-			// Filter required when using CPT (HPOS disabled).
-			$relation_type_query_handler = function( $query ) use ( $relation_type ) {
-				$query['meta_query'][] = [
-					'key'     => '_subscription_' . $relation_type,
-					'compare' => 'EXISTS',
-				];
-				return $query;
-			};
-			add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
-
-			// Fetch the orders.
-			$relation_orders = wc_get_orders( $query_args );
-
-			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
+				]
+			);
 
 			// Sum the totals and count the orders.
 			$count = count( $relation_orders );
@@ -167,43 +154,28 @@ class WC_Subscriptions_Tracker {
 		}
 
 		// Finally, get the initial revenue and count.
-		// Prepare the query to get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
-		$query_args = [
-			'type'       => 'shop_order',
-			'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-			'limit'      => -1,
-			'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				[
-					'key'     => '_subscription_switch',
-					'compare' => 'NOT EXISTS',
+		// Get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
+		$initial_subscription_orders = wcs_get_orders_with_meta_query(
+			[
+				'type'       => 'shop_order',
+				'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+				'limit'      => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => '_subscription_switch',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'     => '_subscription_renewal',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'     => '_subscription_resubscribe',
+						'compare' => 'NOT EXISTS',
+					],
 				],
-				[
-					'key'     => '_subscription_renewal',
-					'compare' => 'NOT EXISTS',
-				],
-				[
-					'key'     => '_subscription_resubscribe',
-					'compare' => 'NOT EXISTS',
-				],
-			],
-		];
-
-		// Filter required when using CPT (HPOS disabled).
-		$initial_type_query_handler = function( $query ) use ( $relation_types ) {
-			foreach ( $relation_types as $relation_type ) {
-				$query['meta_query'][] = [
-					'key'     => '_subscription_' . $relation_type,
-					'compare' => 'NOT EXISTS',
-				];
-			}
-			return $query;
-		};
-		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
-
-		// Fetch the orders.
-		$initial_subscription_orders = wc_get_orders( $query_args );
-
-		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
+			]
+		);
 
 		// Sum the totals and count the orders.
 		$initial_order_count = count( $initial_subscription_orders );

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -101,7 +101,7 @@ class WC_Subscriptions_Tracker {
 	 * @return array
 	 */
 	private static function get_subscription_counts() {
-		$subscription_counts      = array();
+		$subscription_counts      = [];
 		$subscription_counts_data = wp_count_posts( 'shop_subscription' );
 		foreach ( wcs_get_subscription_statuses() as $status_slug => $status_name ) {
 			$subscription_counts[ $status_slug ] = $subscription_counts_data->{ $status_slug };
@@ -201,27 +201,27 @@ class WC_Subscriptions_Tracker {
 	private static function get_subscription_dates() {
 		// Ignore subscriptions with status 'trash'.
 		$first = wcs_get_subscriptions(
-			array(
+			[
 				'subscriptions_per_page' => 1,
 				'orderby'                => 'date',
 				'order'                  => 'ASC',
 				'subscription_status'    => [ 'active', 'on-hold', 'pending', 'cancelled', 'expired' ],
-			)
+			]
 		);
 		$last  = wcs_get_subscriptions(
-			array(
+			[
 				'subscriptions_per_page' => 1,
 				'orderby'                => 'date',
 				'order'                  => 'DESC',
 				'subscription_status'    => [ 'active', 'on-hold', 'pending', 'cancelled', 'expired' ],
-			)
+			]
 		);
 
 		// Return each date in 'Y-m-d H:i:s' format or '-' if no subscriptions found.
-		$min_max = array(
+		$min_max = [
 			'first' => count( $first ) ? array_shift( $first )->get_date( 'date_created' ) : '-',
 			'last'  => count( $last ) ? array_shift( $last )->get_date( 'date_created' ) : '-',
-		);
+		];
 
 		return $min_max;
 	}

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -98,7 +98,7 @@ class WC_Subscriptions_Tracker {
 	/**
 	 * Gets subscription counts.
 	 *
-	 * @return array
+	 * @return array Subscription count by status. Keys are subscription status slugs, values are subscription counts (string).
 	 */
 	private static function get_subscription_counts() {
 		$subscription_counts = [];
@@ -106,13 +106,15 @@ class WC_Subscriptions_Tracker {
 		foreach ( wcs_get_subscription_statuses() as $status_slug => $status_name ) {
 			$subscription_counts[ $status_slug ] = $count_by_status[ $status_slug ] ?? 0;
 		}
+		// Ensure all values are strings.
+		$subscription_counts = array_map( 'strval', $subscription_counts );
 		return $subscription_counts;
 	}
 
 	/**
 	 * Gets subscription order counts and totals.
 	 *
-	 * @return array
+	 * @return array Subscription order counts and totals by type (initial, switch, renewal, resubscribe). Values are returned as strings.
 	 */
 	private static function get_subscription_orders() {
 		$order_totals   = [];
@@ -189,6 +191,9 @@ class WC_Subscriptions_Tracker {
 
 		$order_totals['initial_gross'] = $initial_order_total;
 		$order_totals['initial_count'] = $initial_order_count;
+
+		// Ensure all values are strings.
+		$order_totals = array_map( 'strval', $order_totals );
 
 		return $order_totals;
 	}

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -124,8 +124,20 @@ class WC_Subscriptions_Tracker {
 
 		// Get the subtotal and count for each subscription type.
 		foreach ( $relation_types as $relation_type ) {
+			$query_args = [
+				'type'       => 'shop_order',
+				'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+				'limit'      => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => '_subscription_' . $relation_type,
+						'compare' => 'EXISTS',
+					],
+				],
+			];
 
 			// Prepare the handler for the query to get the orders for this relation type.
+			// Filter required when using CPT (HPOS disabled).
 			$relation_type_query_handler = function( $query ) use ( $relation_type ) {
 				$query['meta_query'][] = [
 					'key'     => '_subscription_' . $relation_type,
@@ -136,13 +148,7 @@ class WC_Subscriptions_Tracker {
 			add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
 
 			// Fetch the orders.
-			$relation_orders = wc_get_orders(
-				[
-					'type'   => 'shop_order',
-					'status' => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-					'limit'  => -1,
-				]
-			);
+			$relation_orders = wc_get_orders( $query_args );
 
 			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
 
@@ -161,7 +167,28 @@ class WC_Subscriptions_Tracker {
 		}
 
 		// Finally, get the initial revenue and count.
-		// Prepare the handler for the query to get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
+		// Prepare the query to get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
+		$query_args = [
+			'type'       => 'shop_order',
+			'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+			'limit'      => -1,
+			'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => '_subscription_switch',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_subscription_renewal',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_subscription_resubscribe',
+					'compare' => 'NOT EXISTS',
+				],
+			],
+		];
+
+		// Filter required when using CPT (HPOS disabled).
 		$initial_type_query_handler = function( $query ) use ( $relation_types ) {
 			foreach ( $relation_types as $relation_type ) {
 				$query['meta_query'][] = [
@@ -174,13 +201,7 @@ class WC_Subscriptions_Tracker {
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
 
 		// Fetch the orders.
-		$initial_subscription_orders = wc_get_orders(
-			[
-				'type'   => 'shop_order',
-				'status' => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-				'limit'  => -1,
-			]
-		);
+		$initial_subscription_orders = wc_get_orders( $query_args );
 
 		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
 

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -101,10 +101,10 @@ class WC_Subscriptions_Tracker {
 	 * @return array
 	 */
 	private static function get_subscription_counts() {
-		$subscription_counts      = [];
-		$subscription_counts_data = wp_count_posts( 'shop_subscription' );
+		$subscription_counts = [];
+		$count_by_status     = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
 		foreach ( wcs_get_subscription_statuses() as $status_slug => $status_name ) {
-			$subscription_counts[ $status_slug ] = $subscription_counts_data->{ $status_slug };
+			$subscription_counts[ $status_slug ] = $count_by_status[ $status_slug ] ?? 0;
 		}
 		return $subscription_counts;
 	}


### PR DESCRIPTION
Fixes #147

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR replaces SQL queries and other non-CRUD WC functions present in the `WC_Subscriptions_Tracker` class with HPOS-compatible alternatives.

This class hooks into the WC `woocommerce_tracker_data` filter to calculate and send subscription-related data about a store (opted-in only) to [`tracking.woocommerce.com/v1/`](https://github.com/woocommerce/woocommerce/blob/2de5a8f08657a70987f48421dc43706890b96e4d/plugins/woocommerce/includes/class-wc-tracker.php#L28), [once per week by default](https://github.com/woocommerce/woocommerce/blob/2de5a8f08657a70987f48421dc43706890b96e4d/plugins/woocommerce/includes/class-wc-tracker.php#L48-L60).

You can prepare and view the data to be sent without sending by running `WC_Tracker::get_tracking_data()` in the [WP Console](https://wordpress.org/plugins/wp-console/) plugin or similar.

#### Note on data types

~The data type of some values in the output has changed from `str` to `float`/`int`.~

As we talked about below, all values will be returned as a string. https://github.com/Automattic/woocommerce-subscriptions-core/pull/374#issuecomment-1385320556

This data is processed by `wp_json_encode()` in [`WC_Tracker::send_tracking_data()`](https://github.com/woocommerce/woocommerce/blob/2de5a8f08657a70987f48421dc43706890b96e4d/plugins/woocommerce/includes/class-wc-tracker.php#L75) which keeps the dtypes intact (keeps an `int` an `int`).

In practice, the new approach outputting numbers as ~`int`/`float`~ `string` is more consistent and predictable. ~However, this _may_ be a concern for backwards compatibility purposes, depending on what the recipient of this data is expecting.~

The values are received by gh-woocommerce/woocommerce-tracking-api-service and converted to a string before storing (`WC_Tracker_API_V1::save_tracking_data()`).

## Todo

- [x] `get_subscription_orders()`
  - ~This is not working properly with HPOS enabled + sync disabled.~ Fixed in c957286.
  - TIL [`wcs_get_orders_with_meta_query()`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/c95728673b2ed3d49a2d83e9085c445a6edc7b9b/includes/wcs-order-functions.php#L384). Refactor to use this helper function.
- [x] `get_subscription_dates()`
- [x] `get_subscription_counts()`. Replace `wp_count_posts()` with `get_subscriptions_count_by_status` from #372.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable WC Tracking in **WC Settings → Advanced → WooCommerce.com → Enable Tracking**.
2. Ensure your store has multiple subscriptions. Ideally, some are created in the past, including switch, renewal and resubscribes.
3. Start on `trunk` with HPOS disabled.
4. Run `WC_Tracker::get_tracking_data()` with the [WP Console](https://wordpress.org/plugins/wp-console/) plugin, noting what is output under `'extensions'=>'wc_subscriptions'`
5. Checkout this branch, enable HPOS + syncing (wait for the sync to complete).
6. Run `WC_Tracker::get_tracking_data()` again. Compare the output of `'extensions'=>'wc_subscriptions'` with what was output on `trunk`, ensuring they are identical.
   Note: run `WC_Tracker::get_tracking_data()['extensions']['wc_subscriptions']` for direct access to relevant data.

Example before (`trunk`):
```php
"subscription_orders" => [
    "switch_gross" => "0",
    "switch_count" => "3",
    "renewal_gross" => "200",
    "renewal_count" => "16",
    "resubscribe_gross" => "10",
    "resubscribe_count" => "1",
    "initial_gross" => 45,
    "initial_count" => 5,
  ],
```

After (this PR):

```php
"subscription_orders" => [
    "switch_gross" => 0.0,
    "switch_count" => 3,
    "renewal_gross" => 200.0,
    "renewal_count" => 16,
    "resubscribe_gross" => 10.0,
    "resubscribe_count" => 1,
    "initial_gross" => 45.0,
    "initial_count" => 5,
  ],
```

After `wp_json_encode()`:

```json
"subscription_orders": {
    "switch_gross": 0,
    "switch_count": 3,
    "renewal_gross": 200,
    "renewal_count": 16,
    "resubscribe_gross": 10,
    "resubscribe_count": 1,
    "initial_gross": 45,
    "initial_count": 5
  }
```


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **No deprecations**
