### PR TITLE
Fix fatal error when renewing a subscription with a `_shipping_address` meta key.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 5.5.0 - 2023-03-09 =
+= 5.5.0 - 2023-xx-xx =
 * Fix - When HPOS is enabled, changing your address while paying for a renewal order will update the address on the subscription. #413
 * Fix - Prevent admin error notices being shown for the "subscription trial end" event that was caused by no callbacks being attached to this scheduled action. #414
+* Fix - Prevent fatal error when copying the `_shipping_address` meta data where the value is not an array. #417
 
 = 5.4.0 - 2023-02-21 =
 * Fix - Remove the recurring shipping method cache that caused bugs for third-party plugins like Conditional Shipping and Payments. #407

--- a/includes/class-wc-subscriptions-data-copier.php
+++ b/includes/class-wc-subscriptions-data-copier.php
@@ -181,6 +181,14 @@ class WC_Subscriptions_Data_Copier {
 			return;
 		}
 
+		// The WC_Order setter for these keys will expect an array of values, return early if the value is not an array.
+		if (
+			in_array( $key, [ '_shipping_address', '_shipping', '_billing_address', '_billing' ], true )
+			&& ! is_array( $value )
+		) {
+			return;
+		}
+
 		// Special cases where properties with setters don't map nicely to their function names.
 		$setter_map = [
 			'_cart_discount'      => 'set_discount_total',


### PR DESCRIPTION
Fixes #416 

## Description

This PR fixes a fatal error when renewing a subscription where a `_shipping_address` meta key is present.

This fatal was due to an unsupported value type (string) being passed to [`WC_Order::set_shipping_address()`](https://github.com/woocommerce/woocommerce/blob/4ebd35b41d4dc981b1790a0d660a397a92d808ce/plugins/woocommerce/includes/class-wc-order.php#L1110) (array expected).

This PR will skip calling the following WC_Order setters if the value is not an array:
* [`WC_Order::set_shipping()`](https://github.com/woocommerce/woocommerce/blob/4ebd35b41d4dc981b1790a0d660a397a92d808ce/plugins/woocommerce/includes/class-wc-order.php#L1123)
* [`WC_Order::set_shipping_address()`](https://github.com/woocommerce/woocommerce/blob/4ebd35b41d4dc981b1790a0d660a397a92d808ce/plugins/woocommerce/includes/class-wc-order.php#L1110)
* [`WC_Order::set_billing()`](https://github.com/woocommerce/woocommerce/blob/4ebd35b41d4dc981b1790a0d660a397a92d808ce/plugins/woocommerce/includes/class-wc-order.php#L1099)
* [`WC_Order::set_billing_address()`](https://github.com/woocommerce/woocommerce/blob/4ebd35b41d4dc981b1790a0d660a397a92d808ce/plugins/woocommerce/includes/class-wc-order.php#L1084)


### Testing instructions

1. Create a new subscription and ensure that the shipping information is blank by marking the subscription product as virtual.
2. In the database, create the following rows in `_postmeta` with empty string values:`_billing_address`, `_shipping_address`.
4. on `trunk`, process a renewal. You should see a fatal error.
5. On this branch, process a renewal. The error will not occur.
6. Ensure subscription renewals with shipping addresses copy these correctly.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes https://github.com/woocommerce/woocommerce-subscriptions/issues/4493
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
