### PR TITLE
Returns response from WC_Subscription::set_status() parent function

### DIFF
--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -653,7 +653,7 @@ class WC_Subscription extends WC_Order {
 			$new_status = apply_filters( 'woocommerce_default_subscription_status', 'pending' );
 		}
 
-		parent::set_status( $new_status, $note, $manual_update );
+		return parent::set_status( $new_status, $note, $manual_update );
 	}
 
 	/**


### PR DESCRIPTION
Resolves #425

Returns response from the parent function of WC_Subscription::set_status() instead of null

## Description

I'm the customer that wrote into support asking about the change in response when the `WC_Subscription` class was given its own `set_status()` function. I'm including in this PR the code we've tested in our install that has resolved the incompatibility with our custom code that relied on `set_status()` returning an array.

I can't foresee any issues including this would cause. No code should be depending on a null response here but some code like ours may have been looking for the array response WC_Order has. Since WC_Subscription::set_status() modifies the behavior of WC_Order::set_status() very little, I feel it should return the same response.

## How to test this PR

1. Change the status of a subscription in the admin to confirm this function's functionality hasn't been affected
2. The following code will also add to the error log the array response without changing any data in the DB (since save isn't called). Just replace 12345 with the ID of a subscription in your DB.

```
add_action('wp_loaded', function() {
	$subscription_id = 12345;
	$subscription = new WC_Subscription($subscription_id);
	$response = $subscription->set_status('cancelled');
	error_log(print_r($response, true));
});
```

## Product impact

- [ ] Added changelog entry
- [X] Will this PR affect WooCommerce Subscriptions? Yes, #425
- [X] Will this PR affect WooCommerce Payments? No
- [X] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
