### PR TITLE
Fix incorrect pay for order redirect after a user logs in via My Account

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.7.2 - 2023-xx-xx =
+* Fix - Resolved an issue with customers being redirected to an incorrect Pay for Order URL after login.
+
 = 5.7.1 - 2023-05-11 =
 * Dev - Resolve errors for third-party code using the URLs returned from WC_Subscriptions_Admin::add_subscription_url() and WCS_Cart_Renewal::get_checkout_payment_url() because they were erroneously escaped. #440
 * Dev - Enable third-party code to alter the delete payment token URL returned from flag_subscription_payment_token_deletions. #440

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1030,7 +1030,7 @@ class WCS_Cart_Renewal {
 	 * @return string
 	 * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.1.0
 	 */
-	function maybe_redirect_after_login( $redirect, $user = null ) {
+	public function maybe_redirect_after_login( $redirect, $user = null ) {
 		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' === $_GET['wcs_redirect'] ) {
 			$order = wc_get_order( $_GET['wcs_redirect_id'] );
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -42,7 +42,7 @@ class WCS_Cart_Renewal {
 		add_filter( 'woocommerce_create_order', array( &$this, 'update_cart_hash' ), 10, 1 );
 
 		// When a user is prevented from paying for a failed/pending renewal order because they aren't logged in, redirect them back after login
-		add_filter( 'woocommerce_login_redirect', array( &$this, 'maybe_redirect_after_login' ), 10, 1 );
+		add_filter( 'woocommerce_login_redirect', array( &$this, 'maybe_redirect_after_login' ), 10, 2 );
 
 		// Once we have finished updating the renewal order on checkout, update the session cart so the cart changes are honoured.
 		add_action( 'woocommerce_checkout_order_processed', array( &$this, 'update_session_cart_after_updating_renewal_order' ), 10 );
@@ -1025,15 +1025,16 @@ class WCS_Cart_Renewal {
 	/**
 	 * Redirect back to pay for an order after successfully logging in.
 	 *
-	 * @param string | redirect URL after successful login
+	 * @param string  The redirect URL after successful login.
+	 * @param WP_User The newly logged in user object.
 	 * @return string
 	 * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.1.0
 	 */
-	function maybe_redirect_after_login( $redirect ) {
-		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' == $_GET['wcs_redirect'] ) {
+	function maybe_redirect_after_login( $redirect, $user = null ) {
+		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' === $_GET['wcs_redirect'] ) {
 			$order = wc_get_order( $_GET['wcs_redirect_id'] );
 
-			if ( $order ) {
+			if ( $order && user_can( $user, 'pay_for_order', $order->get_id() ) ) {
 				$redirect = $order->get_checkout_payment_url();
 			}
 		}

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1034,8 +1034,11 @@ class WCS_Cart_Renewal {
 		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' === $_GET['wcs_redirect'] ) {
 			$order = wc_get_order( $_GET['wcs_redirect_id'] );
 
-			if ( $order && user_can( $user, 'pay_for_order', $order->get_id() ) ) {
+			if ( $order && $order->get_user_id() && user_can( $user, 'pay_for_order', $order->get_id() ) ) {
 				$redirect = $order->get_checkout_payment_url();
+			} else {
+				// Remove the wcs_redirect query args if the user doesn't have permission to pay for the order.
+				$redirect = remove_query_arg( array( 'wcs_redirect', 'wcs_redirect_id' ), $redirect );
 			}
 		}
 


### PR DESCRIPTION
## Description

This PR fixes an issue with customers being redirected to an invalid pay for order URLs after logging in via their My Account page. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
