### PR TITLE
Ensure update_all_payment_methods_from_subscription() function call receives the latest version of the subscription after a payment method change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.3.0 - 2023-xx-xx =
+* Fix - When processing customer requests to update all their subscription payment methods, ensure the updated subscription is used fetch the new payment meta, not and old instance.
+
 = 5.2.0 - 2023-01-23 =
 * Add - New wcs_set_order_address() helper function to set an array of address fields on an order or subscription.
 * Add - Highlight subscriptions with overdue payment in list view with red icon & tooltip.

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -343,6 +343,14 @@ class WC_Subscriptions_Change_Payment_Gateway {
 					return;
 				}
 
+				/**
+				 * After processing the payment result. Make sure we get a new instance of the subscription.
+				 *
+				 * Because process_payment() is sent an ID, all subscription meta changes would occur on a different instance on the subscription.
+				 * We need a new instance to ensure we have the latest changes, when processing an update all subscription payment method request.
+				 */
+				$subscription = wcs_get_subscription( $subscription->get_id() );
+
 				$subscription->set_requires_manual_renewal( false );
 				$subscription->save();
 

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -344,10 +344,10 @@ class WC_Subscriptions_Change_Payment_Gateway {
 				}
 
 				/**
-				 * After processing the payment result. Make sure we get a new instance of the subscription.
+				 * After processing the payment result, make sure we get a new instance of the subscription.
 				 *
 				 * Because process_payment() is sent an ID, all subscription meta changes would occur on a different instance on the subscription.
-				 * We need a new instance to ensure we have the latest changes, when processing an update all subscription payment method request.
+				 * We need a new instance to ensure we have the latest changes when processing the update all subscription payment method request below.
 				 */
 				$subscription = wcs_get_subscription( $subscription->get_id() );
 


### PR DESCRIPTION
## Description

When a customer updates the payment method for one of their subscriptions, they have the option to update all their subscription payment methods. 

<img width="1124" alt="Screen Shot 2023-01-26 at 5 12 01 pm" src="https://user-images.githubusercontent.com/8490476/214777276-d73bf5e3-7f2c-44b8-aea3-8101a8ef2ff7.png">

When a customer checks this box, on a HPOS environment, its possible (depending on the payment method) that the old payment meta (tokens) will be copied to all their subscriptions, not the new one. 

This is because. 

1. When we update the subscription payment method, we call `gateway->process_payment( $subscription->get_id() )`. 
    - Because only the subscription ID is passed, you can assume that all payment method changes would occur on a different instance of the subscription. 
2. Then we call `update_all_payment_methods_from_subscription()` to fire off all the updates. 
   - However, the instance passed to this function, would be a original instance which has the old payment meta. 
   - Any plugin hooked into that process, would naturally return the old payment tokens, not the new ones. 

THis all occurs in [this section](https://github.com/automattic/woocommerce-subscriptions-core/blob/fix/update_all_subscription_payment_methods/includes/class-wc-subscriptions-change-payment-gateway.php#L334-L368) of the `change_payment_method_via_pay_shortcode()` function. 

This PR fixes that by ensuring we get a fresh instance after calling `process_payment()` to make sure the `update_all_payment_methods_from_subscription()` and APIs hooked into it, get the latest version of the subscription which has the new payment method and meta (tokens.

## How to test this PR

1. Checkout [PR version](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2533) of the Stripe payment gateway. 
2. Set up Stripe if you haven't before. 
3. Enable HPOS - sycning disabled.
4. Purchase two subscriptions using Stripe. 
5. Go to one of the subscriptions from your My account page.
6. Click the change payment button. 
7. Select a different payment method and check the box to "Update the payment method used for all ..."
8. Change payment method.
9. Note that all other subscriptions haven't been updated or have been updated to the old payment method, not the new one.


This video by @alefesouza, originally posted [here](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2531), explains it perfectly

https://user-images.githubusercontent.com/1025173/214762531-2cfbd27d-5104-4aa9-9b44-278964bedfb2.mov

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
