### PR TITLE
[HPOS] Update the subscription address when a customer changes their address while paying for a renewal order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.5.0 - 2023-xx-xx =
+* Fix - When HPOS is enabled, changing your address while paying for a renewal order will update the address on the subscription. #413
+
 = 5.4.0 - 2023-02-21 =
 * Fix - Remove the recurring shipping method cache that caused bugs for third-party plugins like Conditional Shipping and Payments. #407
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1159,9 +1159,11 @@ class WCS_Cart_Renewal {
 		$cart_renewal_item = $this->cart_contains();
 
 		if ( false !== $cart_renewal_item ) {
-			$subscription    = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
-			$billing_address = $shipping_address = array();
-			foreach ( array( 'billing', 'shipping' ) as $address_type ) {
+			$subscription     = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
+			$billing_address  = [];
+			$shipping_address = [];
+
+			foreach ( [ 'billing', 'shipping' ] as $address_type ) {
 				$checkout_fields = WC()->checkout()->get_checkout_fields( $address_type );
 
 				if ( is_array( $checkout_fields ) ) {

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1210,7 +1210,7 @@ class WCS_Cart_Renewal {
 				$subscription->set_address( $request['shipping_address'] ?? $request['billing_address'], 'shipping' );
 			} else {
 				$subscription->set_billing_address( $request['billing_address'] );
-				$subscription->set_billing_address( $request['shipping_address'] ?? $request['billing_address'] );
+				$subscription->set_shipping_address( $request['shipping_address'] ?? $request['billing_address'] );
 
 				$subscription->save();
 			}

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1203,10 +1203,17 @@ class WCS_Cart_Renewal {
 					$customer->{"set_billing_$key"}( $value );
 				}
 			}
-			// Billing address is a required field.
-			$subscription->set_address( $request['billing_address'], 'billing' );
-			// If shipping address (optional field) was not provided, set it to the given billing address (required field).
-			$subscription->set_address( $request['shipping_address'] ?? $request['billing_address'], 'shipping' );
+
+			// Save Billing & Shipping addresses. Billing address is a required field, if shipping address (optional field) was not provided, set it to the given billing address.
+			if ( wcs_is_woocommerce_pre( '7.1' ) ) {
+				$subscription->set_address( $request['billing_address'], 'billing' );
+				$subscription->set_address( $request['shipping_address'] ?? $request['billing_address'], 'shipping' );
+			} else {
+				$subscription->set_billing_address( $request['billing_address'] );
+				$subscription->set_billing_address( $request['shipping_address'] ?? $request['billing_address'] );
+
+				$subscription->save();
+			}
 		}
 	}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1161,8 +1161,6 @@ class WCS_Cart_Renewal {
 		if ( false !== $cart_renewal_item ) {
 			$subscription         = wcs_get_subscription( $cart_renewal_item[ $this->cart_item_key ]['subscription_id'] );
 			$subscription_updated = false;
-			$billing_address      = [];
-			$shipping_address     = [];
 
 			foreach ( [ 'billing', 'shipping' ] as $address_type ) {
 				$checkout_fields = WC()->checkout()->get_checkout_fields( $address_type );


### PR DESCRIPTION
Fixes #412 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

With HPOS enabled, when a customer is paying for a renewal order and updates their address on the checkout, the subscription doesn't get updated with the newest address.

This is because we were using a legacy order function `$subscription->set_address()` which calls both `update_post_meta()` and the CRUD method to set the address prop, but we were never saving the subscription.

There are two issues with our code using `set_address()`:
1. This function always calls `update_post_meta()` which shouldn't be used in an HPOS environment. When HPOS is enabled and data syncing disabled, the address was always being saved to the `shop_order_placehold` post object.
2. Address data wasn't being saved on the subscription because we weren't calling `$subscription->save()`

This PR address both of these issues by refactoring how we were using `$subscription->set_address()`.

- Inside `maybe_update_subscription_address_data()` we were already setting up arrays of shipping and billing data so I changed this function to use the `set_shipping|billing_$field()` functions and then call `$subscription->save()`.
- Inside `maybe_update_subscription_address_data_from_store_api()` we are already given the arrays of address data so I opted to use the new WC Core functions introduced in WC 7.1 which accepts an address array and sets the data

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing these changes requires testing both the Checkout Block and old checkout flows and with HPOS enabled and disabled.

1. Purchase a subscription
2. On the Edit Subscription page use the action list to **Create pending renewal order**
3. Go to My Account > View Subscription and click to pay for the pending order
4. While on the checkout, change your address and submit the checkout
5. Check that the address on the subscription has been updated
6. When HPOS is enabled with syncing off, confirm the address data is no longer being saved in postmeta.
7. Perform the same checks for HPOS disabled/enabled and with Checkout Blocks.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
