### PR TITLE
Introduces new handling for trash, delete and untrash subscription bulk actions

### DIFF
--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -290,7 +290,7 @@ class WCS_Admin_Post_Types {
 		// Remove actions that are not relevant to subscriptions.
 		$actions = array_diff_key( $actions, array_flip( $actions_to_remove ) );
 
-		// If we are currently in trash, expired or cancelled listing. We only need to add specific subscriptions actions.
+		// If we are currently in expired or cancelled listing. We only need to add specific subscriptions actions.
 		if ( in_array( $status_filter, [ 'cancelled', 'wc-expired' ], true ) ) {
 			$actions = array_merge(
 				$actions,

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -282,13 +282,33 @@ class WCS_Admin_Post_Types {
 			'mark_completed',
 			'mark_cancelled',
 			'remove_personal_data',
+			'trash',
+			'delete',
+			'untrash',
 		];
 
 		// Remove actions that are not relevant to subscriptions.
 		$actions = array_diff_key( $actions, array_flip( $actions_to_remove ) );
 
-		// If we are currently in trash, expired or cancelled listing. We don't need to add subscriptions specific actions.
-		if ( in_array( $post_status, [ 'cancelled', 'trash', 'wc-expired' ], true ) ) {
+		// If we are currently in trash, expired or cancelled listing. We only need to add specific subscriptions actions.
+		if ( in_array( $status_filter, [ 'cancelled', 'wc-expired' ], true ) ) {
+			$actions = array_merge(
+				$actions,
+				[
+					'trash_subscriptions' => _x( 'Move to Trash', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				]
+			);
+
+			return $actions;
+		} elseif ( 'trash' === $status_filter ) {
+			$actions = array_merge(
+				$actions,
+				[
+					'untrash_subscriptions' => _x( 'Restore', 'an action on a subscription', 'woocommerce-subscriptions' ),
+					'delete_subscriptions'  => _x( 'Delete Permanently', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				]
+			);
+
 			return $actions;
 		}
 
@@ -303,16 +323,17 @@ class WCS_Admin_Post_Types {
 		$subscriptions_actions = apply_filters(
 			'woocommerce_subscription_bulk_actions',
 			[
-				'active'    => _x( 'Activate', 'an action on a subscription', 'woocommerce-subscriptions' ),
-				'on-hold'   => _x( 'Put on-hold', 'an action on a subscription', 'woocommerce-subscriptions' ),
-				'cancelled' => _x( 'Cancel', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'active'              => _x( 'Activate', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'on-hold'             => _x( 'Put on-hold', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'cancelled'           => _x( 'Cancel', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'trash_subscriptions' => _x( 'Move to Trash', 'an action on a subscription', 'woocommerce-subscriptions' ),
 			]
 		);
 
 		$actions = array_merge( $actions, $subscriptions_actions );
 
 		// No need to display certain bulk actions if we know all the subscriptions on the page have that status already.
-		switch ( $post_status ) {
+		switch ( $status_filter ) {
 			case 'wc-active':
 				unset( $actions['active'] );
 				break;
@@ -346,7 +367,7 @@ class WCS_Admin_Post_Types {
 			$action = wc_clean( wp_unslash( $_REQUEST['action2'] ) );
 		}
 
-		if ( ! in_array( $action, array( 'active', 'on-hold', 'cancelled' ), true ) ) {
+		if ( ! in_array( $action, [ 'active', 'on-hold', 'cancelled', 'trash_subscriptions', 'untrash_subscriptions', 'delete_subscriptions' ], true ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1409,7 +1409,7 @@ class WCS_Admin_Post_Types {
 	/**
 	 * Handles bulk updating the status subscriptions.
 	 *
-	 * @param array  $ids Subscription IDs to be trashed or deleted.
+	 * @param array  $ids        Subscription IDs to be trashed or deleted.
 	 * @param string $new_status The new status to update the subscriptions to.
 	 *
 	 * @return array Array of query args to redirect to after handling the bulk action request.
@@ -1417,7 +1417,7 @@ class WCS_Admin_Post_Types {
 	private function do_bulk_action_update_status( $subscription_ids, $new_status ) {
 		$sendback_args = [
 			'ids'         => join( ',', $subscription_ids ),
-			'bulk_action' => 'marked_' . $action,
+			'bulk_action' => 'marked_' . $new_status,
 			'changed'     => 0,
 			'error_count' => 0,
 		];
@@ -1427,14 +1427,14 @@ class WCS_Admin_Post_Types {
 			$note         = _x( 'Subscription status changed by bulk edit:', 'Used in order note. Reason why status changed.', 'woocommerce-subscriptions' );
 
 			try {
-				if ( 'cancelled' === $action ) {
+				if ( 'cancelled' === $new_status ) {
 					$subscription->cancel_order( $note );
 				} else {
 					$subscription->update_status( $new_status, $note, true );
 				}
 
 				// Fire the action hooks.
-				do_action( 'woocommerce_admin_changed_subscription_to_' . $action, $subscription_id );
+				do_action( 'woocommerce_admin_changed_subscription_to_' . $new_status, $subscription_id );
 
 				$sendback_args['changed']++;
 			} catch ( Exception $e ) {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1463,7 +1463,7 @@ class WCS_Admin_Post_Types {
 
 		foreach ( $subscription_ids as $id ) {
 			$subscription = wcs_get_subscription( $id );
-			$subscription->delete( $order, $force_delete );
+			$subscription->delete( $force_delete );
 			$updated_subscription = wcs_get_subscription( $id );
 
 			if ( ( $force_delete && false === $updated_subscription ) || ( ! $force_delete && $updated_subscription->get_status() === 'trash' ) ) {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1323,7 +1323,7 @@ class WCS_Admin_Post_Types {
 			if ( 'trash' === $status ) {
 				// If the subscription is already trashed, add an untrash action instead.
 				if ( 'trash' === $subscription->get_status() ) {
-					$untrash_url        = $is_hpos_enabled ? add_query_arg( 'action', 'untrash', $action_url ) : wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $subscription->get_id() ) ), 'untrash-post_' . $subscription->get_id() );
+					$untrash_url        = $is_hpos_enabled ? add_query_arg( 'action', 'untrash_subscriptions', $action_url ) : wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $subscription->get_id() ) ), 'untrash-post_' . $subscription->get_id() );
 					$actions['untrash'] = sprintf(
 						'<a title="%s" href="%s">%s</a>',
 						esc_attr( __( 'Restore this item from the Trash', 'woocommerce-subscriptions' ) ),
@@ -1603,7 +1603,7 @@ class WCS_Admin_Post_Types {
 	private function get_trash_or_delete_subscription_link( $subscription_id, $base_action_url, $status ) {
 
 		if ( wcs_is_custom_order_tables_usage_enabled() ) {
-			return add_query_arg( 'action', $status, $base_action_url );
+			return add_query_arg( 'action', $status . '_subscriptions', $base_action_url );
 		}
 
 		return get_delete_post_link( $subscription_id, '', 'delete' === $status );

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1449,7 +1449,7 @@ class WCS_Admin_Post_Types {
 	/**
 	 * Handles bulk trashing and deleting of subscriptions.
 	 *
-	 * @param array $ids Subscription IDs to be trashed or deleted.
+	 * @param array $ids          Subscription IDs to be trashed or deleted.
 	 * @param bool  $force_delete When set, the subscription will be completed deleted. Otherwise, it will be trashed.
 	 *
 	 * @return array Array of query args to redirect to after handling the bulk action request.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -291,7 +291,7 @@ class WCS_Admin_Post_Types {
 		$actions = array_diff_key( $actions, array_flip( $actions_to_remove ) );
 
 		// If we are currently in expired or cancelled listing. We only need to add specific subscriptions actions.
-		if ( in_array( $status_filter, [ 'cancelled', 'wc-expired' ], true ) ) {
+		if ( in_array( $status_filter, [ 'wc-cancelled', 'wc-expired' ], true ) ) {
 			$actions = array_merge(
 				$actions,
 				[

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -272,7 +272,7 @@ class WCS_Admin_Post_Types {
 		 * Note: The nonce check is ignored below as there is no nonce provided on status filter requests and it's not necessary
 		 * because we're filtering an admin screen, not processing or acting on the data.
 		 */
-		$post_status = sanitize_key( wp_unslash( $_GET['post_status'] ?? $_GET['status'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$status_filter = sanitize_key( wp_unslash( $_GET['post_status'] ?? $_GET['status'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// List of actions to remove that are irrelevant to subscriptions.
 		$actions_to_remove = [


### PR DESCRIPTION
Fixes #390 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

While testing #383 we discovered that our subscription hooks which are supposed to be fired before and after deleting, trashing and untrashing a subscription, were not firing when using bulk actions on the new Subscriptions List Table with HPOS enabled.

The reason for this is because WooCommerce's [`ListTable->do_delete()`](https://github.com/woocommerce/woocommerce/blob/e84c38504f88bdfd1f3caae8942591d1161c307c/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php#L1256) and `do_untrash()` fetches an instance of the `OrdersTableDataStore` class and calls the `delete()` directly.

In order to workaround this, this PR introduces new bulk actions so we can handle these for subscriptions objects.

New subscription bulk actions:
 - `trash_subscriptions`
 - `untrash_subscriptions`
 - `delete_subscriptions`

A few changes were needed to support these new actions:
 - Delete the WC Core actions for delete, trash and untrash
 - Manually add our new `trash_subscriptions` bulk action
 - Only load the delete and untrash bulk actions when the list table is filtered by trashed subscriptions
 - Update the quick edit links under each subscription in the table to use the new action names


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To properly test this is working with HPOS enabled, I used the following snippet:

```
add_action( 'woocommerce_before_delete_subscription', function( $id ) {
	error_log( 'woocommerce_before_delete_subscription' );
} );

add_action( 'woocommerce_before_trash_subscription', function( $id ) {
	error_log( 'woocommerce_before_trash_subscription' );
} );

add_action( 'woocommerce_untrash_subscription', function( $id ) {
	error_log( 'woocommerce_untrash_subscription' );
} );
```

1. Enable HPOS and purchase a bunch of different subscriptions
2. Go to the **WooCommerce > Subscriptions** list table
3. Use the bulk actions to trash a subscription
4. Use the bulk actions to untrash the subscription
5. Use the bulk actions to trash and then delete permanently
6. Use the quick edit links to Cancel -> Cancel Now -> Trash
7. Use the quick edit links to Untrash and also delete

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
