### PR TITLE
Replace `wp_count_posts( 'shop_subscription' )` with new data store function to work with HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Fix - On HPOS environments, handle the admin subscriptions list table bulk actions and row actions in a HPOS compatible way.
 * Fix - On HPOS environments, admin notices might show incorrect subscription or order link as part of the admin notice.
 * Fix - On HPOS environments, parent order link on subscription edit page, in subscription details box, is incorrect.
+* Fix - Replace code using wp_count_posts( 'shop_subscription' ) with data store function to count subscriptions grouped by statuses on stores with HPOS enabled.
 * Dev - Replace code using get_post_type( $subscription_id ) with WC Data Store get_order_type().
 * Dev - Add subscriptions-core library version to the WooCommerce system status report.
 * Dev - Introduced a WCS_Object_Data_Cache_Manager and WCS_Object_Data_Cache_Manager_Many_To_One class as HPOS equivalents of the WCS_Post_Meta_Cache_Manager classes.

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -385,7 +385,7 @@ class WCS_Admin_System_Status {
 	 * @return array
 	 */
 	public static function get_subscription_statuses() {
-		$subscriptions_by_status        = (array) wp_count_posts( 'shop_subscription' );
+		$subscriptions_by_status        = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
 		$subscriptions_by_status_output = array();
 
 		foreach ( $subscriptions_by_status as $status => $count ) {

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -598,6 +598,6 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * @return array
 	 */
 	public function get_subscriptions_count_by_status() {
-		return WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
+		return (array) wp_count_posts( 'shop_subscription' );
 	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -598,6 +598,6 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * @return array
 	 */
 	public function get_subscriptions_count_by_status() {
-		return (array) wp_count_posts( 'shop_subscription' );
+		return WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
 	}
 }

--- a/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
+++ b/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php
@@ -229,7 +229,7 @@ class WC_Subscriptions_Deprecation_Handler extends WCS_Deprecated_Functions_Hand
 	 * @deprecated
 	 */
 	protected function _get_subscription_status_counts() {
-		$results = wp_count_posts( 'shop_subscription' );
+		$results = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
 		$counts  = array();
 
 		foreach ( $results as $status => $count ) {

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -914,7 +914,10 @@ function wcs_is_large_site() {
 	// If an option has been set previously, convert it to a bool.
 	if ( false !== $is_large_site ) {
 		$is_large_site = wc_string_to_bool( $is_large_site );
-	} elseif ( array_sum( (array) wp_count_posts( 'shop_subscription' ) ) > 3000 || array_sum( (array) wp_count_posts( 'shop_order' ) ) > 25000 ) {
+	} elseif (
+		array_sum( WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status() ) > 3000
+		|| ( ! wcs_is_custom_order_tables_usage_enabled() && array_sum( (array) wp_count_posts( 'shop_order' ) ) > 25000 )
+	) {
 		$is_large_site = true;
 		update_option( 'wcs_is_large_site', wc_bool_to_string( $is_large_site ), false );
 	} else {


### PR DESCRIPTION
Fixes #382 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

In #372 we introduced a new data store function that returns an array of subscription statuses and the number of subscriptions on the store with that status:

```
WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status()
```

In this PR, I'm updating all uses of `wp_count_posts()` with this new data store function.

**Notes**

- The `wcs_is_large_site()` was also counting the number of orders on a store but there's currently not HPOS equivalent function for this so for the time being I've opted into just leaving this count out of the condition when HPOS is enabled.
- There's a `wp_count_posts()` calls in the repair script files that I didn't bother updating in this PR because it's a repair script specifically for stores upgrading from 2.0.0 to 2.0.2

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test the Admin System Status changes:

1. Enable HPOS and purchase a handful of subscriptions
2. Change some statuses of the subscriptions
3. View **WooCommerce > Status**
4. Scroll down to Subscriptions section and look at the `Subscription Statuses:` row.
5. Disable HPOS and purchase some more subscriptions to test with HPOS disabled.

For the rest of the changes I ran the following snippet in WP Console and tested with HPOS enabled and disabled:


```
echo 'WC_Subscriptions::get_subscription_status_counts(): ' . var_export( WC_Subscriptions::get_subscription_status_counts(), true ) . "\n";

echo "\n\n";
delete_option( 'wcs_is_large_site' );

echo 'wcs_is_large_site(): ' . var_export( wcs_is_large_site(), true );

echo "\n\n";

echo 'WCS_Admin_System_Status::get_subscription_statuses(): ' . var_export( WCS_Admin_System_Status::get_subscription_statuses(), true );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
