### PR TITLE
fixed php8.1 float precision loss notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ phpunit.xml
 
 # Release Packages
 *.zip
+
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,3 @@ phpunit.xml
 
 # Release Packages
 *.zip
-
-/build

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.x.x - 20xx-xx-xx =
+* Dev - Fixed precision loss notice.
+
 = 5.5.0 - 2023-03-10 =
 * Fix - When HPOS is enabled, changing your address while paying for a renewal order will update the address on the subscription. #413
 * Fix - Prevent admin error notices being shown for the "subscription trial end" event that was caused by no callbacks being attached to this scheduled action. #414

--- a/includes/class-wcs-staging.php
+++ b/includes/class-wcs-staging.php
@@ -174,7 +174,12 @@ class WCS_Staging {
 		$scheme   = parse_url( $site_url, PHP_URL_SCHEME ) . '://';
 		$site_url = str_replace( $scheme, '', $site_url );
 
-		return $scheme . substr_replace( $site_url, '_[wc_subscriptions_siteurl]_', strlen( $site_url ) / 2, 0 );
+		return $scheme . substr_replace(
+			$site_url,
+			'_[wc_subscriptions_siteurl]_',
+			intval( strlen( $site_url ) / 2 ),
+			0
+		);
 	}
 
 	/**


### PR DESCRIPTION
Part of https://github.com/Automattic/woocommerce-payments/issues/5985

## Description
This PR fixes a notice generated by php 8.1 about precision loss on a division by 2 for an integer parameter.

## How to test this PR
- Using php 8.1
- Checkout this branch
- Open /wp-admin
- No error/warning should show up or be logged

## Product impact
- [x] Added changelog entry (or does not apply)