### PR TITLE
Replace esc url with ignore comments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.7.1 - 2023-xx-xx =
+* Dev - Resolve errors for third-party code using the URLs returned from WC_Subscriptions_Admin::add_subscription_url() and WCS_Cart_Renewal::get_checkout_payment_url() because they were erroneously escaped. #440
+* Dev - Enable third-party code to alter the delete payment token URL returned from flag_subscription_payment_token_deletions. #440
+
 = 5.7.0 - 2023-05-04 =
 * Fix - Fatal error from third-party extensions using the `woocommerce_update_order` expecting the second parameter.
 * Dev - Pass the subscription object as the second parameter to `woocommerce_update_subscription` hook (and `woocommerce_update_order` for backwards compatibility).

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1302,7 +1302,7 @@ class WC_Subscriptions_Admin {
 			$add_subscription_url = add_query_arg( 'subscription_pointers', 'true', $add_subscription_url );
 		}
 
-		return esc_url( $add_subscription_url );
+		return $add_subscription_url; // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. The returned URL is escaped where it is used and escaping URLs should be done at the point of output or usage, not on return.
 	}
 
 	/**

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1629,7 +1629,7 @@ class WCS_Admin_Post_Types {
 	private function get_trash_or_delete_subscription_link( $subscription_id, $base_action_url, $status ) {
 
 		if ( wcs_is_custom_order_tables_usage_enabled() ) {
-			return esc_url( add_query_arg( 'action', $status . '_subscriptions', $base_action_url ) );
+			return add_query_arg( 'action', $status . '_subscriptions', $base_action_url ); // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. The URL returned from this function is escaped at the point of output.
 		}
 
 		return get_delete_post_link( $subscription_id, '', 'delete' === $status );

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -604,7 +604,7 @@ class WCS_Cart_Renewal {
 	public function get_checkout_payment_url( $pay_url, $order ) {
 
 		if ( wcs_order_contains_renewal( $order ) ) {
-			$pay_url = esc_url( add_query_arg( array( $this->cart_item_key => 'true' ), $pay_url ) );
+			$pay_url = add_query_arg( array( $this->cart_item_key => 'true' ), $pay_url ); // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. $pay_url should be escaped at the point of output or usage. Keep the URL in tact for functions hooked in further down the chain.
 		}
 
 		return $pay_url;

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -604,10 +604,10 @@ class WCS_Cart_Renewal {
 	public function get_checkout_payment_url( $pay_url, $order ) {
 
 		if ( wcs_order_contains_renewal( $order ) ) {
-			$pay_url = add_query_arg( array( $this->cart_item_key => 'true' ), $pay_url ); // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. $pay_url should be escaped at the point of output or usage. Keep the URL in tact for functions hooked in further down the chain.
+			$pay_url = add_query_arg( array( $this->cart_item_key => 'true' ), $pay_url );
 		}
 
-		return $pay_url;
+		return $pay_url; // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. $pay_url should be escaped at the point of output or usage. Keep the URL in tact for functions hooked in further down the chain.
 	}
 
 	/**

--- a/includes/class-wcs-my-account-payment-methods.php
+++ b/includes/class-wcs-my-account-payment-methods.php
@@ -48,7 +48,7 @@ class WCS_My_Account_Payment_Methods {
 						'wcs_nonce'                 => wp_create_nonce( 'delete_subscription_token_' . $payment_token->get_id() ),
 					);
 
-					$payment_token_data['actions']['delete']['url'] = add_query_arg( $delete_subscription_token_args, $payment_token_data['actions']['delete']['url'] ); // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. This URL is escaped in the WC template when the token links are outputted.
+					$payment_token_data['actions']['delete']['url'] = add_query_arg( $delete_subscription_token_args, $payment_token_data['actions']['delete']['url'] );
 				} else {
 					/**
 					 * Allow third-party gateways to override whether the token delete button should be removed.
@@ -84,7 +84,7 @@ class WCS_My_Account_Payment_Methods {
 			}
 		}
 
-		return $payment_token_data;
+		return $payment_token_data; // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. This URL is escaped in the WC template when the token links are outputted.
 	}
 
 	/**

--- a/includes/class-wcs-my-account-payment-methods.php
+++ b/includes/class-wcs-my-account-payment-methods.php
@@ -48,7 +48,7 @@ class WCS_My_Account_Payment_Methods {
 						'wcs_nonce'                 => wp_create_nonce( 'delete_subscription_token_' . $payment_token->get_id() ),
 					);
 
-					$payment_token_data['actions']['delete']['url'] = esc_url( add_query_arg( $delete_subscription_token_args, $payment_token_data['actions']['delete']['url'] ) );
+					$payment_token_data['actions']['delete']['url'] = add_query_arg( $delete_subscription_token_args, $payment_token_data['actions']['delete']['url'] ); // nosemgrep: audit.php.wp.security.xss.query-arg -- False positive. This URL is escaped in the WC template when the token links are outputted.
 				} else {
 					/**
 					 * Allow third-party gateways to override whether the token delete button should be removed.

--- a/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api.php
@@ -267,10 +267,11 @@ class WCS_PayPal_Reference_Transaction_API extends WCS_SV_API_Base {
 	/** Helper methods ******************************************************/
 
 	/**
-	 * Get the wc-api URL to redirect to
+	 * Get the wc-api URL to redirect to.
 	 *
-	 * @param string $action checkout action, either `set_express_checkout or `get_express_checkout_details`
-	 * @return string URL
+	 * @param string $action checkout action, either `set_express_checkout or `get_express_checkout_details`.
+	 *
+	 * @return string URL The URL. Note: this URL is escaped.
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
 	public function get_callback_url( $action ) {


### PR DESCRIPTION
## Description

This PR reverses the changes in previous commits to escape these URLs. Escaping URLs returned from functions and passed to filters breaks compatibility making the URL impossible for third-party code to add additional query args or remove existing args. 

See this comment https://github.com/woocommerce/woocommerce-subscriptions/pull/4510#issuecomment-1535934966

I've looked over the URLs returned from these functions and where they are used and confirmed they are escaped at output or final usage.

## How to test this PR

This PR reverses previous changes and adds inline comments instead. With that in mind, there's no need to test the places these URLs are used. I'd recommend:

1. Confirming that these changes don't reintroduce semgrep warnings. 
    - Install semgrep eg `brew install semgrep`.
    - Clone `git@github.com:Automattic/wpscan-semgrep-rules.git`
    - cd into the wpscan-semgrep-rules repo.
    - Run the following command: 
    
```
semgrep -c audit {wp_path}/wp-content/plugins/woocommerce-subscriptions-core/
```

2. Look over the previous changes. 
- I've listed all the PRs we merged here: p1683523589400989/1683283676.180859-slack-C02BW3Z8SHK


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref