### PR TITLE
Update from deprecated Ubuntu v18.04 for GH workflows

### DIFF
--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name:    JS linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name:    JS linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/js-lint-test.yml
+++ b/.github/workflows/js-lint-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name:    JS linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   phpcs:
     name:    PHP Code Sniffer
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name:    PHP Linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -77,7 +77,7 @@ jobs:
           fi
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       WC_VERSION: 5.5.0  # the min supported version as per L-2 policy
       WP_VERSION: 'latest'
@@ -98,7 +98,7 @@ jobs:
       - run: bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       WC_VERSION: 'beta'
       WP_VERSION: 'latest'

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   phpcs:
     name:    PHP Code Sniffer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name:    PHP Linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -77,7 +77,7 @@ jobs:
           fi
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       WC_VERSION: 5.5.0  # the min supported version as per L-2 policy
       WP_VERSION: 'latest'
@@ -98,7 +98,7 @@ jobs:
       - run: bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       WC_VERSION: 'beta'
       WP_VERSION: 'latest'

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   phpcs:
     name:    PHP Code Sniffer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name:    PHP Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -77,7 +77,7 @@ jobs:
           fi
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       WC_VERSION: 5.5.0  # the min supported version as per L-2 policy
       WP_VERSION: 'latest'
@@ -98,7 +98,7 @@ jobs:
       - run: bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       WC_VERSION: 'beta'
       WP_VERSION: 'latest'

--- a/bin/run-ci-tests.sh
+++ b/bin/run-ci-tests.sh
@@ -5,10 +5,23 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Install dependencies and remove sarb as it creates problems on php 7.0
+echo 'Updating composer version & Install dependencies...'
 composer self-update 2.0.6 \
   && composer remove --dev "dave-liddament/sarb" \
   && composer install --no-progress
+
+echo 'Starting MySQL service...'
 sudo systemctl start mysql.service
+
+# On GitHub actions, set MySQL authentication to mysql_native_password instead of caching_sha2_password
+# to prevent DB connection problems with PHP versions less than 7.4
+if [[ -n $CI ]]; then
+	echo "Configuring MySQL to use mysql_native_password"
+	mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+fi
+
+echo 'Setting up test environment...'
 bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false
+
 echo 'Running the tests...'
 bash bin/phpunit.sh


### PR DESCRIPTION
## Description

[Ubuntu v18.04 has been deprecated for GH actions runners since 2023/04/03](https://github.com/actions/runner-images/issues/6002), resulting in the GH checks for this repo eventually failing and showing the following error:


```
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.
```

This PR updates the Ubuntu version to `ubuntu-latest` for failing checks.

## How to test this PR

Ensure all GH checks for this PR pass ✅

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
