### PR TITLE
Fix PHP Lint issues currently causing automated checks to fail

### DIFF
--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -1151,6 +1151,7 @@ class WC_Subscriptions_Cart {
 
 				$package_rates_match = false;
 				if ( isset( $standard_packages[ $package_index ] ) ) {
+					// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 					$package_rates_match = apply_filters( 'wcs_recurring_shipping_package_rates_match_standard_rates', $package['rates'] == $standard_packages[ $package_index ]['rates'], $package['rates'], $standard_packages[ $package_index ]['rates'], $recurring_cart_key );
 				}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1031,6 +1031,7 @@ class WCS_Cart_Renewal {
 	 * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.1.0
 	 */
 	public function maybe_redirect_after_login( $redirect, $user = null ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' === $_GET['wcs_redirect'] ) {
 			$order = wc_get_order( $_GET['wcs_redirect_id'] );
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1031,8 +1031,10 @@ class WCS_Cart_Renewal {
 	 * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.1.0
 	 */
 	public function maybe_redirect_after_login( $redirect, $user = null ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' === $_GET['wcs_redirect'] ) {
+		/**
+		 * Nonce verification is not needed here as it was already checked during the log-in process, see WC_Form_Handler::process_login().
+		 */
+		if ( isset( $_GET['wcs_redirect'], $_GET['wcs_redirect_id'] ) && 'pay_for_order' === $_GET['wcs_redirect'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$order = wc_get_order( $_GET['wcs_redirect_id'] );
 
 			if ( $order && $order->get_user_id() && user_can( $user, 'pay_for_order', $order->get_id() ) ) {


### PR DESCRIPTION
## Description

Automated checks in this repo are failing because of existing lint issues.  This fixes those two issues by adding a phpcs:ignore for the specific problems.  In both cases, this is the correct fix.

`maybe_redirect_after_login()` already has a nonce check during the log-in process.

`validate_recurring_shipping_methods()` is comparing arrays which may not have the same key order.
