### PR TITLE
Move changelog up into 5.3.0 after 5.2.0 was already tagged

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.3.0 - 2023-xx-xx =
+* Add - Highlight subscriptions with overdue payment in list view with red icon & tooltip.
+
 = 5.2.0 - 2023-01-23 =
 * Add - New wcs_set_order_address() helper function to set an array of address fields on an order or subscription.
-* Add - Highlight subscriptions with overdue payment in list view with red icon & tooltip.
 * Fix - Edit, add, and list Subscription admin pages now work when HPOS is enabled.
 * Fix - Fixed issues where multiple subscription purchases wouldn't appear on the My Account > Subscriptions screen, on HPOS environments.
 * Fix - Refactor `WCS_Meta_Box_Subscription_Data::save` to support HPOS stores, fixing a PHP warning notice when updating an order via the Edit Order screen.


### PR DESCRIPTION
## Description

This is a tiny PR to fix the changelog entry added in #354. It was added under 5.2.0 when 5.2 had been tagged.

This PR simply moves it up to 5.3

## How to test this PR

NA 
