### PR TITLE
Fix issues with discounts being applied to manually created parent orders

### DIFF
--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1350,14 +1350,14 @@ class WCS_Cart_Renewal {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.4.3
 	 */
 	public function setup_discounts( $order ) {
-		$order_discount = $order->get_total_discount();
+		$order_discount = $order->get_total_discount() + $order->get_discount_tax();
 		$coupon_items   = $order->get_items( 'coupon' );
 
 		if ( empty( $order_discount ) && empty( $coupon_items ) ) {
 			return;
 		}
 
-		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) );
+		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) + array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		$coupons               = array();
 
 		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1360,8 +1360,11 @@ class WCS_Cart_Renewal {
 		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) + array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		$coupons               = array();
 
-		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.
-		$order_has_manual_discount = $order_discount !== $total_coupon_discount;
+		// If the order total discount is different from the discount applied from coupons then we have a manually applied discount.
+		$delta_threshold = 1; // Allow for floating point rounding errors.
+
+		// Add the rounding number precision (eg convert to cents) to compare the order discount and coupon discount at the same precision.
+		$order_has_manual_discount = abs( wc_add_number_precision( $order_discount ) - wc_add_number_precision( $total_coupon_discount ) ) > $delta_threshold;
 
 		// Get all coupon line items as coupon objects.
 		if ( ! empty( $coupon_items ) ) {


### PR DESCRIPTION
Fixes [woocommerce-subscriptions/issues/4504](https://github.com/woocommerce/woocommerce-subscriptions/issues/4504)

### 🛑 This PR is on-hold while more work and testing is done. I've submitted it as a draft for now. 

## Description

When you apply a coupon to a subscription manually and then pay for a newly created subscription parent order, the discount is supposed to be copied into into the cart as a coupon. Because of a rounding discrepancy with how WC core stores coupon line item totals and order discounts, this was not working as intended. What's more, because this wasn't working as intended, customers would end up in a flow that had even more issues. 

This PR fixes those issues. Namely: 

1. When the order discount total doesn't match the coupon line item total because of a rounding discrepancy, allow for a delta of 1 unit of precision (eg 1 cent). This allows us to use the actual coupon rather than having to retrofit a custom coupon to match the actual total. 
2. When using a custom coupon (eg when a discount is applied to the line item manually), make sure we use the discount total + the discount tax, otherwise the total will be incorrect.
3. 🕙 **TODO** when a custom coupon is applied, it should also apply to the subscription if the same discount also applies to the subscription.   

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Set up:** 

1. Create a 50% **Recurring Product % Discount coupon**
2. Create a $10 monthly subscription
   - This 50% and $10 combination is important as it leads to the rounding discrepancy. 
3. Store Tax settings: prices entered including taxes and a 10% store tax applies
4. manually create a subscription
5. Add the product, recalculate taxes, apply the coupon. The amount is right.
6. Create a pending order
7. click the pay for order link
   8. On `trunk` the order total will be incorrect ($5.46) and the recurring cart won't have the coupon applied. 
   9. On this branch the total should be correct and the coupon should apply to both the initial amount and recurring cart. 

Further tests should be ran to make sure different tax, amounts and ways of applying discounts to parent orders and subscriptions should be tested.  

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
