### PR TITLE
Fix changes to shipping methods resulting in incorrect Recurring Total amounts

### DIFF
--- a/assets/js/frontend/wcs-cart.js
+++ b/assets/js/frontend/wcs-cart.js
@@ -19,6 +19,30 @@ jQuery( function ( $ ) {
 		hide_non_applicable_coupons();
 	} );
 
+	/**
+	 * Update all subscriptions shipping methods which inherit the chosen method from the initial cart when the customer changes the shipping method.
+	 */
+	$( document ).on(
+		'change',
+		'select.shipping_method, :input[name^=shipping_method]',
+		function( event ) {
+			var shipping_method_option = $( event.target );
+			var shipping_method_id     = shipping_method_option.val();
+			var package_index          = shipping_method_option.data( 'index' );
+
+			// We're only interested in the initial cart shipping method options which have int package indexes.
+			if ( ! ( typeof package_index === 'number' && isFinite( package_index ) && Math.floor( package_index ) === package_index ) ) {
+				return;
+			}
+
+			// Find all recurring cart shipping info elements that match the same package index as the shipping method that was changed.
+			$( '.recurring-cart-shipping-mapping-info[data-index=' + package_index + ']' ).each( function() {
+				// Update the corresponding subscription's hidden chosen shipping method.
+				$( 'input[name="shipping_method[' + $( this ).data( 'recurring_index' ) + ']"]' ).val( shipping_method_id );
+			});
+		}
+	);
+
 	$( '.payment_methods [name="payment_method"]' ).on( 'click', function () {
 		if ( $( this ).hasClass( 'supports-payment-method-changes' ) ) {
 			$( '.update-all-subscriptions-payment-method-wrap' ).show();

--- a/assets/js/frontend/wcs-cart.js
+++ b/assets/js/frontend/wcs-cart.js
@@ -20,7 +20,8 @@ jQuery( function ( $ ) {
 	} );
 
 	/**
-	 * Update all subscriptions shipping methods which inherit the chosen method from the initial cart when the customer changes the shipping method.
+	 * Update all subscriptions shipping methods which inherit the chosen method from the initial
+	 * cart when the customer changes the shipping method.
 	 */
 	$( document ).on(
 		'change',
@@ -31,7 +32,7 @@ jQuery( function ( $ ) {
 			var package_index          = shipping_method_option.data( 'index' );
 
 			// We're only interested in the initial cart shipping method options which have int package indexes.
-			if ( ! ( typeof package_index === 'number' && isFinite( package_index ) && Math.floor( package_index ) === package_index ) ) {
+			if ( ! Number.isInteger( package_index ) ) {
 				return;
 			}
 
@@ -39,7 +40,7 @@ jQuery( function ( $ ) {
 			$( '.recurring-cart-shipping-mapping-info[data-index=' + package_index + ']' ).each( function() {
 				// Update the corresponding subscription's hidden chosen shipping method.
 				$( 'input[name="shipping_method[' + $( this ).data( 'recurring_index' ) + ']"]' ).val( shipping_method_id );
-			});
+			} );
 		}
 	);
 

--- a/assets/js/frontend/wcs-cart.js
+++ b/assets/js/frontend/wcs-cart.js
@@ -36,7 +36,7 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			// Find all recurring cart shipping info elements that match the same package index as the shipping method that was changed.
+			// Find all recurring cart info elements with the same package index as the changed shipping method.
 			$( '.recurring-cart-shipping-mapping-info[data-index=' + package_index + ']' ).each( function() {
 				// Update the corresponding subscription's hidden chosen shipping method.
 				$( 'input[name="shipping_method[' + $( this ).data( 'recurring_index' ) + ']"]' ).val( shipping_method_id );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 5.9.0 - 2023-xx-xx =
+* Fix - Ensure when a customer changes the shipping method on cart and checkout that the recurring totals correctly reflect the chosen method.
+
 = 5.8.0 - 2023-07-05 =
 * Fix - When HPOS is enabled, permanently deleting a subscription related order wasn't updating the related orders cache properly.
 * Fix - Added logic to check if the recurring cart array is present before displaying the recurring totals section in the cart.

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -83,11 +83,11 @@ function wcs_cart_totals_shipping_html() {
 					$chosen_recurring_method = empty( $package['rates'] ) ? '' : current( $package['rates'] )->id;
 				}
 
-				$shipping_selection_displayed       = false;
-				$only_one_shipping_option           = count( $package['rates'] ) === 1;
-				$recurring_rates_match_intial_rates = isset( $package['rates'][ $chosen_initial_method ] ) && isset( $initial_packages[ $package_index ] ) && $package['rates'] == $initial_packages[ $package_index ]['rates'];
+				$shipping_selection_displayed        = false;
+				$only_one_shipping_option            = count( $package['rates'] ) === 1;
+				$recurring_rates_match_initial_rates = isset( $package['rates'][ $chosen_initial_method ] ) && isset( $initial_packages[ $package_index ] ) && $package['rates'] == $initial_packages[ $package_index ]['rates']; // phpcs:ignore WordPress.PHP.StrictComparisons
 
-				if ( $only_one_shipping_option || ( $recurring_rates_match_intial_rates && apply_filters( 'wcs_cart_totals_shipping_html_price_only', true, $package, $recurring_cart ) ) ) {
+				if ( $only_one_shipping_option || ( $recurring_rates_match_initial_rates && apply_filters( 'wcs_cart_totals_shipping_html_price_only', true, $package, $recurring_cart ) ) ) {
 					$shipping_method = ( 1 === count( $package['rates'] ) ) ? current( $package['rates'] ) : $package['rates'][ $chosen_initial_method ];
 					// packages match, display shipping amounts only
 					?>
@@ -110,7 +110,7 @@ function wcs_cart_totals_shipping_html() {
 							<?php if ( ! empty( $show_package_details ) ) : ?>
 								<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
 							<?php endif; ?>
-							<?php if ( $recurring_rates_match_intial_rates ) : ?>
+							<?php if ( $recurring_rates_match_initial_rates ) : ?>
 								<?php wcs_cart_print_inherit_shipping_flag( $recurring_cart_package_key ); ?>
 							<?php endif; ?>
 						</td>

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -110,6 +110,9 @@ function wcs_cart_totals_shipping_html() {
 							<?php if ( ! empty( $show_package_details ) ) : ?>
 								<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
 							<?php endif; ?>
+							<?php if ( $recurring_rates_match_intial_rates ) : ?>
+								<?php wcs_cart_print_inherit_shipping_flag( $recurring_cart_package_key ); ?>
+							<?php endif; ?>
 						</td>
 					</tr>
 					<?php
@@ -180,6 +183,30 @@ function wcs_cart_print_shipping_input( $shipping_method_index, $shipping_method
 		esc_attr( sanitize_title( $shipping_method->id ) ),
 		esc_attr( $shipping_method->id ),
 		esc_attr( $checked )
+	);
+}
+
+/**
+ * Prints a hidden element which indicates that the shipping method for a given recurring cart is inherited from the initial cart.
+ *
+ * In frontend scripts, this hidden element's data properties are used to link initial cart shipping method changes to the
+ * corresponding hidden recurring cart shipping method input element.
+ *
+ * @param string $shipping_method_index The shipping method index for the recurring cart. eg 2023_08_11_monthly_0.
+ */
+function wcs_cart_print_inherit_shipping_flag( $shipping_method_index ) {
+	// Split the string using the underscore character
+	$parts = explode( '_', $shipping_method_index );
+
+	// Extract the recurring cart key and package index
+	$recurring_cart_key = implode( '_', array_slice( $parts, 0, -1 ) );
+	$package_index      = end( $parts );
+
+	printf(
+		'<input type="hidden" data-recurring_index="%1$s" data-index="%2$s" data-recurring-cart-key="%3$s" data-recurring-cart-key="%2$s" value="true" class="recurring-cart-shipping-mapping-info"/>',
+		esc_attr( $shipping_method_index ),
+		esc_attr( $package_index ),
+		esc_attr( $recurring_cart_key ),
 	);
 }
 

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -206,7 +206,7 @@ function wcs_cart_print_inherit_shipping_flag( $shipping_method_index ) {
 		'<input type="hidden" data-recurring_index="%1$s" data-index="%2$s" data-recurring-cart-key="%3$s" data-recurring-cart-key="%2$s" value="true" class="recurring-cart-shipping-mapping-info"/>',
 		esc_attr( $shipping_method_index ),
 		esc_attr( $package_index ),
-		esc_attr( $recurring_cart_key ),
+		esc_attr( $recurring_cart_key )
 	);
 }
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4335

## Description

When a recurring cart's shipping method choices match those of the global (initial) cart, shipping method radio buttons aren't shown for a recurring cart. 

<p align="center">
<img width="330" alt="Screenshot 2023-07-11 at 4 40 52 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/7733abfa-5b3f-4e8d-8af7-ca77a021738b">
</p>

These recurring carts are supposed to inherit the method the customer chooses for the initial order, however, this wasn't the case because of a quirk in how the hidden recurring shipping method elements worked. 

When the page would load the recurring cart shipping method be given the same chosen method (eg free shipping) via a hidden input field. If the customer changed the chosen method, the form would submit and that hidden recurring shipping method element that still stored free shipping would be submitted. [This code](https://github.com/Automattic/woocommerce-subscriptions-core/blob/issue/wcs-4335/includes/class-wc-subscriptions-cart.php#L949-L960), would then set the recurring cart's chosen method to what was the previously chosen method. The cart html elements would be updated via ajax, but because this recurring cart is supposed to inherit the global cart's chosen method, it would display the correct name, but the shipping method cost used in recurring cart calculations would have been the old chosen method. 

This process would then repeat, and each time the user changed the chosen method, the recurring totals would lag by 1 change. eg the total would reflect the last chosen method. 

This PR addresses the issue by ensuring that when a recurring cart shipping method is expected to adopt the chosen method from the global cart, our hidden shipping method elements are appropriately updated to reflect that, ensuring that the data submitted in the form is correct. 

## How to test this PR

1. Add at least 3 shipping methods. eg
   - Free shipping
   - Flat rate: $10
   - Flat rate: $50
3. Place a subscription in the cart.
4. On the cart page change back and forth the shipping method.
    - On `trunk` you'll notice the recurring total is incorrect between changes and the correct total lags between each change. 
    - On this branch it should update correctly. 
4. Repeat on the checkout page 

<table>
  <tr>
    <th><code>trunk</code></th>
    <th>This branch</th>
  </tr>
  <tr>
    <td><img src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/e7eb88b8-4cd0-413f-96cb-8dbff2b169b9" width="320"></td>
    <td><img src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/506c1be4-d440-4d6b-880b-8e986087f4ae"  width="320"></td>
  </tr>
</table>

## Additional Testing

Above I've outlined a simple test to replicate and observe the fix. Additional steps should be taken to test more complicate shipping arrangements like, free shipping only being offered to totals reaching a minimum. Free trials, sign up fees, free shipping coupons etc.

## Comments

The Block cart and checkouts don't appear to be impacted by this because they always give the customer the option to select a shipping method for each recurring cart. There isn't a situation where it inherits the choice from the initial cart. 


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
