### PR TITLE
[HPOS] Fix wcs_get_subscription_orders() returning empty list when querying parent orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.0.0 - 2023-xx-xx =
+* Dev - Fixed wcs_get_subscription_orders() returning an empty list when querying parent orders when HPOS is enabled with data syncing off.
+
 = 5.9.0 - 2023-07-14 =
 * Fix - Ensure when a customer changes the shipping method on cart and checkout that the recurring totals correctly reflect the chosen method.
 

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -455,11 +455,18 @@ function wcs_get_subscription_orders( $return_fields = 'ids', $order_type = 'par
 	$order_ids = array();
 
 	if ( $any_order_type || in_array( 'parent', $order_type ) ) {
+		$is_hpos          = wcs_is_custom_order_tables_usage_enabled();
+		$table_name       = $is_hpos ? 'wc_orders' : 'posts';
+		$parent_order_col = $is_hpos ? 'parent_order_id' : 'post_parent';
+		$type_col         = $is_hpos ? 'type' : 'post_type';
+
+		// @codingStandardsIgnoreStart
 		$order_ids = array_merge( $order_ids, $wpdb->get_col(
-			"SELECT DISTINCT post_parent FROM {$wpdb->posts}
-			 WHERE post_type = 'shop_subscription'
-			 AND post_parent <> 0"
+			"SELECT DISTINCT {$parent_order_col} FROM {$wpdb->prefix}{$table_name}
+			WHERE {$type_col} = 'shop_subscription'
+			AND {$parent_order_col} <> 0"
 		) );
+		// @codingStandardsIgnoreEnd
 	}
 
 	if ( $any_order_type || in_array( 'renewal', $order_type ) || in_array( 'resubscribe', $order_type ) || in_array( 'switch', $order_type ) ) {


### PR DESCRIPTION
Fixes #422

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

With HPOS enabled & data synchronization disabled, calling `wcs_get_subscription_orders( 'ids', 'parent' )` will return an empty array due to this function querying for `post_parent` from the posts table.

In this PR I'm replacing the following query with code that alters the query based on whether HPOS is enabled.

```
$order_ids = array_merge( $order_ids, $wpdb->get_col(
	"SELECT DISTINCT post_parent FROM {$wpdb->posts}
	 WHERE post_type = 'shop_subscription'
	 AND post_parent <> 0"
) );
```

> **Note** - This function not working as expected doesn't impact WC Subscriptions as we don't use this with HPOS enabled.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPOS on your store and turn off data syncing
2. Purchase a subscription
3. With WP Console run the following snippet:
```
echo var_export( wcs_get_subscription_orders( 'ids', 'parent' ), true );
```
4. While on `trunk`, this will return an empty array.
5. On this branch, the query will return all subscription parent orders.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
