### PR TITLE
Deprecate and remove cached shipping rates for recurring carts and related functions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.4.0 - 2023-xx-xx =
+* Fix - Remove the recurring shipping method cache that caused bugs for third-party plugins like Conditional Shipping and Payments. #407
+
 = 5.3.1 - 2023-02-01 =
 * Fix - Fatal error when loading the Edit Subscription page with custom admin billing or shipping fields. #403
 

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -41,13 +41,6 @@ class WC_Subscriptions_Cart {
 	private static $recurring_shipping_packages = array();
 
 	/**
-	 * A cache of the calculated shipping package rates
-	 *
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
-	 */
-	private static $shipping_rates = array();
-
-	/**
 	 * A cache of the current recurring cart being calculated
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.20
@@ -95,9 +88,6 @@ class WC_Subscriptions_Cart {
 
 		// Make sure we use our recurring shipping method for recurring shipping calculations not the default method
 		add_filter( 'woocommerce_shipping_chosen_method', array( __CLASS__, 'set_chosen_shipping_method' ), 10, 2 );
-
-		// Cache package rates. Hook in early to ensure we get a full set of rates.
-		add_filter( 'woocommerce_package_rates', __CLASS__ . '::cache_package_rates', 1, 2 );
 
 		// When WooCommerce calculates rates for a recurring shipping package, make sure there is a different set of rates
 		add_filter( 'woocommerce_shipping_package_name', __CLASS__ . '::change_initial_shipping_package_name', 1, 3 );
@@ -1154,7 +1144,7 @@ class WC_Subscriptions_Cart {
 
 			foreach ( $recurring_cart->get_shipping_packages() as $recurring_cart_package_key => $recurring_cart_package ) {
 				$package_index = isset( $recurring_cart_package['package_index'] ) ? $recurring_cart_package['package_index'] : 0;
-				$package       = self::get_calculated_shipping_for_package( $recurring_cart_package );
+				$package       = WC()->shipping->calculate_shipping_for_package( $recurring_cart_package );
 
 				if ( ( isset( $standard_packages[ $package_index ] ) && $package['rates'] == $standard_packages[ $package_index ]['rates'] ) ) {
 					// the recurring package rates match the initial package rates, there won't be a selected shipping method for this recurring cart package move on to the next package.
@@ -1228,53 +1218,6 @@ class WC_Subscriptions_Cart {
 		}
 
 		return $cart_contains_other_subscription_products;
-	}
-
-	/**
-	 * Cache the package rates calculated by @see WC_Shipping::calculate_shipping_for_package() to avoid multiple calls of calculate_shipping_for_package() per request.
-	 *
-	 * @param array $rates A set of WC_Shipping_Rate objects.
-	 * @param array $package A shipping package in the form returned by @see WC_Cart->get_shipping_packages()
-	 * @return array $rates An unaltered set of WC_Shipping_Rate objects passed to the function
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
-	 */
-	public static function cache_package_rates( $rates, $package ) {
-		self::$shipping_rates[ self::get_package_shipping_rates_cache_key( $package ) ] = $rates;
-
-		return $rates;
-	}
-
-	/**
-	 * Calculates the shipping rates for a package.
-	 *
-	 * This function will check cached rates based on a hash of the package contents to avoid re-calculation per page load.
-	 * If there are no rates stored in the cache for this package, it will fall back to @see WC_Shipping::calculate_shipping_for_package()
-	 *
-	 * @param array $package A shipping package in the form returned by @see WC_Cart->get_shipping_packages()
-	 * @return array $package
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
-	 */
-	public static function get_calculated_shipping_for_package( $package ) {
-		$key = self::get_package_shipping_rates_cache_key( $package );
-
-		if ( isset( self::$shipping_rates[ $key ] ) ) {
-			$package['rates'] = apply_filters( 'woocommerce_package_rates', self::$shipping_rates[ $key ], $package );
-		} else {
-			$package = WC()->shipping->calculate_shipping_for_package( $package );
-		}
-
-		return $package;
-	}
-
-	/**
-	 * Generate a unique package key for a given shipping package to be used for caching package rates.
-	 *
-	 * @param array $package A shipping package in the form returned by WC_Cart->get_shipping_packages().
-	 * @return string key hash
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
-	 */
-	private static function get_package_shipping_rates_cache_key( $package ) {
-		return md5( json_encode( array( array_keys( $package['contents'] ), $package['contents_cost'], $package['applied_coupons'] ) ) );
 	}
 
 	/**
@@ -1528,6 +1471,38 @@ class WC_Subscriptions_Cart {
 	}
 
 	/* Deprecated */
+
+	/**
+	 * Calculates the shipping rates for a package.
+	 *
+	 * This function will check cached rates based on a hash of the package contents to avoid re-calculation per page load.
+	 * If there are no rates stored in the cache for this package, it will fall back to @see WC_Shipping::calculate_shipping_for_package()
+	 *
+	 * @deprecated 5.4.0
+	 *
+	 * @param array $package A shipping package in the form returned by @see WC_Cart->get_shipping_packages()
+	 * @return array $package
+	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
+	 */
+	public static function get_calculated_shipping_for_package( $package ) {
+		_deprecated_function( __METHOD__, '5.4.0', 'WC()->shipping->calculate_shipping_for_package()' );
+		return WC()->shipping->calculate_shipping_for_package( $package );
+	}
+
+	/**
+	 * Cache the package rates calculated by @see WC_Shipping::calculate_shipping_for_package() to avoid multiple calls of calculate_shipping_for_package() per request.
+	 *
+	 * @deprecated 5.4.0
+	 *
+	 * @param array $rates A set of WC_Shipping_Rate objects.
+	 * @param array $package A shipping package in the form returned by @see WC_Cart->get_shipping_packages()
+	 * @return array $rates An unaltered set of WC_Shipping_Rate objects passed to the function
+	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
+	 */
+	public static function cache_package_rates( $rates, $package ) {
+		_deprecated_function( __METHOD__, '5.4.0' );
+		return $rates;
+	}
 
 	/**
 	 * Don't allow new subscription products to be added to the cart if it contains a subscription renewal already.

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1485,7 +1485,7 @@ class WC_Subscriptions_Cart {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
 	 */
 	public static function get_calculated_shipping_for_package( $package ) {
-		_deprecated_function( __METHOD__, '5.4.0', 'WC()->shipping->calculate_shipping_for_package()' );
+		_deprecated_function( __METHOD__, 'subscriptions-core 5.4.0', 'WC()->shipping->calculate_shipping_for_package()' );
 		return WC()->shipping->calculate_shipping_for_package( $package );
 	}
 

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1500,7 +1500,7 @@ class WC_Subscriptions_Cart {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.18
 	 */
 	public static function cache_package_rates( $rates, $package ) {
-		_deprecated_function( __METHOD__, '5.4.0' );
+		_deprecated_function( __METHOD__, 'subscriptions-core 5.4.0' );
 		return $rates;
 	}
 

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -287,7 +287,7 @@ class WC_Subscriptions_Checkout {
 		if ( $cart->needs_shipping() ) {
 			foreach ( $cart->get_shipping_packages() as $recurring_cart_package_key => $recurring_cart_package ) {
 				$package_index      = isset( $recurring_cart_package['package_index'] ) ? $recurring_cart_package['package_index'] : 0;
-				$package            = WC_Subscriptions_Cart::get_calculated_shipping_for_package( $recurring_cart_package );
+				$package            = WC()->shipping->calculate_shipping_for_package( $recurring_cart_package );
 				$shipping_method_id = isset( WC()->checkout()->shipping_methods[ $package_index ] ) ? WC()->checkout()->shipping_methods[ $package_index ] : '';
 
 				if ( isset( WC()->checkout()->shipping_methods[ $recurring_cart_package_key ] ) ) {

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -62,7 +62,7 @@ function wcs_cart_totals_shipping_html() {
 			foreach ( $recurring_cart->get_shipping_packages() as $recurring_cart_package_key => $recurring_cart_package ) {
 				$package_index = isset( $recurring_cart_package['package_index'] ) ? $recurring_cart_package['package_index'] : 0;
 				$product_names = array();
-				$package       = WC_Subscriptions_Cart::get_calculated_shipping_for_package( $recurring_cart_package );
+				$package       = WC()->shipping->calculate_shipping_for_package( $recurring_cart_package );
 
 				if ( $show_package_details ) {
 					foreach ( $package['contents'] as $item_id => $values ) {


### PR DESCRIPTION
Fixes #400 

## Description

Back in 2016 we introduced a caching layer to avoid fetching available shipping rates multiple times in a single request. You can find the original issue and PR here for reference: 

- https://github.com/woocommerce/woocommerce-subscriptions/issues/1415
- woocommerce/woocommerce-subscriptions#1485

The original motivation for us was purely performance. It's hard to tell that far in the past but today WC core has caching of shipping rates. Whether this caching layer existed back then is unclear - it does look like there was at the very least some cache ([wc 2.6.0 ref](https://github.com/woocommerce/woocommerce/blob/2.6.0/includes/class-wc-shipping.php#L330-L331)).

The original issue didn't include any statistics on the impact on load times or performance, it specifically called out that there are 3-4 calls to get the shipping rates all on 1 load. 

A lot of time has passed since 2016 and there have been a number of improvements to WooCommerce core with a focus on performance over the years. Given this passage of time and the impact this cache is having on third-party compatibility, I've done a review of this cache and removing it hasn't lead to any meaningful performance hit that I've been able to measure or any change in behaviour.

With that in mind, this PR removes the shipping rate cache layer in favour of calling the WC core function directly. 

## How to test this PR

1. Set up shipping methods.
    - It's best to have a variety of free, and flat rate methods. 
3. Add subscription and or simple products to your cart and test whether the shipping methods displayed on checkout and the cart page are as expected. 
4. Complete the purchase and make sure shipping methods and totals are set on the subscriptions matching the choices.
5. Test a variety of different cart and shipping setups.

To test this PR during development, I kept the caching layer intact and compared the value stored in the cache with the value returned from WC core's function directly. In my testing, the result never differed.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)

cc @jimjasson 
