### PR TITLE
When HPOS is disabled use the users subscription cache when fetching subscriptions by customer ID

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.2.0 - 2023-xx-xx =
 * Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.
+* Update - When HPOS is disabled, fetch subscriptions by customer_id using the user's subscription cache to improve performance.
 
 = 6.1.0 - 2023-07-26 =
 * Fix - Resolved an issue that prevented the "Used for variations" checkbox to not be enabled on the edit product page load causing variations to be deleted erroneously.

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -501,7 +501,13 @@ function wcs_get_subscriptions( $args ) {
 
 	// Maybe filter to a specific customer.
 	if ( 0 !== $args['customer_id'] && is_numeric( $args['customer_id'] ) ) {
-		$query_args['customer_id'] = $args['customer_id'];
+		// When HPOS is disabled, fetch subscriptions by customer_id using the user's subscription cache and query by post__in for improved performance.
+		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
+			$users_subscription_ids = WCS_Customer_Store::instance()->get_users_subscription_ids( $args['customer_id'] );
+			$query_args             = WCS_Admin_Post_Types::set_post__in_query_var( $query_args, $users_subscription_ids );
+		} else {
+			$query_args['customer_id'] = $args['customer_id'];
+		}
 	}
 
 	// We need to restrict subscriptions to those which contain a certain product/variation


### PR DESCRIPTION
Fixes #466 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/171 we removed a section of our `wcs_get_subscriptions()` function which used get subscriptions by customer ID using the user's subscription cache and then setting this list of IDs in `post__in` to improve performance of this query.

While working on HPOS changes we removed the cache/post__in approach as it was no longer needed due to improvements with the new order tables, however, this now means non-HPOS stores are now inefficiently getting subscriptions by customer ID.

The code we removed:
```
// Maybe filter to a specific user
if ( 0 != $args['customer_id'] && is_numeric( $args['customer_id'] ) ) {
	$users_subscription_ids = WCS_Customer_Store::instance()->get_users_subscription_ids( $args['customer_id'] );
	$query_args             = WCS_Admin_Post_Types::set_post__in_query_var( $query_args, $users_subscription_ids );
};
```

For large stores without HPOS, this can be a pretty significant hit to performance when using `wcs_get_subscriptions()` with the `customer_id` arg, so this PR brings back the user cache + `post__in` approach we had previously when HPOS is disabled.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
