### PR TITLE
Fix phpcs and semgrep warnings to improve code quality.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.6.0- 2023-xx-xx =
+* Dev - Fix phpcs and semgrep warnings to improve code quality.
+* Dev - Use `wp_safe_redirect()` when processing a payment method change request.
+
 = 5.5.0 - 2023-03-10 =
 * Fix - When HPOS is enabled, changing your address while paying for a renewal order will update the address on the subscription. #413
 * Fix - Prevent admin error notices being shown for the "subscription trial end" event that was caused by no callbacks being attached to this scheduled action. #414

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1302,7 +1302,7 @@ class WC_Subscriptions_Admin {
 			$add_subscription_url = add_query_arg( 'subscription_pointers', 'true', $add_subscription_url );
 		}
 
-		return $add_subscription_url;
+		return esc_url( $add_subscription_url );
 	}
 
 	/**

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1349,7 +1349,7 @@ class WCS_Admin_Post_Types {
 			if ( 'trash' === $status ) {
 				// If the subscription is already trashed, add an untrash action instead.
 				if ( 'trash' === $subscription->get_status() ) {
-					$untrash_url        = $is_hpos_enabled ? add_query_arg( 'action', 'untrash_subscriptions', $action_url ) : wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $subscription->get_id() ) ), 'untrash-post_' . $subscription->get_id() );
+					$untrash_url        = $is_hpos_enabled ? esc_url( add_query_arg( 'action', 'untrash_subscriptions', $action_url ) ) : wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $subscription->get_id() ) ), 'untrash-post_' . $subscription->get_id() );
 					$actions['untrash'] = sprintf(
 						'<a title="%s" href="%s">%s</a>',
 						esc_attr( __( 'Restore this item from the Trash', 'woocommerce-subscriptions' ) ),
@@ -1360,7 +1360,7 @@ class WCS_Admin_Post_Types {
 					$actions['trash'] = sprintf(
 						'<a class="submitdelete" title="%s" href="%s">%s</a>',
 						esc_attr( __( 'Move this item to the Trash', 'woocommerce-subscriptions' ) ),
-						$this->get_trash_or_delete_subscription_link( $subscription->get_id(), $action_url, 'trash' ),
+						esc_url( $this->get_trash_or_delete_subscription_link( $subscription->get_id(), $action_url, 'trash' ) ),
 						$label
 					);
 				}
@@ -1374,7 +1374,7 @@ class WCS_Admin_Post_Types {
 				$actions['delete'] = sprintf(
 					'<a class="submitdelete" title="%s" href="%s">%s</a>',
 					esc_attr( __( 'Delete this item permanently', 'woocommerce-subscriptions' ) ),
-					$this->get_trash_or_delete_subscription_link( $subscription->get_id(), $action_url, 'delete' ),
+					esc_url( $this->get_trash_or_delete_subscription_link( $subscription->get_id(), $action_url, 'delete' ) ),
 					$label
 				);
 
@@ -1387,7 +1387,7 @@ class WCS_Admin_Post_Types {
 				$label = __( 'Cancel Now', 'woocommerce-subscriptions' );
 			}
 
-			$actions[ $status ] = sprintf( '<a href="%s">%s</a>', add_query_arg( 'action', $status, $action_url ), $label );
+			$actions[ $status ] = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( 'action', $status, $action_url ) ), $label );
 		}
 
 		if ( 'pending' === $subscription->get_status() ) {
@@ -1629,7 +1629,7 @@ class WCS_Admin_Post_Types {
 	private function get_trash_or_delete_subscription_link( $subscription_id, $base_action_url, $status ) {
 
 		if ( wcs_is_custom_order_tables_usage_enabled() ) {
-			return add_query_arg( 'action', $status . '_subscriptions', $base_action_url );
+			return esc_url( add_query_arg( 'action', $status . '_subscriptions', $base_action_url ) );
 		}
 
 		return get_delete_post_link( $subscription_id, '', 'delete' === $status );

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1429,7 +1429,7 @@ class WCS_Admin_Post_Types {
 				$sendback_args = $this->do_bulk_action_update_status( $subscription_ids, $action );
 		}
 
-		return esc_url_raw( add_query_arg( $sendback_args, $redirect_to ) );
+		return esc_url_raw( add_query_arg( $sendback_args, $redirect_to ) ); // nosemgrep: audit.php.wp.security.xss.query-arg   -- The output of add_query_arg is being escaped.
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -59,7 +59,7 @@ class WC_Subscriptions_Addresses {
 	public static function add_edit_address_subscription_action( $actions, $subscription ) {
 		if ( $subscription->needs_shipping_address() && $subscription->has_status( array( 'active', 'on-hold' ) ) ) {
 			$actions['change_address'] = array(
-				'url'  => add_query_arg( array( 'subscription' => $subscription->get_id() ), wc_get_endpoint_url( 'edit-address', 'shipping' ) ),
+				'url'  => esc_url( add_query_arg( array( 'subscription' => $subscription->get_id() ), wc_get_endpoint_url( 'edit-address', 'shipping' ) ) ),
 				'name' => __( 'Change address', 'woocommerce-subscriptions' ),
 			);
 		}

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -377,7 +377,7 @@ class WC_Subscriptions_Change_Payment_Gateway {
 
 				// Redirect to success/confirmation/payment page
 				wc_add_notice( $notice );
-				wp_redirect( $result['redirect'] );
+				wp_safe_redirect( $result['redirect'] );
 				exit;
 			}
 		}

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -604,7 +604,7 @@ class WCS_Cart_Renewal {
 	public function get_checkout_payment_url( $pay_url, $order ) {
 
 		if ( wcs_order_contains_renewal( $order ) ) {
-			$pay_url = add_query_arg( array( $this->cart_item_key => 'true' ), $pay_url );
+			$pay_url = esc_url( add_query_arg( array( $this->cart_item_key => 'true' ), $pay_url ) );
 		}
 
 		return $pay_url;

--- a/includes/class-wcs-core-autoloader.php
+++ b/includes/class-wcs-core-autoloader.php
@@ -36,8 +36,6 @@ class WCS_Core_Autoloader {
 
 	/**
 	 * Register the autoloader.
-	 *
-	 * @author Jeremy Pry
 	 */
 	public function register() {
 		spl_autoload_register( array( $this, 'autoload' ) );
@@ -53,8 +51,6 @@ class WCS_Core_Autoloader {
 	/**
 	 * Autoload a class.
 	 *
-	 * @author Jeremy Pry
-	 *
 	 * @param string $class The class name to autoload.
 	 */
 	public function autoload( $class ) {
@@ -67,7 +63,7 @@ class WCS_Core_Autoloader {
 		$full_path = $this->get_class_base_path( $class ) . $this->get_relative_class_path( $class ) . $this->get_file_name( $class );
 
 		if ( is_readable( $full_path ) ) {
-			require_once( $full_path );
+			require_once $full_path; // nosemgrep: audit.php.lang.security.file.inclusion-arg -- This is a safe file inclusion, since the autoloader is only used for classes in the includes dir.
 		}
 	}
 
@@ -84,8 +80,6 @@ class WCS_Core_Autoloader {
 	/**
 	 * Determine whether we should autoload a given class.
 	 *
-	 * @author Jeremy Pry
-	 *
 	 * @param string $class The class name.
 	 *
 	 * @return bool
@@ -101,8 +95,6 @@ class WCS_Core_Autoloader {
 
 	/**
 	 * Convert the class name into an appropriate file name.
-	 *
-	 * @author Jeremy Pry
 	 *
 	 * @param string $class The class name.
 	 *
@@ -122,8 +114,6 @@ class WCS_Core_Autoloader {
 
 	/**
 	 * Determine if the class is one of our abstract classes.
-	 *
-	 * @author Jeremy Pry
 	 *
 	 * @param string $class The class name.
 	 *
@@ -192,8 +182,6 @@ class WCS_Core_Autoloader {
 	 * Get the relative path for the class location.
 	 *
 	 * This handles all of the special class locations and exceptions.
-	 *
-	 * @author Jeremy Pry
 	 *
 	 * @param string $class The class name.
 	 *

--- a/includes/class-wcs-my-account-payment-methods.php
+++ b/includes/class-wcs-my-account-payment-methods.php
@@ -48,7 +48,7 @@ class WCS_My_Account_Payment_Methods {
 						'wcs_nonce'                 => wp_create_nonce( 'delete_subscription_token_' . $payment_token->get_id() ),
 					);
 
-					$payment_token_data['actions']['delete']['url'] = add_query_arg( $delete_subscription_token_args, $payment_token_data['actions']['delete']['url'] );
+					$payment_token_data['actions']['delete']['url'] = esc_url( add_query_arg( $delete_subscription_token_args, $payment_token_data['actions']['delete']['url'] ) );
 				} else {
 					/**
 					 * Allow third-party gateways to override whether the token delete button should be removed.

--- a/includes/gateways/paypal/class-wcs-paypal.php
+++ b/includes/gateways/paypal/class-wcs-paypal.php
@@ -104,6 +104,9 @@ class WCS_PayPal {
 		// Remove PayPal from the available payment methods if it's disabled for subscription purchases.
 		add_filter( 'woocommerce_available_payment_gateways', array( __CLASS__, 'maybe_remove_paypal_standard' ) );
 
+		// Add PayPal domains to the list of allowed hosts for safe redirect.
+		add_filter( 'allowed_redirect_hosts', __CLASS__ . '::allow_paypal_redirect' );
+
 		WCS_PayPal_Supports::init();
 		WCS_PayPal_Status_Manager::init();
 		WCS_PayPal_Standard_Switcher::init();
@@ -535,6 +538,21 @@ class WCS_PayPal {
 			$order->delete_meta_data( 'wcs_lock_order_payment' );
 			$order->save();
 		}
+	}
+
+	/**
+	 * Allow PayPal domains for redirect.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $hosts Add PayPal domains for `wp_safe_redirect`.
+	 *
+	 * @return array
+	 */
+	public static function allow_paypal_redirect( $hosts ) {
+		$hosts[] = 'www.paypal.com';
+		$hosts[] = 'www.sandbox.paypal.com';
+		return $hosts;
 	}
 
 	/** Getters ******************************************************/

--- a/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api.php
@@ -274,7 +274,15 @@ class WCS_PayPal_Reference_Transaction_API extends WCS_SV_API_Base {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
 	public function get_callback_url( $action ) {
-		return add_query_arg( 'action', $action, WC()->api_request_url( 'wcs_paypal' ) );
+		return esc_url(
+			add_query_arg(
+				'action',
+				$action,
+				WC()->api_request_url( 'wcs_paypal' )
+			),
+			null,
+			'db'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR resolves various phpcs & semgrep warnings to improve code quality.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install semgrep: `brew install semgrep`
2. Clone `Automattic/wpscan-semgrep-rules` repo
3. From the `wpscan-semgrep-rules` directory, run the following command, targeting the `woocommerce-subscriptions-core` directory:
	```sh
	semgrep -c audit /path/to/woocommerce-subscriptions-core/
	```
4. Ensure no warnings appear

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
