### PR TITLE
Confirm there are recurring carts before attempting to output the recurring cart totals

### DIFF
--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -981,20 +981,19 @@ class WC_Subscriptions_Cart {
 	}
 
 	/**
-	 * Display the recurring totals for items in the cart
+	 * Displays the recurring totals for items in the cart.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
 	public static function display_recurring_totals() {
 
-		if ( self::cart_contains_subscription() ) {
-
-			// We only want shipping for recurring amounts, and they need to be calculated again here
+		if ( self::cart_contains_subscription() && ! empty( WC()->cart->recurring_carts ) ) {
+			// We only want shipping for recurring amounts, and they need to be calculated again here.
 			self::$calculation_type       = 'recurring_total';
 			$carts_with_multiple_payments = 0;
 
 			foreach ( WC()->cart->recurring_carts as $recurring_cart ) {
-				// Cart contains more than one payment
+				// Cart contains more than one payment.
 				if ( 0 != $recurring_cart->next_payment_date ) {
 					$carts_with_multiple_payments++;
 				}


### PR DESCRIPTION
## Description

6473042-zd-woothemes

The function responsible for displaying the recurring totals section of the cart (see screenshot below) has logic to make sure the cart contains subscriptions, but doesn't check if the recurring cart array is also present. 

<p align="center">
<img width="300" alt="Screenshot 2023-07-03 at 11 00 20 am" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/30b723b6-bee9-4635-94d4-ffe9cc36a61c">
<p>

I haven't been able to replicate an issue here but we received this error report: 

```
Error Level: E_WARNING
Message: Invalid argument supplied for foreach()
File: /wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/class-wc-subscriptions-cart.php
Line: 996
Request: /wp-admin/admin-ajax.php
Referrer: https://example.com/checkout/
```

Given this function is responsible for displaying the recurring carts, it makes sense that we check recurring carts have been generated. Because the request is a `/wp-admin/admin-ajax.php` I have a feeling this is an admin request and we know from past experience that the cart object isn't a reliable API on admin requests. 

## How to test this PR

This change should have no impact on normal use of the plugin. 

1. Place subscription products in the cart. 
2. Go to the cart page and ensure the recurring totals section is being displayed as expected. 
3. Remove subscription products from the cart.
4. Go to the cart page and make sure there is no recurring totals section displayed.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)