### PR TITLE
Attach callback to the subscription_trial_end action scheduler hook to prevent action scheduler triggering a failed action

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.5.0 - 2023-xx-xx =
+* Fix - Prevent admin error notices being shown for the "subscription trial end" event that was caused by no callbacks being attached to this scheduled action. #414
+
 = 5.4.0 - 2023-02-21 =
 * Fix - Remove the recurring shipping method cache that caused bugs for third-party plugins like Conditional Shipping and Payments. #407
 

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -46,6 +46,9 @@ class WC_Subscriptions_Manager {
 		// Whenever a renewal payment is due, put the subscription on hold and create a renewal order before anything else, in case things don't go to plan
 		add_action( 'woocommerce_scheduled_subscription_payment', __CLASS__ . '::prepare_renewal', 1, 1 );
 
+		// When a subscriptions trial end scheduled action is run, attach a callback to trigger a subscription specific trial ended hook.
+		add_action( 'woocommerce_scheduled_subscription_trial_end', __CLASS__ . '::trigger_subscription_trial_ended_hook', 10, 1 );
+
 		// Attach hooks that depend on WooCommerce being loaded.
 		add_action( 'woocommerce_loaded', [ __CLASS__, 'attach_wc_dependant_hooks' ] );
 
@@ -210,6 +213,17 @@ class WC_Subscriptions_Manager {
 		if ( $subscription ) {
 			$subscription->update_status( 'cancelled' );
 		}
+	}
+
+	/**
+	 * Trigger action hook after a subscription's trial period has ended.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param int $subscription_id
+	 */
+	public static function trigger_subscription_trial_ended_hook( $subscription_id ) {
+		do_action( 'woocommerce_subscription_trial_ended', $subscription_id );
 	}
 
 	/**

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -83,8 +83,8 @@ class WCS_Failed_Scheduled_Action_Manager {
 
 		$subscription_action = $this->get_action_hook_label( $action->get_hook() );
 
-		// Not log when there is not a hook associated with the scheduled action
-		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) ) {
+		// Don't log errors for Trial End and Payment Rety scheduled actions when there are no callbacks associated with the scheduled action.
+		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) && in_array( $action->get_hook(), [ 'woocommerce_scheduled_subscription_trial_end', 'woocommerce_scheduled_subscription_payment_retry' ], true ) ) {
 			return;
 		}
 

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -85,7 +85,7 @@ class WCS_Failed_Scheduled_Action_Manager {
 
 		// Not log when there is not a hook associated with the scheduled action
 		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) ) {
-					return;
+			return;
 		}
 
 		switch ( current_filter() ) {

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -83,6 +83,11 @@ class WCS_Failed_Scheduled_Action_Manager {
 
 		$subscription_action = $this->get_action_hook_label( $action->get_hook() );
 
+		// Not log when there is not a hook associated with the scheduled action
+		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) ) {
+					return;
+		}
+
 		switch ( current_filter() ) {
 			case 'action_scheduler_failed_action':
 				$this->log( sprintf( 'scheduled action %s (%s) failed to finish processing after %s seconds', $action_id, $subscription_action, absint( $error ) ) );
@@ -93,11 +98,6 @@ class WCS_Failed_Scheduled_Action_Manager {
 			case 'action_scheduler_unexpected_shutdown':
 				$this->log( sprintf( 'scheduled action %s (%s) failed to finish processing due to the following error: %s', $action_id, $subscription_action, $error['message'] ) );
 				break;
-		}
-
-		// Not log when there is not a hook associated with the scheduled action
-		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) ) {
-			return;
 		}
 
 		$this->log( sprintf( 'action args: %s', $this->get_action_args_string( $action->get_args() ) ) );

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -95,6 +95,11 @@ class WCS_Failed_Scheduled_Action_Manager {
 				break;
 		}
 
+		// Not log when there is not a hook associated with the scheduled action
+		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) ) {
+			return;
+		}
+
 		$this->log( sprintf( 'action args: %s', $this->get_action_args_string( $action->get_args() ) ) );
 
 		// Store information about the scheduled action for displaying an admin notice

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -83,11 +83,6 @@ class WCS_Failed_Scheduled_Action_Manager {
 
 		$subscription_action = $this->get_action_hook_label( $action->get_hook() );
 
-		// Don't log errors for Trial End and Payment Rety scheduled actions when there are no callbacks associated with the scheduled action.
-		if ( strpos( $error->getMessage(), 'not be executed as no callbacks are registered' ) && in_array( $action->get_hook(), [ 'woocommerce_scheduled_subscription_trial_end', 'woocommerce_scheduled_subscription_payment_retry' ], true ) ) {
-			return;
-		}
-
 		switch ( current_filter() ) {
 			case 'action_scheduler_failed_action':
 				$this->log( sprintf( 'scheduled action %s (%s) failed to finish processing after %s seconds', $action_id, $subscription_action, absint( $error ) ) );


### PR DESCRIPTION
> **Note** - From @mattallan
>
> While reviewing this PR we discovered that the error message coming Action Scheduler (AS) is translatable which means it can't reliably by used in a string comparison. To workaround the issue stemming from AS we decided to change the approach and attach a callback to Subscriptions that triggers a subscription-specific trial-ended hook.
>
> Testing instructions on this PR remain the same for the new changes.

---

Fixes #255

## Description

Some scheduled actions don't necessarily have hooks associated with them and have only been added for extensibility, such as `woocommerce_scheduled_subscription_trial_end`.

Action Scheduler 3.5.x introduced a new error message for empty callbacks, but we wouldn't want to log these as errors on WooCommerce Subscriptions Core, so we changed the code accordingly. 

For reference, followed @mattallan [suggestion here](https://github.com/Automattic/woocommerce-subscriptions-core/issues/255#issuecomment-1378034683):

> What I think we'll need to do is update our [WCS_Failed_Scheduled_Action_Manager::log_action_scheduler_failure()](https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/includes/class-wcs-failed-scheduled-action-manager.php#L77) function to have special handling to not log/store failed trial end action scheduler errors that contain the message "not be executed as no callbacks are registered.". 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a subscription with a free trial
1. Wait until the trial ends (or manually run the action for `woocommerce_scheduled_subscription_trial_end`)
1. See the error as a failed scheduled action

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
