### PR TITLE
Remove use of strptime which is being deprecated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Highlight subscriptions with overdue payment in list view with red icon & tooltip.
 * Fix - Shipping address correctly set when resubscribing or switching subscriptions that contain different billing and shipping addresses.
 * Fix - When processing customer requests to update all their subscription payment methods, ensure the updated subscription is used fetch the new payment meta, not and old instance.
+* Dev - Remove deprecated `strptime` function in favour of `DateTime::createFromFormat`.
 
 = 5.2.0 - 2023-01-23 =
 * Add - New wcs_set_order_address() helper function to set an array of address fields on an order or subscription.

--- a/includes/wcs-time-functions.php
+++ b/includes/wcs-time-functions.php
@@ -618,29 +618,21 @@ function wcs_sort_by_fractions( $a, $b ) {
 }
 
 /**
- * PHP on Windows does not have strptime function. Therefore this is what we're using to check
- * whether the given time is of a specific format.
+ * Validate whether a given datetime matches the mysql pattern of YYYY-MM-DD HH:MM:SS
+ * This function will return false when the date or time is invalid (e.g. 2015-02-29 00:00:00)
  *
  * @param  string $time the mysql time string
- * @return boolean      true if it matches our mysql pattern of YYYY-MM-DD HH:MM:SS
+ * @return boolean      if the string is valid
  */
 function wcs_is_datetime_mysql_format( $time ) {
 	if ( ! is_string( $time ) ) {
 		return false;
 	}
 
-	if ( function_exists( 'strptime' ) ) {
-		$valid_time = $match = ( false !== strptime( $time, '%Y-%m-%d %H:%M:%S' ) );
-	} else {
-		// parses for the pattern of YYYY-MM-DD HH:MM:SS, but won't check whether it's a valid timedate
-		$match = preg_match( '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/', $time );
+	$format = 'Y-m-d H:i:s';
 
-		// parses time, returns false for invalid dates
-		$valid_time = wcs_date_to_time( $time );
-	}
-
-	// magic number -2209078800 is strtotime( '1900-01-00 00:00:00' ). Needed to achieve parity with strptime
-	return $match && false !== $valid_time && -2209078800 <= $valid_time;
+	$date_object = DateTime::createFromFormat( $format, $time );
+	return $date_object && $date_object->format( $format ) === $time;
 }
 
 /**

--- a/includes/wcs-time-functions.php
+++ b/includes/wcs-time-functions.php
@@ -632,7 +632,14 @@ function wcs_is_datetime_mysql_format( $time ) {
 	$format = 'Y-m-d H:i:s';
 
 	$date_object = DateTime::createFromFormat( $format, $time );
-	return $date_object && $date_object->format( $format ) === $time;
+
+	// DateTime::createFromFormat will return false if it is an invalid date.
+	return $date_object
+			// We also need to check the output of the format() method against the provided string as it will sometimes return
+			// the closest date. Passing `2022-02-29 01:02:03` will return `2022-03-01 01:02:03`
+			&& $date_object->format( $format ) === $time
+			// we check the year is greater than or equal to 1900 as mysql will not accept dates before this.
+			&& (int) $date_object->format( 'Y' ) >= 1900;
 }
 
 /**

--- a/tests/unit/test-wcs-time-functions.php
+++ b/tests/unit/test-wcs-time-functions.php
@@ -775,6 +775,7 @@ class WCS_Time_Functions_Tests extends WP_UnitTestCase {
 			array( 'foo' ),
 			array( '2015:12:32 11:11:11' ),
 			array( '2015-13-34 24:11:92' ),
+			array( '1899-12-30 23:11:12' ),
 			array( '0000-00-00 00:00:00' ),
 			array( 4 ),
 			array( -1 ),


### PR DESCRIPTION
Fixes #212

## Description

The function `strptime` has been marked as deprecated in php8.1. 
@davefx suggested a fix in #368 but it makes sense to remove the use of this function entirely rather than only use it on older versions of PHP.

I've [tested](https://3v4l.org/aqrC1) the [suggested fix](https://github.com/Automattic/woocommerce-subscriptions-core/pull/368#issuecomment-1379805998) by @james-allan and confirmed that it works as expected.


## How to test this PR

Reviewing the PHPUnit tests or using the manually testing against the function on https://3v4l.org/aqrC1


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
