### PR TITLE
Display all applied coupon labels in cart/checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.6.0 - 2023-xx-xx =
+* Fix - Display labels for all coupons applied to cart and checkout. #427
+
 = 5.5.0 - 2023-03-10 =
 * Fix - When HPOS is enabled, changing your address while paying for a renewal order will update the address on the subscription. #413
 * Fix - Prevent admin error notices being shown for the "subscription trial end" event that was caused by no callbacks being attached to this scheduled action. #414

--- a/templates/checkout/recurring-coupon-totals.php
+++ b/templates/checkout/recurring-coupon-totals.php
@@ -2,7 +2,6 @@
 /**
  * Recurring cart subtotals totals
  *
- * @author  WooCommerce
  * @package WooCommerce Subscriptions/Templates
  * @version 1.0.0 - Migrated from WooCommerce Subscriptions v3.1.0
  */

--- a/templates/checkout/recurring-coupon-totals.php
+++ b/templates/checkout/recurring-coupon-totals.php
@@ -8,7 +8,6 @@
  */
 
 defined( 'ABSPATH' ) || exit;
-$display_heading = true;
 
 foreach ( WC()->cart->get_coupons() as $code => $coupon ) {
 	foreach ( $recurring_carts as $recurring_cart_key => $recurring_cart ) {
@@ -17,18 +16,16 @@ foreach ( WC()->cart->get_coupons() as $code => $coupon ) {
 				continue;
 			} ?>
 			<tr class="cart-discount coupon-<?php echo esc_attr( $code ); ?> recurring-total">
-			<?php if ( $display_heading ) { ?>
-				<?php $display_heading = false; ?>
 				<th rowspan="<?php echo esc_attr( count( $recurring_carts ) ); ?>"><?php wc_cart_totals_coupon_label( $coupon ); ?></th>
-				<td data-title="<?php wc_cart_totals_coupon_label( $coupon ); ?>"><?php
-				wcs_cart_totals_coupon_html( $recurring_coupon, $recurring_cart );
-				echo '&nbsp;';
-				wcs_cart_coupon_remove_link_html( $recurring_coupon );?>
+				<td data-title="<?php wc_cart_totals_coupon_label( $coupon ); ?>">
+				<?php
+					wcs_cart_totals_coupon_html( $recurring_coupon, $recurring_cart );
+					echo '&nbsp;';
+					wcs_cart_coupon_remove_link_html( $recurring_coupon );
+				?>
 				</td>
-			<?php } else { ?>
-				<td><?php wcs_cart_totals_coupon_html( $recurring_coupon, $recurring_cart ); ?></td>
-			<?php } ?>
-			</tr> <?php
+			</tr>
+			<?php
 		}
 	}
 }


### PR DESCRIPTION
Fixes #426 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create at least two recurring product coupon codes as merchant.
2. As shopper, add a subscription product to your cart.
1. Apply both recurring coupons via the cart screen.
1. Ensure all coupon labels are displayed in the cart and checkout

<img width="436" alt="Screenshot 2023-04-12 at 09 47 01" src="https://user-images.githubusercontent.com/3147296/231312275-2599a0ca-9db2-44d4-8978-9284d6792486.png">


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? **yes**  
https://github.com/woocommerce/woocommerce-subscriptions/issues/4502
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
