### PR TITLE
Fix parent order link in subscription details box on subscription admin edit page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Fix - Reorder the edit subscription meta boxes on HPOS environments so the line items meta box appears after the subscription data.
 * Fix - On HPOS environments, prepopulate the subscription start date when creating a new subscription via the admin edit screen.
 * Fix - On HPOS environments, handle the admin subscriptions list table bulk actions and row actions in a HPOS compatible way.
+* Fix - On HPOS environments, parent order link on subscription edit page, in subscription details box, is incorrect.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -121,7 +121,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							?>
 						<p class="form-field form-field-wide">
 							<?php echo esc_html__( 'Parent order: ', 'woocommerce-subscriptions' ); ?>
-						<a href="<?php echo esc_url( wc_get_order( $subscription->get_parent_id() )->get_edit_order_url() ); ?>">
+						<a href="<?php echo esc_url( wcs_get_edit_post_link( $subscription->get_parent_id() ) ); ?>">
 							<?php
 							// translators: placeholder is an order number.
 							echo sprintf( esc_html__( '#%1$s', 'woocommerce-subscriptions' ), esc_html( $parent_order->get_order_number() ) );

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -121,7 +121,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							?>
 						<p class="form-field form-field-wide">
 							<?php echo esc_html__( 'Parent order: ', 'woocommerce-subscriptions' ); ?>
-						<a href="<?php echo esc_url( get_edit_post_link( $subscription->get_parent_id() ) ); ?>">
+						<a href="<?php echo esc_url( wc_get_order( $subscription->get_parent_id() )->get_edit_order_url() ); ?>">
 							<?php
 							// translators: placeholder is an order number.
 							echo sprintf( esc_html__( '#%1$s', 'woocommerce-subscriptions' ), esc_html( $parent_order->get_order_number() ) );


### PR DESCRIPTION
Fixes #371

## Description

Parent order link in subscription details box, below the subscription status dropdown is incorrect when HPOS is enabled with WC orders as authoritative and sync off, specific to this configuration.

<img width="419" alt="Screenshot 2023-01-13 at 03 11 36" src="https://user-images.githubusercontent.com/73803630/212159470-40da62d3-a26d-45b8-80b1-2d554dc38a2b.png">

This problem is because we call `get_edit_post_link()` [here](https://github.com/Automattic/woocommerce-subscriptions-core/blob/52aa0edfb9d7fbd788b8930a5d227a931f0abc3e/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php#L124) and since the parent order in the posts table is a post with type`shop_order_placehold`, the [_edit_link](https://github.com/WordPress/WordPress/blob/6ed4fb675ee4c48d0366e405a8e2260c52a4b146/wp-includes/link-template.php#L1472) is an empty string.

## How to test this PR

1. Enable HPOS, choose WC orders table as the authoritative data store, and set sync off.
2. Create a subscription. It can have no line items.
3. [Create a pending parent order](https://woocommerce.com/document/subscriptions/add-or-modify-a-subscription/#section-14).
4. With base branch, the parent order link below the Subscription status dropdown is empty so clicking it will just reload the same page (the subscription edit page). With head branch, the link will bring to the subscription's parent order edit page.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
