### PR TITLE
Fix "Invalid recurring shipping method" errors on checkout when a min required free shipping option is chosen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 5.6.0- 2023-xx-xx =
+* Fix - Correctly determine subscription free shipping eligibility when the initial payment cart isn't eligible. Fixes erroneous "Invalid recurring shipping method" errors on checkout. #409
 * Dev - Fix phpcs and semgrep warnings to improve code quality.
 * Dev - Use `wp_safe_redirect()` when processing a payment method change request.
 
@@ -11,7 +12,6 @@
 
 = 5.4.0 - 2023-02-21 =
 * Fix - Remove the recurring shipping method cache that caused bugs for third-party plugins like Conditional Shipping and Payments. #407
-* Fix - Correctly determine subscription free shipping eligibility when the initial payment cart isn't eligible. Fixes erroneous "Invalid recurring shipping method" errors on checkout. #409
 
 = 5.3.1 - 2023-02-01 =
 * Fix - Fatal error when loading the Edit Subscription page with custom admin billing or shipping fields. #403

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.4.0 - 2023-02-21 =
 * Fix - Remove the recurring shipping method cache that caused bugs for third-party plugins like Conditional Shipping and Payments. #407
+* Fix - Correctly determine subscription free shipping eligibility when the initial payment cart isn't eligible. Fixes erroneous "Invalid recurring shipping method" errors on checkout. #409
 
 = 5.3.1 - 2023-02-01 =
 * Fix - Fatal error when loading the Edit Subscription page with custom admin billing or shipping fields. #403

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1139,7 +1139,7 @@ class WC_Subscriptions_Cart {
 		$added_invalid_notice = false;
 		$standard_packages    = WC()->shipping->get_packages();
 
-		// temporarily store the current calculation type and recurring cart key so we can restore them later
+		// Temporarily store the current calculation type and recurring cart key so we can restore them later.
 		$calculation_type        = self::$calculation_type;
 		$recurring_cart_key_flag = self::$recurring_cart_key;
 
@@ -1157,12 +1157,13 @@ class WC_Subscriptions_Cart {
 				$package       = self::get_calculated_shipping_for_package( $recurring_cart_package );
 
 				if ( ( isset( $standard_packages[ $package_index ] ) && $package['rates'] == $standard_packages[ $package_index ]['rates'] ) ) {
-					// the recurring package rates match the initial package rates, there won't be a selected shipping method for this recurring cart package move on to the next package.
+					// The recurring package rates match the initial package rates, there won't be a selected shipping method for this recurring cart package move on to the next package.
 					if ( apply_filters( 'wcs_cart_totals_shipping_html_price_only', true, $package, $recurring_cart ) ) {
 						continue;
 					}
 				}
 
+				// If the chosen shipping method is not available for this recurring cart package, display an error and unset the selected method.
 				if ( ! isset( $package['rates'][ $shipping_methods[ $recurring_cart_package_key ] ] ) ) {
 					if ( ! $added_invalid_notice ) {
 						wc_add_notice( __( 'Invalid recurring shipping method.', 'woocommerce-subscriptions' ), 'error' );
@@ -1179,6 +1180,7 @@ class WC_Subscriptions_Cart {
 			WC()->checkout()->shipping_methods = $shipping_methods;
 		}
 
+		// Restore the calculation type and recurring cart key.
 		self::set_calculation_type( $calculation_type );
 		self::set_recurring_cart_key( $recurring_cart_key_flag );
 	}

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1142,15 +1142,18 @@ class WC_Subscriptions_Cart {
 		// Temporarily store the current calculation type and recurring cart key so we can restore them later.
 		$calculation_type        = self::$calculation_type;
 		$recurring_cart_key_flag = self::$recurring_cart_key;
+		$cached_recurring_cart   = self::$cached_recurring_cart;
 
 		self::set_calculation_type( 'recurring_total' );
 
 		foreach ( WC()->cart->recurring_carts as $recurring_cart_key => $recurring_cart ) {
-			self::set_recurring_cart_key( $recurring_cart_key );
-
 			if ( false === $recurring_cart->needs_shipping() || 0 == $recurring_cart->next_payment_date ) {
 				continue;
 			}
+
+			// Set the recurring cart flags so shipping calculations have the recurring cart as context.
+			self::set_recurring_cart_key( $recurring_cart_key );
+			self::set_cached_recurring_cart( $recurring_cart );
 
 			foreach ( $recurring_cart->get_shipping_packages() as $recurring_cart_package_key => $recurring_cart_package ) {
 				$package_index = isset( $recurring_cart_package['package_index'] ) ? $recurring_cart_package['package_index'] : 0;
@@ -1183,6 +1186,7 @@ class WC_Subscriptions_Cart {
 		// Restore the calculation type and recurring cart key.
 		self::set_calculation_type( $calculation_type );
 		self::set_recurring_cart_key( $recurring_cart_key_flag );
+		self::set_cached_recurring_cart( $cached_recurring_cart );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #409 

## Description

The free shipping method has an option to limit it's availability to carts that exceed a required amount (eg free shipping is available to all orders over $100). The way this limitation interacts with subscriptions isn't immediately apparent but it does make sense and honor the limitation. 

- If the initial cart exceeds the minimum requirement, it will be given the free shipping method option.
- Each recurring cart that exceeds the minimum requirement will be given free shipping. 
- On the contrary. If the initial cart doesn't meet the minimum requirement, it wont have free shipping. 
- And, any recurring cart that doesn't meet the requirement, won't have free shipping available to it.

When you consider mixed cart (simple and subscriptions products purchased at once), free trials and sign up fees, you can get into a mix of free shipping availability across the initial and recurring carts. 

For example: 

| Free trial (A) | Sign up fee (B) | Mixed checkout (C) ❗|
|:----------:|:-----------:|:--------------:|
|     <img width="598" alt="Screenshot 2023-02-21 at 4 41 47 pm" src="https://user-images.githubusercontent.com/8490476/220267217-b43ac1f3-b67b-4e7c-b622-34341edcbf1b.png">      |    <img width="592" alt="Screenshot 2023-02-21 at 4 47 46 pm" src="https://user-images.githubusercontent.com/8490476/220268375-28a109a8-eb71-495a-8a2f-9d3cedcccf64.png">         |       <img width="602" alt="Screenshot 2023-02-21 at 4 38 18 pm" src="https://user-images.githubusercontent.com/8490476/220266538-bf49a743-842a-48c3-8d53-a1617342deea.png">         |
|       Free initial cart with no shipping, but recurring cart is eligible.     |         $20/year with a $100 sign up fee. Free shipping available to initial cart, but not the recurring cart.   |       Free shipping available to $100 recurring cart, but not $12 initial cart.         |


The issue this PR fixes occurs **when you have free shipping available to the recurring cart but not to the initial cart** - scenario **C** above. In this scenario, when we go to validate the shipping method on checkout submission, we incorrectly determine that the recurring cart isn't eligible for free shipping because we missed setting a flag that enables the [`maybe_recalculate_shipping_method_availability()` function](https://github.com/Automattic/woocommerce-subscriptions-core/blob/ff84be72765c88c5cbe31514bf828819c25c1d4b/includes/class-wc-subscriptions-cart.php#L1233-L1263) to calculate method availability for recurring carts. Essentially, because free shipping isn't available to the initial cart, the validation fails for the eligible recurring cart. This eventually leads to this error message on checkout:

<img width="892" alt="Screenshot 2023-02-21 at 4 52 40 pm" src="https://user-images.githubusercontent.com/8490476/220269420-99042190-e749-4827-9e10-f64f459f89e3.png">

This PR fixes that by making sure we set the `self::$cached_recurring_cart` before validating recurring shipping methods. 

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a free shipping option that is limited to carts that exceed $100 ([screenshot](https://user-images.githubusercontent.com/8490476/219591433-d76e473b-9d30-4e0c-812c-b8efd5762d96.png))
2. Add a flat rate option ([screenshot](https://user-images.githubusercontent.com/8490476/219591571-777761bb-5a92-4e15-b868-25f1be3e3114.png))
3. Add products to the cart to end up with an initial payment less than $100 and at least 1 recurring cart with a total greater than $100. Options include:
    - Add enough free trial subscription products to exceed the $100 requirement and at least 1 other product with an initial cost (subscription or standard product).
    - Add a sign up fee & free trial product to the cart where the sign up fee is less than $100, but the recurring price exceeds it. Eg a $20 sign up fee with a free trial + $100 recurring price. 
6. Now visit the checkout. You should have standard shipping available to the initial cart, and free shipping available to the recurring cart that exceeds $100. (see screenshot example under **(C)** above).
7. Choose free shipping in the recurring cart section.
8. Attempt to checkout.
    - On `trunk` you should get the error message "Invalid recurring shipping method." and be blocked from checking out.
    - On this branch there shouldn't be any error message, checkout should be successful and the subscription set up with free shipping.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
