### PR TITLE
Fix PHPCS violations in `WC_Subscriptions_Tracker` to improve code quality

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - When a customer changes their address on their account or subscription, make sure the new address is saved when HPOS is enabled.
 * Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
 * Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
+* Fix - Refactor the `WC_Subscriptions_Tracker` class to support HPOS stores.
 * Fix - Check whether the order actually exists before accessing order properties in wcs_order_contains_subscription()
 * Fix - Replace the get_posts() used in get_subscriptions_from_token() to support HPOS stores.
 * Fix - On HPOS stores, when a subscription's parent order is trashed or deleted, make sure the related subscription is also trashed or deleted.

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@
 * Dev - Introduced a new `untrash_order()` in the `WCS_Orders_Table_Subscription_Data_Store` class to fix untrashing subscriptions on stores that have HPOS enabled.
 * Dev - Moved the trash, untrash & delete related `add_actions()` in the `WC_Subscriptions_Manager` class to be added on the `woocommerce_loaded` action.
 * Dev - Update `wp_delete_post()` code that was used to delete a subscription to use CRUD methods to support HPOS.
+* Dev - Fix phpcs violations in the `WC_Subscriptions_Tracker` class to improve code quality.
 
 = 5.1.0 - 2022-11-24 =
 * Fix - Set payment tokens when copying data between orders and subscriptions in a CRUD compatible way. Fixes PHP notices during renewal order process.

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -55,12 +55,12 @@ class WC_Subscriptions_Tracker {
 
 			// Renewals
 			'accept_manual_renewals'               => get_option( WC_Subscriptions_Admin::$option_prefix . '_accept_manual_renewals' ),
-			'turn_off_automatic_payments'          => 'no' == get_option( WC_Subscriptions_Admin::$option_prefix . '_accept_manual_renewals' ) ? 'none' : get_option( WC_Subscriptions_Admin::$option_prefix . '_turn_off_automatic_payments', 'none' ),
+			'turn_off_automatic_payments'          => 'no' === get_option( WC_Subscriptions_Admin::$option_prefix . '_accept_manual_renewals' ) ? 'none' : get_option( WC_Subscriptions_Admin::$option_prefix . '_turn_off_automatic_payments', 'none' ),
 			'enable_auto_renewal_toggle'           => get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_auto_renewal_toggle' ),
 
 			// Early renewal
 			'enable_early_renewal'                 => get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_early_renewal' ),
-			'enable_early_renewal_via_modal'       => 'no' == get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_early_renewal' ) ? 'none' : get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_early_renewal_via_modal', 'none' ),
+			'enable_early_renewal_via_modal'       => 'no' === get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_early_renewal' ) ? 'none' : get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_early_renewal_via_modal', 'none' ),
 
 			// Switching
 			'allow_switching'                      => get_option( WC_Subscriptions_Admin::$option_prefix . '_allow_switching' ),
@@ -71,8 +71,8 @@ class WC_Subscriptions_Tracker {
 
 			// Synchronization
 			'sync_payments'                        => get_option( WC_Subscriptions_Admin::$option_prefix . '_sync_payments' ),
-			'prorate_synced_payments'              => $prorate_synced_payments = ( 'no' == get_option( WC_Subscriptions_Admin::$option_prefix . '_sync_payments' ) ? 'none' : get_option( WC_Subscriptions_Admin::$option_prefix . '_prorate_synced_payments', 'none' ) ),
-			'days_no_fee'                          => 'recurring' == $prorate_synced_payments ? get_option( WC_Subscriptions_Admin::$option_prefix . '_days_no_fee', 'none' ) : 'none',
+			'prorate_synced_payments'              => $prorate_synced_payments = ( 'no' === get_option( WC_Subscriptions_Admin::$option_prefix . '_sync_payments' ) ? 'none' : get_option( WC_Subscriptions_Admin::$option_prefix . '_prorate_synced_payments', 'none' ) ),
+			'days_no_fee'                          => 'recurring' === $prorate_synced_payments ? get_option( WC_Subscriptions_Admin::$option_prefix . '_days_no_fee', 'none' ) : 'none',
 
 			// Miscellaneous
 			'max_customer_suspensions'             => get_option( WC_Subscriptions_Admin::$option_prefix . '_max_customer_suspensions' ),

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -156,8 +156,8 @@ class WC_Subscriptions_Tracker {
 				0
 			);
 
-			$order_totals[ $relation_type . '_count' ] = $count;
 			$order_totals[ $relation_type . '_gross' ] = $total;
+			$order_totals[ $relation_type . '_count' ] = $count;
 		}
 
 		// Finally, get the initial revenue and count.

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -6,7 +6,6 @@
  * @version   1.0.0 - Migrated from WooCommerce Subscriptions v2.6.4
  * @package   WooCommerce Subscriptions/Classes
  * @category  Class
- * @author    WooCommerce
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -124,33 +124,20 @@ class WC_Subscriptions_Tracker {
 
 		// Get the subtotal and count for each subscription type.
 		foreach ( $relation_types as $relation_type ) {
-			$query_args = [
-				'type'       => 'shop_order',
-				'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-				'limit'      => -1,
-				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'     => '_subscription_' . $relation_type,
-						'compare' => 'EXISTS',
+			// Get orders with the given relation type.
+			$relation_orders = wcs_get_orders_with_meta_query(
+				[
+					'type'       => 'shop_order',
+					'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+					'limit'      => -1,
+					'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						[
+							'key'     => '_subscription_' . $relation_type,
+							'compare' => 'EXISTS',
+						],
 					],
-				],
-			];
-
-			// Prepare the handler for the query to get the orders for this relation type.
-			// Filter required when using CPT (HPOS disabled).
-			$relation_type_query_handler = function( $query ) use ( $relation_type ) {
-				$query['meta_query'][] = [
-					'key'     => '_subscription_' . $relation_type,
-					'compare' => 'EXISTS',
-				];
-				return $query;
-			};
-			add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
-
-			// Fetch the orders.
-			$relation_orders = wc_get_orders( $query_args );
-
-			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
+				]
+			);
 
 			// Sum the totals and count the orders.
 			$count = count( $relation_orders );
@@ -167,43 +154,28 @@ class WC_Subscriptions_Tracker {
 		}
 
 		// Finally, get the initial revenue and count.
-		// Prepare the query to get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
-		$query_args = [
-			'type'       => 'shop_order',
-			'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-			'limit'      => -1,
-			'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				[
-					'key'     => '_subscription_switch',
-					'compare' => 'NOT EXISTS',
+		// Get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
+		$initial_subscription_orders = wcs_get_orders_with_meta_query(
+			[
+				'type'       => 'shop_order',
+				'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+				'limit'      => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => '_subscription_switch',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'     => '_subscription_renewal',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'     => '_subscription_resubscribe',
+						'compare' => 'NOT EXISTS',
+					],
 				],
-				[
-					'key'     => '_subscription_renewal',
-					'compare' => 'NOT EXISTS',
-				],
-				[
-					'key'     => '_subscription_resubscribe',
-					'compare' => 'NOT EXISTS',
-				],
-			],
-		];
-
-		// Filter required when using CPT (HPOS disabled).
-		$initial_type_query_handler = function( $query ) use ( $relation_types ) {
-			foreach ( $relation_types as $relation_type ) {
-				$query['meta_query'][] = [
-					'key'     => '_subscription_' . $relation_type,
-					'compare' => 'NOT EXISTS',
-				];
-			}
-			return $query;
-		};
-		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
-
-		// Fetch the orders.
-		$initial_subscription_orders = wc_get_orders( $query_args );
-
-		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
+			]
+		);
 
 		// Sum the totals and count the orders.
 		$initial_order_count = count( $initial_subscription_orders );

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -101,7 +101,7 @@ class WC_Subscriptions_Tracker {
 	 * @return array
 	 */
 	private static function get_subscription_counts() {
-		$subscription_counts      = array();
+		$subscription_counts      = [];
 		$subscription_counts_data = wp_count_posts( 'shop_subscription' );
 		foreach ( wcs_get_subscription_statuses() as $status_slug => $status_name ) {
 			$subscription_counts[ $status_slug ] = $subscription_counts_data->{ $status_slug };
@@ -201,27 +201,27 @@ class WC_Subscriptions_Tracker {
 	private static function get_subscription_dates() {
 		// Ignore subscriptions with status 'trash'.
 		$first = wcs_get_subscriptions(
-			array(
+			[
 				'subscriptions_per_page' => 1,
 				'orderby'                => 'date',
 				'order'                  => 'ASC',
 				'subscription_status'    => [ 'active', 'on-hold', 'pending', 'cancelled', 'expired' ],
-			)
+			]
 		);
 		$last  = wcs_get_subscriptions(
-			array(
+			[
 				'subscriptions_per_page' => 1,
 				'orderby'                => 'date',
 				'order'                  => 'DESC',
 				'subscription_status'    => [ 'active', 'on-hold', 'pending', 'cancelled', 'expired' ],
-			)
+			]
 		);
 
 		// Return each date in 'Y-m-d H:i:s' format or '-' if no subscriptions found.
-		$min_max = array(
+		$min_max = [
 			'first' => count( $first ) ? array_shift( $first )->get_date( 'date_created' ) : '-',
 			'last'  => count( $last ) ? array_shift( $last )->get_date( 'date_created' ) : '-',
-		);
+		];
 
 		return $min_max;
 	}

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -124,8 +124,20 @@ class WC_Subscriptions_Tracker {
 
 		// Get the subtotal and count for each subscription type.
 		foreach ( $relation_types as $relation_type ) {
+			$query_args = [
+				'type'       => 'shop_order',
+				'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+				'limit'      => -1,
+				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => '_subscription_' . $relation_type,
+						'compare' => 'EXISTS',
+					],
+				],
+			];
 
 			// Prepare the handler for the query to get the orders for this relation type.
+			// Filter required when using CPT (HPOS disabled).
 			$relation_type_query_handler = function( $query ) use ( $relation_type ) {
 				$query['meta_query'][] = [
 					'key'     => '_subscription_' . $relation_type,
@@ -136,13 +148,7 @@ class WC_Subscriptions_Tracker {
 			add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
 
 			// Fetch the orders.
-			$relation_orders = wc_get_orders(
-				[
-					'type'   => 'shop_order',
-					'status' => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-					'limit'  => -1,
-				]
-			);
+			$relation_orders = wc_get_orders( $query_args );
 
 			remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $relation_type_query_handler, 10 );
 
@@ -161,7 +167,28 @@ class WC_Subscriptions_Tracker {
 		}
 
 		// Finally, get the initial revenue and count.
-		// Prepare the handler for the query to get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
+		// Prepare the query to get the orders for all initial subscription orders (no switch, renewal or resubscribe meta key).
+		$query_args = [
+			'type'       => 'shop_order',
+			'status'     => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
+			'limit'      => -1,
+			'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => '_subscription_switch',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_subscription_renewal',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_subscription_resubscribe',
+					'compare' => 'NOT EXISTS',
+				],
+			],
+		];
+
+		// Filter required when using CPT (HPOS disabled).
 		$initial_type_query_handler = function( $query ) use ( $relation_types ) {
 			foreach ( $relation_types as $relation_type ) {
 				$query['meta_query'][] = [
@@ -174,13 +201,7 @@ class WC_Subscriptions_Tracker {
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
 
 		// Fetch the orders.
-		$initial_subscription_orders = wc_get_orders(
-			[
-				'type'   => 'shop_order',
-				'status' => [ 'wc-completed', 'wc-processing', 'wc-refunded' ],
-				'limit'  => -1,
-			]
-		);
+		$initial_subscription_orders = wc_get_orders( $query_args );
 
 		remove_filter( 'woocommerce_order_data_store_cpt_get_orders_query', $initial_type_query_handler, 10 );
 

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -18,7 +18,7 @@ class WC_Subscriptions_Tracker {
 	public static function init() {
 		// Only add data if Tracker enabled
 		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
-			add_filter( 'woocommerce_tracker_data', array( __CLASS__, 'add_subscriptions_tracking_data' ), 10, 1 );
+			add_filter( 'woocommerce_tracker_data', [ __CLASS__, 'add_subscriptions_tracking_data' ], 10, 1 );
 		}
 	}
 
@@ -41,7 +41,7 @@ class WC_Subscriptions_Tracker {
 	 * @return array Subscriptions options data.
 	 */
 	private static function get_subscriptions_options() {
-		return array(
+		return [
 			// Staging and live site
 			'wc_subscriptions_staging'             => WCS_Staging::is_duplicate_site() ? 'staging' : 'live',
 			'wc_subscriptions_live_url'            => esc_url( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ),
@@ -79,7 +79,7 @@ class WC_Subscriptions_Tracker {
 			'allow_zero_initial_order_without_payment_method' => get_option( WC_Subscriptions_Admin::$option_prefix . '_zero_initial_payment_requires_payment' ),
 			'drip_downloadable_content_on_renewal' => get_option( WC_Subscriptions_Admin::$option_prefix . '_drip_downloadable_content_on_renewal' ),
 			'enable_retry'                         => get_option( WC_Subscriptions_Admin::$option_prefix . '_enable_retry' ),
-		);
+		];
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-tracker.php
+++ b/includes/class-wc-subscriptions-tracker.php
@@ -101,10 +101,10 @@ class WC_Subscriptions_Tracker {
 	 * @return array
 	 */
 	private static function get_subscription_counts() {
-		$subscription_counts      = [];
-		$subscription_counts_data = wp_count_posts( 'shop_subscription' );
+		$subscription_counts = [];
+		$count_by_status     = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
 		foreach ( wcs_get_subscription_statuses() as $status_slug => $status_name ) {
-			$subscription_counts[ $status_slug ] = $subscription_counts_data->{ $status_slug };
+			$subscription_counts[ $status_slug ] = $count_by_status[ $status_slug ] ?? 0;
 		}
 		return $subscription_counts;
 	}


### PR DESCRIPTION
Based on #374. Please wait for it to be merged before reviewing/merging.

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR only fixes PHPCS violations in the `WC_Subscriptions_Tracker` class to improve code quality. No changes to the underlying logic are expected.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable WC Tracking in **WC Settings → Advanced → WooCommerce.com → Enable Tracking**.
1. Run `WC_Tracker::get_tracking_data()['extensions']['wc_subscriptions']['settings']` with the [WP Console](https://wordpress.org/plugins/wp-console/) plugin. The output should be identical on `trunk` and this branch. Toggle settings such as `enable_early_renewal_via_modal` to check the enabled/disabled output.
2. Run `./vendor/bin/phpcs includes/class-wc-subscriptions-tracker.php` in your terminal. On `trunk` you should see errors/warnings. On this branch, you should not see any violations.
   Note: running phpcs directly from `./vendor/bin/` skips the "only changed LOC" rule that we use for PHPCS GH checks.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
