### PR TITLE
Fix "Subscriptions by Payment Gateway" in WC → Status when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Removed the potential for an infinite loop when getting a subscription's related orders while the subscription is being loaded.
 * Fix - Refactor `WC_Subscriptions_Renewal_Order::get_failed_order_replaced_by()` to support HPOS stores.
 * Fix - Refactor the `WC_Subscriptions_Tracker` class to support HPOS stores.
+* Fix - "Subscriptions by Payment Gateway" in WooCommerce → Status now shows the correct values when HPOS is enabled.
 * Fix - Check whether the order actually exists before accessing order properties in wcs_order_contains_subscription()
 * Fix - Replace the get_posts() used in get_subscriptions_from_token() to support HPOS stores.
 * Fix - On HPOS stores, when a subscription's parent order is trashed or deleted, make sure the related subscription is also trashed or deleted.

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -363,19 +363,51 @@ class WCS_Admin_System_Status {
 	 */
 	public static function get_subscriptions_by_gateway() {
 		global $wpdb;
-		$subscription_gatway_data = array();
+		$subscription_gateway_data = [];
 
-		$results = $wpdb->get_results( "
-			SELECT COUNT(subscriptions.ID) as count, post_meta.meta_value as payment_method, subscriptions.post_status
-			FROM $wpdb->posts as subscriptions RIGHT JOIN $wpdb->postmeta as post_meta ON post_meta.post_id = subscriptions.ID
-			WHERE subscriptions.post_type = 'shop_subscription' && post_meta.meta_key = '_payment_method'
-			GROUP BY post_meta.meta_value, subscriptions.post_status", ARRAY_A );
+		// Set variables to be used in the DB query based on whether HPOS is enabled or not.
+		$is_hpos_in_use           = wcs_is_custom_order_tables_usage_enabled();
+		$order_status_column_name = $is_hpos_in_use ? 'status' : 'post_status';
 
-		foreach ( $results as $result ) {
-			$subscription_gatway_data[ $result['payment_method'] ][ $result['post_status'] ] = $result['count'];
+		// Conduct a different query for HPOS and non-HPOS stores.
+		if ( $is_hpos_in_use ) {
+			// For HPOS stores, `payment_method` is a column in the `wc_orders` table.
+			$results = $wpdb->get_results(
+				"SELECT
+					COUNT(subscriptions.id) as count,
+					subscriptions.payment_method,
+					subscriptions.status
+				FROM {$wpdb->prefix}wc_orders as subscriptions
+				WHERE subscriptions.type = 'shop_subscription'
+				GROUP BY subscriptions.payment_method, subscriptions.status",
+				ARRAY_A
+			);
+		} else {
+			// For non-HPOS stores, `_payment_method` is a column in the `post_meta` table.
+			$results = $wpdb->get_results(
+				"SELECT
+					COUNT(subscriptions.ID) as count,
+					post_meta.meta_value as payment_method,
+					subscriptions.post_status
+				FROM {$wpdb->prefix}posts as subscriptions
+				RIGHT JOIN {$wpdb->prefix}postmeta as post_meta ON post_meta.post_id = subscriptions.ID
+				WHERE
+					subscriptions.post_type = 'shop_subscription'
+					&& post_meta.meta_key = '_payment_method'
+				GROUP BY post_meta.meta_value, subscriptions.post_status",
+				ARRAY_A
+			);
 		}
 
-		return $subscription_gatway_data;
+		foreach ( $results as $result ) {
+			// Ignore any results that don't have a payment method.
+			if ( empty( $result['payment_method'] ) ) {
+				continue;
+			}
+			$subscription_gateway_data[ $result['payment_method'] ][ $result[ $order_status_column_name ] ] = $result['count'];
+		}
+
+		return $subscription_gateway_data;
 	}
 
 	/**

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -371,7 +371,7 @@ class WCS_Admin_System_Status {
 
 		// Conduct a different query for HPOS and non-HPOS stores.
 		if ( $is_hpos_in_use ) {
-			// For HPOS stores, `payment_method` is a column in the `wc_orders` table.
+			// With HPOS enabled, `payment_method` is a column in the `wc_orders` table.
 			$results = $wpdb->get_results(
 				"SELECT
 					COUNT(subscriptions.id) as count,
@@ -383,7 +383,7 @@ class WCS_Admin_System_Status {
 				ARRAY_A
 			);
 		} else {
-			// For non-HPOS stores, `_payment_method` is a column in the `post_meta` table.
+			// With HPOS disabled, `_payment_method` is a column in the `post_meta` table.
 			$results = $wpdb->get_results(
 				"SELECT
 					COUNT(subscriptions.ID) as count,

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -383,7 +383,7 @@ class WCS_Admin_System_Status {
 				ARRAY_A
 			);
 		} else {
-			// With HPOS disabled, `_payment_method` is a column in the `post_meta` table.
+			// With HPOS disabled, `_payment_method` is a column in the `postmeta` table.
 			$results = $wpdb->get_results(
 				"SELECT
 					COUNT(subscriptions.ID) as count,

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -364,10 +364,8 @@ class WCS_Admin_System_Status {
 	public static function get_subscriptions_by_gateway() {
 		global $wpdb;
 		$subscription_gateway_data = [];
-
-		// Set variables to be used in the DB query based on whether HPOS is enabled or not.
-		$is_hpos_in_use           = wcs_is_custom_order_tables_usage_enabled();
-		$order_status_column_name = $is_hpos_in_use ? 'status' : 'post_status';
+		$is_hpos_in_use            = wcs_is_custom_order_tables_usage_enabled();
+		$order_status_column_name  = $is_hpos_in_use ? 'status' : 'post_status';
 
 		// Conduct a different query for HPOS and non-HPOS stores.
 		if ( $is_hpos_in_use ) {


### PR DESCRIPTION
Fixes #384

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR refactors the `WCS_Admin_System_Status::get_subscriptions_by_gateway()` to provide the correct subscription count by status & payment gateway when HPOS is enabled.

This function is used when rendering **Subscriptions by Payment Gateway** in **WooCommerce → Status** and the [WCS Rest API](https://github.com/woocommerce/woocommerce-subscriptions/blob/a2831c03c92bf4d28c87e0f01aeb09844f355193/includes/api/class-wc-rest-subscription-system-status-manager.php#L39).

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPOS + no syncing.
2. Purchase a few subscriptions with 1 or more payment gateways.
3. Change the status of 1 or more subscriptions (e.g. move to trash, cancel, place on hold).
5. Go to **WooCommerce → Status** and find **Subscriptions by Payment Gateway**.
6. Ensure these values are correct by comparing with **WooCommerce → Subscriptions** and filtering by Payment Gateway.
7. Enable HPOS syncing and wait for the sync to complete.
8. Ensure the **WooCommerce → Status → Subscriptions by Payment Gateway** are correct.
7. Disable HPOS.
8. Ensure the **WooCommerce → Status → Subscriptions by Payment Gateway** are correct.


**WCS REST API**

I have tested the output provided to the `/wp-json/wc/v3/system_status` endpoint when WCS is enabled, and can confirm that the results are correct with both HPOS enabled/disabled. 

This can be tested (optional) by:
1. Enable the [WooCommerce Rest API](https://woocommerce.com/document/woocommerce-rest-api/).
1. Using Postman or similar, prepare a GET request, setting up Basic Auth as per guide above.
   1. If not using HTTPS, replace `is_ssl()` with a truthy value [on this line within WC](https://github.com/woocommerce/woocommerce/blob/2de5a8f08657a70987f48421dc43706890b96e4d/plugins/woocommerce/includes/class-wc-rest-authentication.php#L82).
1. Send a `GET` request to `/wp-json/wc/v3/system_status`.
2. The relevant values will be output under `subscriptions.subscriptions_by_payment_gateway`.

Example:

```json
"subscriptions_by_payment_gateway": {
    "square_credit_card": {
        "wc-active": "1",
        "wc-cancelled": "1",
        "wc-on-hold": "2"
    },
    "woocommerce_payments": {
        "trash": "1",
        "wc-active": "3",
        "wc-cancelled": "2",
        "wc-on-hold": "1"
    }
},
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **No deprecations**
