### PR TITLE
Fixes error on Admin Edit Subscription page when the subscription has custom billing fields.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.3.1 - 2023-xx-xx =
+* Fix - Fatal error when loading the Edit Subscription page with custom admin billing or shipping fields. #403
+
 = 5.3.0 - 2023-01-26 =
 * Add - Highlight subscriptions with overdue payment in list view with red icon & tooltip.
 * Fix - Shipping address correctly set when resubscribing or switching subscriptions that contain different billing and shipping addresses.

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -308,7 +308,12 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 										wcs_woocommerce_wp_select( $field, $subscription );
 										break;
 									default:
-										$field['value'] = $subscription->{"get_shipping_$key"}();
+										if ( is_callable( array( $subscription, 'get_shipping_' . $key ) ) ) {
+											$field['value'] = $subscription->{"get_shipping_$key"}();
+										} else {
+											$field['value'] = $subscription->get_meta( $field['id'] );
+										}
+
 										woocommerce_wp_text_input( $field );
 										break;
 								}

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -213,7 +213,12 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 									wcs_woocommerce_wp_select( $field, $subscription );
 									break;
 								default:
-									$field['value'] = $subscription->{"get_billing_$key"}();
+									if ( is_callable( array( $subscription, 'get_billing_' . $key ) ) ) {
+										$field['value'] = $subscription->{"get_billing_$key"}();
+									} else {
+										$field['value'] = $subscription->get_meta( '_billing_' . $key );
+									}
+
 									woocommerce_wp_text_input( $field );
 									break;
 							}

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -216,7 +216,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 									if ( is_callable( array( $subscription, 'get_billing_' . $key ) ) ) {
 										$field['value'] = $subscription->{"get_billing_$key"}();
 									} else {
-										$field['value'] = $subscription->get_meta( '_billing_' . $key );
+										$field['value'] = $subscription->get_meta( $field['id'] );
 									}
 
 									woocommerce_wp_text_input( $field );


### PR DESCRIPTION
Fixes #401
Fixes #402
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4468

## Description

When a store has set custom address fields (using `woocommerce_admin_billing_fields` or `woocommerce_admin_shipping_fields`) and these fields don't have `$order->get_billing_{field}` or `$order->get_shipping_{field}` functions, opening the Edit subscription page in the admin will result in:

```
[31-Jan-2023 23:21:08 UTC] PHP Fatal error:  Uncaught Error: Call to undefined method WC_Subscription::get_billing_my_custom_field() in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php:216
Stack trace:
#0 /Users/matt/local/woo/wp-admin/includes/template.php(1401): WCS_Meta_Box_Subscription_Data::output(Object(WC_Subscription), Array)
#1 /Users/matt/local/woo/wp-admin/edit-form-advanced.php(688): do_meta_boxes(Object(WP_Screen), 'normal', Object(WP_Post))
#2 /Users/matt/local/woo/wp-admin/post.php(206): require('/Users/matt/loc...')
#3 /Users/matt/.composer/vendor/laravel/valet/server.php(235): require('/Users/matt/loc...')
#4 {main}
  thrown in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php on line 216
```

To fix this problem, we just need to make sure the function exists before we try to use it 😅 In cases where a getter function doesn't exist, we need to fallback to using `$subscription->get_meta( '_custom_meta_key' )` 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This issue was reported by a store using our EU Vat number plugin, however it can also be replicated by using the following snippet to add custom billing and shipping fields:

```
add_filter( 'woocommerce_admin_billing_fields', function( $fields ) {
	$fields['my_custom_field'] = array(
		'label' => 'My custom field'
	);

	return $fields;
}, 0 );

add_filter( 'woocommerce_admin_shipping_fields', function( $fields ) {
	$fields['my_custom_field'] = array(
		'label' => 'My custom field'
	);

	return $fields;
}, 0 );
```

1. With this snippet, on `trunk`, try to navigate to the Edit Subscription page. You will notice half the page loaded and a fatal error.
2. Check out this branch and confirm there's no fatal error.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
