### PR TITLE
Update cache when subscription is trashed, deleted, or untrashed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@
 * Fix - On HPOS environments, handle the admin subscriptions list table bulk actions and row actions in a HPOS compatible way.
 * Fix - On HPOS environments, admin notices might show incorrect subscription or order link as part of the admin notice.
 * Fix - On HPOS environments, parent order link on subscription edit page, in subscription details box, is incorrect.
+* Fix - On HPOS environments, update cache when subscription is trashed, deleted, or restored / untrashed.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -92,7 +92,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 			return;
 		}
 
-		// If object is to be deleted, we want to update all fields, ignoring $generate_type.
+		// If object is to be deleted, we want to update all fields.
 		$force_all_fields = $is_delete_object || 'all_fields' === $generate_type;
 		$changes          = $object->get_changes();
 		$base_data        = $object->get_base_data();
@@ -219,18 +219,18 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order is to be deleted, call prepare_object_changes() to update all fields
+	 * When an order is to be deleted, prepare object changes to update all fields
 	 * and pass a flag to indicate that the object is being deleted.
 	 *
-	 * @param int      $order_id The id of order being deleted.
-	 * @param WC_Order $order    The order being deleted.
+	 * @param int   $order_id The id of the order being deleted.
+	 * @param mixed $order    The order being deleted.
 	 */
 	public function prepare_object_to_be_deleted( $order_id, $order ) {
 		$this->prepare_object_changes( $order, 'all_fields', true );
 	}
 
 	/**
-	 * When an order is trashed, gets the object and action on object changes.
+	 * When an order is trashed, action on object changes.
 	 *
 	 * @param int $order_id The id of order being restored.
 	 */
@@ -240,9 +240,11 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order has been deleted, trigger update cache hook.
+	 * When an order has been deleted, trigger update cache hook on all the object changes.
+	 * We cannot use action_object_cache_changes(), which requires an object, here because
+	 * object has been deleted.
 	 *
-	 * @param int $order_id The id of order being deleted.
+	 * @param int $order_id The id of the order being deleted.
 	 */
 	public function deleted( $order_id ) {
 		if ( ! isset( $this->object_changes[ $order_id ] ) ) {

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -93,7 +93,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		}
 
 		// If object is to be deleted, we want to update all fields, ignoring $generate_type.
-		$force_all_fields = 'all_fields' === $generate_type || $is_delete_object;
+		$force_all_fields = $is_delete_object || 'all_fields' === $generate_type;
 		$changes          = $object->get_changes();
 		$base_data        = $object->get_base_data();
 		$meta_data        = $object->get_meta_data();
@@ -207,8 +207,8 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order is restored from the trash, check if this class instance cares about updating its cache
-	 * to reflect the change.
+	 * When an order is restored from the trash, call action_object_cache_changes().
+	 * Since in this case, we didn't call prepare_object_changes(), object will be considered as new.
 	 *
 	 * @param int $order_id The order being restored.
 	 */
@@ -218,7 +218,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order is deleted, call prepare_object_changes() to update all fields
+	 * When an order is to be deleted, call prepare_object_changes() to update all fields
 	 * and pass a flag to indicate that the object is being deleted.
 	 *
 	 * @param int      $order_id The id of order being deleted.
@@ -229,8 +229,9 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order is deleted or trashed, check if this class instance cares about updating its cache
-	 * to reflect the change.
+	 * When an order is deleted or trashed, call action_object_cache_changes().
+	 * Since in this case, we called prepare_object_to_be_deleted(), object will be deleted
+	 * from cache.
 	 *
 	 * @param int $order_id The id of order being restored.
 	 */

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -224,7 +224,15 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	 * @param mixed $order    The order being deleted.
 	 */
 	public function prepare_object_to_be_deleted( $order_id, $order ) {
+		if ( ! $order->get_id() ) {
+			return;
+		}
+
 		$this->prepare_object_changes( $order, 'all_fields', true );
+
+		if ( ! isset( $this->object_changes[ $order->get_id() ] ) ) {
+			return;
+		}
 
 		// If the object is being deleted, we want to record all the changes as deletes.
 		foreach ( $this->object_changes[ $order->get_id() ] as $data_key => $data ) {

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -195,6 +195,8 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		}
 
 		if ( empty( $this->object_changes[ $object->get_id() ] ) ) {
+			// No changes to record. Unset the object ID to 'reset' $this->object_changes' state.
+			unset( $this->object_changes[ $object->get_id() ] );
 			return;
 		}
 

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -218,7 +218,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 
 	/**
 	 * When an order is to be deleted, prepare object changes to update all fields
-	 * and pass a flag to indicate that the object is being deleted.
+	 * and mark those changes as deletes.
 	 *
 	 * @param int   $order_id The id of the order being deleted.
 	 * @param mixed $order    The order being deleted.

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -231,6 +231,8 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 			$this->object_changes[ $order->get_id() ][ $data_key ]['type'] = 'delete';
 			if ( ! isset( $this->object_changes[ $order->get_id() ][ $data_key ]['previous'] ) ) {
 				$this->object_changes[ $order->get_id() ][ $data_key ]['previous'] = $data['new'];
+			}
+			if ( isset( $this->object_changes[ $order->get_id() ][ $data_key ]['new'] ) ) {
 				unset( $this->object_changes[ $order->get_id() ][ $data_key ]['new'] );
 			}
 		}

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -225,6 +225,15 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	 */
 	public function prepare_object_to_be_deleted( $order_id, $order ) {
 		$this->prepare_object_changes( $order, 'all_fields', true );
+
+		// If the object is being deleted, we want to record all the changes as deletes.
+		foreach ( $this->object_changes[ $order->get_id() ] as $data_key => $data ) {
+			$this->object_changes[ $order->get_id() ][ $data_key ]['type'] = 'delete';
+			if ( ! isset( $this->object_changes[ $order->get_id() ][ $data_key ]['previous'] ) ) {
+				$this->object_changes[ $order->get_id() ][ $data_key ]['previous'] = $data['new'];
+				unset( $this->object_changes[ $order->get_id() ][ $data_key ]['new'] );
+			}
+		}
 	}
 
 	/**

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -209,10 +209,9 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order is restored from the trash, call action_object_cache_changes().
-	 * Since in this case, we didn't call prepare_object_changes(), object will be considered as new.
+	 * When an order is restored from the trash, action on object changes.
 	 *
-	 * @param int $order_id The order being restored.
+	 * @param int $order_id The order id being restored.
 	 */
 	public function untrashed( $order_id ) {
 		$order = wc_get_order( $order_id );
@@ -231,13 +230,21 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	}
 
 	/**
-	 * When an order is trashed, call action_object_cache_changes().
-	 * We would have called prepare_object_to_be_deleted(), so object will be deleted
-	 * from cache.
+	 * When an order is trashed, gets the object and action on object changes.
 	 *
 	 * @param int $order_id The id of order being restored.
 	 */
 	public function trashed( $order_id ) {
+		$order = wc_get_order( $order_id );
+		$this->action_object_cache_changes( $order );
+	}
+
+	/**
+	 * When an order has been deleted, trigger update cache hook.
+	 *
+	 * @param int $order_id The id of order being deleted.
+	 */
+	public function deleted( $order_id ) {
 		if ( ! isset( $this->object_changes[ $order_id ] ) ) {
 			return;
 		}
@@ -248,16 +255,6 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		foreach ( $object_changes as $key => $change ) {
 			$this->trigger_update_cache_hook( $change['type'], $order_id, $key, $change['new'] );
 		}
-	}
-
-	/**
-	 * When an order has been deleted, we would have called prepare_object_to_be_deleted().
-	 *
-	 * @param int $order_id The id of order being restored.
-	 */
-	public function deleted( $order_id ) {
-		$order = wc_get_order( $order_id );
-		$this->action_object_cache_changes( $order );
 	}
 
 	/**

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -72,7 +72,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		add_action( "woocommerce_before_trash_{$this->object_type}", [ $this, 'prepare_object_to_be_deleted' ], 10, 2 );
 		add_action( "woocommerce_trash_{$object_type}", [ $this, 'trashed' ] );
 
-		add_action( "woocommerce_{$this->object_type}_untrashed", [ $this, 'untrashed' ] );
+		add_action( "woocommerce_untrash_{$this->object_type}", [ $this, 'untrashed' ] );
 	}
 
 	/**

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -67,7 +67,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		add_action( "woocommerce_after_{$this->object_type}_object_save", [ $this, 'action_object_cache_changes' ] );
 
 		add_action( "woocommerce_before_delete_{$this->object_type}", [ $this, 'prepare_object_to_be_deleted' ], 10, 2 );
-		add_action( "woocommerce_{$this->object_type}_deleted", [ $this, 'deleted' ] );
+		add_action( "woocommerce_delete_{$this->object_type}", [ $this, 'deleted' ] );
 
 		add_action( "woocommerce_before_trash_{$this->object_type}", [ $this, 'prepare_object_to_be_deleted' ], 10, 2 );
 		add_action( "woocommerce_trash_{$object_type}", [ $this, 'trashed' ] );

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -232,7 +232,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 			return;
 		}
 
-		$this->prepare_object_changes( $object, 'all_fields', true );
+		$this->prepare_object_changes( $object, 'all_fields' );
 
 		if ( ! isset( $this->object_changes[ $object->get_id() ] ) ) {
 			return;

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -70,7 +70,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		add_action( "woocommerce_{$this->object_type}_deleted", [ $this, 'deleted' ] );
 
 		add_action( "woocommerce_before_trash_{$this->object_type}", [ $this, 'prepare_object_to_be_deleted' ], 10, 2 );
-		add_action( "woocommerce_{$this->object_type}_trashed", [ $this, 'trashed' ] );
+		add_action( "woocommerce_trash_{$object_type}", [ $this, 'trashed' ] );
 
 		add_action( "woocommerce_{$this->object_type}_untrashed", [ $this, 'untrashed' ] );
 	}

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -228,11 +228,11 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 			throw new InvalidArgumentException( sprintf( __( 'Invalid update type: %s. Order update types supported are "add" or "delete". Updates are done on order meta directly.', 'woocommerce-subscriptions' ), $update_type ) );
 		}
 
-		$object = ( 'shop_order' === $this->post_type ) ? wc_get_order( $order_id ) : get_post( $order_id );
+		$order = wc_get_order( $order_id );
 
 		foreach ( $this->meta_keys as $meta_key => $value ) {
 			$property   = preg_replace( '/^_/', '', $meta_key );
-			$meta_value = ( 'add' === $update_type ) ? wcs_get_objects_property( $object, $property ) : '';
+			$meta_value = ( 'add' === $update_type ) ? wcs_get_objects_property( $order, $property ) : '';
 
 			$this->maybe_trigger_update_cache_hook( $update_type, $order_id, $meta_key, $meta_value );
 		}

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -70,7 +70,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		add_action( "woocommerce_delete_{$this->object_type}", [ $this, 'deleted' ] );
 
 		add_action( "woocommerce_before_trash_{$this->object_type}", [ $this, 'prepare_object_to_be_deleted' ], 10, 2 );
-		add_action( "woocommerce_trash_{$object_type}", [ $this, 'trashed' ] );
+		add_action( "woocommerce_trash_{$this->object_type}", [ $this, 'trashed' ] );
 
 		add_action( "woocommerce_untrash_{$this->object_type}", [ $this, 'untrashed' ] );
 	}

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -241,9 +241,11 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		// If the object is being deleted, we want to record all the changes as deletes.
 		foreach ( $this->object_changes[ $object->get_id() ] as $data_key => $data ) {
 			$this->object_changes[ $object->get_id() ][ $data_key ]['type'] = 'delete';
+
 			if ( ! isset( $this->object_changes[ $object->get_id() ][ $data_key ]['previous'] ) ) {
 				$this->object_changes[ $object->get_id() ][ $data_key ]['previous'] = $data['new'];
 			}
+
 			if ( isset( $this->object_changes[ $object->get_id() ][ $data_key ]['new'] ) ) {
 				unset( $this->object_changes[ $object->get_id() ][ $data_key ]['new'] );
 			}

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -82,18 +82,16 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 	 * Relevant changes to the object's data is stored in the $this->object_changes property
 	 * to be processed after the object is saved. See $this->action_object_cache_changes().
 	 *
-	 * @param WC_Data $object           The object which is being saved.
-	 * @param string  $generate_type    Optional. The data to generate the changes from. Defaults to 'changes_only' which will generate the data from changes to the object. 'all_fields' will fetch data from the object for all tracked data keys.
-	 * @param bool    $is_delete_object Optional. Whether the object is being deleted. Defaults to false.
+	 * @param WC_Data $object        The object which is being saved.
+	 * @param string  $generate_type Optional. The data to generate the changes from. Defaults to 'changes_only' which will generate the data from changes to the object. 'all_fields' will fetch data from the object for all tracked data keys.
 	 */
-	public function prepare_object_changes( $object, $generate_type = 'changes_only', $is_delete_object = false ) {
+	public function prepare_object_changes( $object, $generate_type = 'changes_only' ) {
 		// If the object hasn't been created yet, we can't do anything yet. We'll have to wait until after the object is saved.
 		if ( ! $object->get_id() ) {
 			return;
 		}
 
-		// If object is to be deleted, we want to update all fields.
-		$force_all_fields = $is_delete_object || 'all_fields' === $generate_type;
+		$force_all_fields = 'all_fields' === $generate_type;
 		$changes          = $object->get_changes();
 		$base_data        = $object->get_base_data();
 		$meta_data        = $object->get_meta_data();
@@ -168,13 +166,6 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 					'previous' => $previous_meta,
 					'type'     => 'delete',
 				];
-			}
-		}
-
-		// If the object is being deleted, we want to record all the changes as deletes.
-		if ( $is_delete_object ) {
-			foreach ( $this->object_changes[ $object->get_id() ] as $data_key => $data ) {
-				$this->object_changes[ $object->get_id() ][ $data_key ]['type'] = 'delete';
 			}
 		}
 	}

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -313,6 +313,13 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		}
 	}
 
+	/**
+	 * Fetches an instance of the object with the given ID.
+	 *
+	 * @param int $object_id The ID of the object to fetch.
+	 *
+	 * @return mixed The object instance, or null if it doesn't exist.
+	 */
 	private function get_object( $id ) {
 		switch ( $this->object_type ) {
 			case 'order':

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -422,16 +422,6 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 				wp_untrash_post( $id );
 			}
 
-			/**
-			 * Fires after a subscription is restored from the trash.
-			 *
-			 * @since 5.2.0
-			 *
-			 * @param int    $subscription_id Subscription ID.
-			 * @param string $previous_status The status of the subscription before it was trashed.
-			 */
-			do_action( 'woocommerce_subscription_untrashed', $subscription->get_id(), $previous_status );
-
 			return true;
 		}
 

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -422,6 +422,16 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 				wp_untrash_post( $id );
 			}
 
+			/**
+			 * Fires after a subscription is restored from the trash.
+			 *
+			 * @since 5.2.0
+			 *
+			 * @param int    $subscription_id Subscription ID.
+			 * @param string $previous_status The status of the subscription before it was trashed.
+			 */
+			do_action( 'woocommerce_subscription_untrashed', $subscription->get_id(), $previous_status );
+
 			return true;
 		}
 


### PR DESCRIPTION
Fixes #310

## Description

When HPOS on, remove a subscription from cache when it's trashed or deleted, and add it to cache if it's restored / untrashed.

Changes in this PR:
- I notice that there is no action fired after subscription is untrashed, so I added `woocommerce_subscription_untrashed`.
- Introduce a new optional argument for `prepare_object_changes()` so it knows that the object is being deleted.
- Hook to actions before subscription is trashed or deleted so we can prepare object changes.
- Hook to action after subscription is trashed to action on object changes.
- Hook to action after subscription is deleted to trigger update cache hook.
- Hook to action after subscription is untrashed.

I notice that untrashing does not update cache correctly when HPOS is off or when HPOS is on but authoritative table is set to posts table. I created a separate issue for that bug: https://github.com/Automattic/woocommerce-subscriptions-core/issues/385.

## How to test this PR

1. Enable HPOS.
2. Purchase a subscription product.
3. Trash that subscription's parent order. Make sure that subscription does not show up on My Account > Subscriptions.
4. Untrash the parent order. Make sure the subscription re-appears on My Account > Subscriptions.
5. Trash and delete the subscription's parent order. Make sure that subscription does not show up on My Account > Subscriptions.

## Product impact

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
