### PR TITLE
New filter to compare package rates and standard package rates

### DIFF
--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1149,7 +1149,12 @@ class WC_Subscriptions_Cart {
 				$package_index = isset( $recurring_cart_package['package_index'] ) ? $recurring_cart_package['package_index'] : 0;
 				$package       = WC()->shipping->calculate_shipping_for_package( $recurring_cart_package );
 
-				if ( ( isset( $standard_packages[ $package_index ] ) && $package['rates'] == $standard_packages[ $package_index ]['rates'] ) ) {
+				$package_rates_match = false;
+				if ( isset( $standard_packages[ $package_index ] ) ) {
+					$package_rates_match = apply_filters( 'wcs_recurring_shipping_package_rates_match_standard_rates', $package['rates'] == $standard_packages[ $package_index ]['rates'], $package['rates'], $standard_packages[ $package_index ]['rates'], $recurring_cart_key );
+				}
+
+				if ( $package_rates_match ) {
 					// The recurring package rates match the initial package rates, there won't be a selected shipping method for this recurring cart package move on to the next package.
 					if ( apply_filters( 'wcs_cart_totals_shipping_html_price_only', true, $package, $recurring_cart ) ) {
 						continue;


### PR DESCRIPTION
Creates a new filter that will return the boolean comparison between the package rates and the standard_package rates.

This is to allow a theme to include shipping taxes on the comparison between package rates and standard package rates. More context on issue 430

Fixes #430 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->
There seems to be a data gap between Avatax, WooCommerce Subscriptions when creating a Subscription with Google Pay (WooCommerce Payments)

When Avatax sets the taxes for the shipping methods, it modifies the standard package rates but for some reason that change is not getting into the recurring cart rates.

While we aim to find and fix the root cause, the following filter will allow a theme to manually include the shipping taxes from the standard package rates to the actual package rates, and then return the == comparison from the hook function:

```
$package_rates_match = apply_filters(
    'wcs_recurring_shipping_package_rates_match_standard_rates', 
    $package['rates'] == $standard_packages[ $package_index ]['rates'], 
    $package['rates'], $standard_packages[ $package_index ]['rates'], 
    $recurring_cart_key
);
```

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->


<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->
1. Set up a site with the Avatax plugin and configure a flat rate
2. Configure the site to have Google Pay or Apple Pay enabled, via WooCommerce Payments
3. Try to create a Subscriptions directly from the Product page
4. The user will get the error _"Invalid recurring shipping method"_


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
