### PR TITLE
Fix deleting related order_id cache after delete with HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.8.0 - 2023-xx-xx =
+* Fix - When HPOS is enabled, permanently deleting a subscription related order wasn't updating the related orders cache properly.
+
 = 5.7.2 - 2023-06-05 =
 * Fix - Resolved an issue with customers being redirected to an incorrect Pay for Order URL after login.
 

--- a/includes/class-wcs-object-data-cache-manager.php
+++ b/includes/class-wcs-object-data-cache-manager.php
@@ -282,7 +282,7 @@ class WCS_Object_Data_Cache_Manager extends WCS_Post_Meta_Cache_Manager {
 		unset( $this->object_changes[ $object_id ] );
 
 		foreach ( $object_changes as $key => $change ) {
-			$this->trigger_update_cache_hook( $change['type'], $object_id, $key, $change['new'] );
+			$this->trigger_update_cache_hook( $change['type'], $object_id, $key, $change['previous'] );
 		}
 	}
 

--- a/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
+++ b/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
@@ -242,6 +242,70 @@ class WCS_Related_Order_Store_Cached_CPT_Test extends WCS_Base_Related_Order_Sto
 	}
 
 	/**
+	 * Make sure a related order is removed from the cached relationship array after deletion.
+	 *
+	 * @dataProvider provider_relation_type
+	 */
+	public function test_cache_updates_after_related_object_is_deleted_foo( $relation_type ) {
+		$subscription       = WCS_Helper_Subscription::create_subscription();
+		$order_to_delete    = WCS_Helper_Subscription::create_order();
+		$order_id_to_delete = $order_to_delete->get_id();
+		$order_to_keep      = WCS_Helper_Subscription::create_order();
+		$order_id_to_keep   = $order_to_keep->get_id();
+
+		self::$cache_store->add_relation( $order_to_delete, $subscription, $relation_type );
+		self::$cache_store->add_relation( $order_to_keep, $subscription, $relation_type );
+
+		// Verify that the related orders are correct and cached.
+		$related_order_ids = self::$cache_store->get_related_order_ids( $subscription, $relation_type );
+		$this->assertContains( $order_id_to_keep, $related_order_ids );
+		$this->assertContains( $order_id_to_delete, $related_order_ids );
+
+		$order_to_delete->delete( true );
+
+		// Verify that the deleted order was removed from the cached relationship
+		$related_order_ids = self::$cache_store->get_related_order_ids( $subscription, $relation_type );
+		$this->assertContains( $order_id_to_keep, $related_order_ids );
+		$this->assertNotContains( $order_id_to_delete, $related_order_ids );
+	}
+
+	/**
+	 * Make sure a related order is removed from the cached relationship array after deletion when the order is related
+	 * to more than one Subscription.
+	 *
+	 * @dataProvider provider_relation_type
+	 */
+	public function test_cache_updates_after_related_object_is_deleted_many_to_many( $relation_type ) {
+		$subscription_one   = WCS_Helper_Subscription::create_subscription();
+		$subscription_two   = WCS_Helper_Subscription::create_subscription();
+		$order_to_delete    = WCS_Helper_Subscription::create_order();
+		$order_id_to_delete = $order_to_delete->get_id();
+		$order_to_keep      = WCS_Helper_Subscription::create_order();
+		$order_id_to_keep   = $order_to_keep->get_id();
+
+		self::$cache_store->add_relation( $order_to_delete, $subscription_one, $relation_type );
+		self::$cache_store->add_relation( $order_to_keep, $subscription_one, $relation_type );
+		self::$cache_store->add_relation( $order_to_delete, $subscription_two, $relation_type );
+		self::$cache_store->add_relation( $order_to_keep, $subscription_two, $relation_type );
+
+		// Verify that the related orders are correct and cached.
+		foreach ( [ $subscription_one, $subscription_two ] as $subscription ) {
+			$related_order_ids = self::$cache_store->get_related_order_ids( $subscription, $relation_type );
+			$this->assertContains( $order_id_to_keep, $related_order_ids );
+			$this->assertContains( $order_id_to_delete, $related_order_ids );
+		}
+
+		$order_to_delete->delete( true );
+
+		// Verify that the deleted order was removed from the cached relationship
+		foreach ( [ $subscription_one, $subscription_two ] as $subscription ) {
+			$related_order_ids = self::$cache_store->get_related_order_ids( $subscription, $relation_type );
+			$this->assertContains( $order_id_to_keep, $related_order_ids );
+			$this->assertNotContains( $order_id_to_delete, $related_order_ids );
+		}
+	}
+
+	/**
 	 * Check the related renewal order cache value is set when creating a subscription, becuase it should be set by
 	 * WCS_Related_Order_Store_Cached_CPT::set_empty_renewal_order_cache()
 	 */

--- a/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
+++ b/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
@@ -273,42 +273,6 @@ class WCS_Related_Order_Store_Cached_CPT_Test extends WCS_Base_Related_Order_Sto
 	}
 
 	/**
-	 * Make sure a related order is removed from the cached relationship array after deletion when the order is related
-	 * to more than one Subscription.
-	 *
-	 * @dataProvider provider_relation_type
-	 */
-	public function test_cache_updates_after_related_object_is_deleted_many_to_many( $relation_type ) {
-		$subscription_one   = WCS_Helper_Subscription::create_subscription();
-		$subscription_two   = WCS_Helper_Subscription::create_subscription();
-		$order_to_delete    = WCS_Helper_Subscription::create_order();
-		$order_id_to_delete = $order_to_delete->get_id();
-		$order_to_keep      = WCS_Helper_Subscription::create_order();
-		$order_id_to_keep   = $order_to_keep->get_id();
-
-		self::$cache_store->add_relation( $order_to_delete, $subscription_one, $relation_type );
-		self::$cache_store->add_relation( $order_to_keep, $subscription_one, $relation_type );
-		self::$cache_store->add_relation( $order_to_delete, $subscription_two, $relation_type );
-		self::$cache_store->add_relation( $order_to_keep, $subscription_two, $relation_type );
-
-		// Verify that the related orders are correct and cached.
-		foreach ( [ $subscription_one, $subscription_two ] as $subscription ) {
-			$related_order_ids = self::$cache_store->get_related_order_ids( $subscription, $relation_type );
-			$this->assertContains( $order_id_to_keep, $related_order_ids );
-			$this->assertContains( $order_id_to_delete, $related_order_ids );
-		}
-
-		$order_to_delete->delete( true );
-
-		// Verify that the deleted order was removed from the cached relationship
-		foreach ( [ $subscription_one, $subscription_two ] as $subscription ) {
-			$related_order_ids = self::$cache_store->get_related_order_ids( $subscription, $relation_type );
-			$this->assertContains( $order_id_to_keep, $related_order_ids );
-			$this->assertNotContains( $order_id_to_delete, $related_order_ids );
-		}
-	}
-
-	/**
 	 * Check the related renewal order cache value is set when creating a subscription, becuase it should be set by
 	 * WCS_Related_Order_Store_Cached_CPT::set_empty_renewal_order_cache()
 	 */

--- a/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
+++ b/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
@@ -246,7 +246,7 @@ class WCS_Related_Order_Store_Cached_CPT_Test extends WCS_Base_Related_Order_Sto
 	 *
 	 * @dataProvider provider_relation_type
 	 */
-	public function test_cache_updates_after_related_object_is_deleted_foo( $relation_type ) {
+	public function test_cache_updates_after_related_object_is_deleted_one_to_many( $relation_type ) {
 		$subscription       = WCS_Helper_Subscription::create_subscription();
 		$order_to_delete    = WCS_Helper_Subscription::create_order();
 		$order_id_to_delete = $order_to_delete->get_id();


### PR DESCRIPTION
## Description

With HPOS enabled, the cached order relationships for subscriptions is not updated when the order is deleted.  

It does properly update without HPOS enabled.

There are two bugs here causing the issue.

First, the `WCS_Object_Data_Cache_Manager::deleted()` attempts to pass in the `new` value instead of the `previous` value for the call to `trigger_update_cache_hook()`.

https://github.com/Automattic/woocommerce-subscriptions-core/blob/39fc2b3394f207154fd29bbf78b7b3ad41b889b4/includes/class-wcs-object-data-cache-manager.php#L285

This means that `WCS_Related_Order_Store_Cached_CPT::maybe_update_for_post_meta_change()` doesn't receive a `$subscription_id`  and call `WCS_Related_Order_Store_Cached_CPT::delete_related_order_id_from_caches()` to delete the order_id from all subscription relationships.   However, `::delete_related_order_id_from_caches()` fails to retrieve any related subscriptions for the order because the order is already deleted at this point.

https://github.com/Automattic/woocommerce-subscriptions-core/blob/39fc2b3394f207154fd29bbf78b7b3ad41b889b4/includes/wcs-order-functions.php#L40

## How to test this PR

New unit test added: `WCS_Related_Order_Store_Cached_CPT_Test::test_cache_updates_after_related_object_is_deleted_one_to_many()`

1. Follow the testing instructions given in the [subscriptions-core Unit Tests](https://github.com/Automattic/woocommerce-subscriptions-core/tree/trunk/tests#subscriptions-core-unit-tests).
2. Set the HPOS environmental variable when running the test: `$> HPOS=1 ./vendor/bin/phpunit --filter=WCS_Related_Order_Store_Cached_CPT_Test::test_cache_updates_after_related_object_is_deleted_one_to_many`

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
