### PR TITLE
Ensure variable subscription products have the "Used for variations" checkbox enabled on WC v7.9.0

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -768,7 +768,6 @@ jQuery( function ( $ ) {
 	});
 
 	$( 'input#_downloadable, input#_virtual' ).on( 'change', function () {
-
 		$.showHideSubscriptionMeta();
 		$.showHideVariableSubscriptionMeta();
 	} );

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -86,6 +86,25 @@ jQuery( function ( $ ) {
 					.addClass( 'form-row-last' );
 			}
 		},
+		enableProductFields: function () {
+			product_type = $( 'select#product-type' ).val();
+			enable_type  = '';
+
+			if ( product_type == 'variable-subscription' ) {
+				enable_type = 'variable'
+			} else {
+				enable_type = 'simple';
+			}
+
+			if ( enable_type ) {
+				$( `.enable_if_${ enable_type }` ).each( function () {
+					$( this ).removeClass( 'disabled' );
+					if ( $( this ).is( 'input' ) ) {
+						$( this ).prop( 'disabled', false );
+					}
+				} );
+			}
+		},
 		showOrHideStockFields: function () {
 			if ( $( 'input#_manage_stock' ).is( ':checked' ) ) {
 				$( 'div.stock_fields' ).show();
@@ -718,11 +737,37 @@ jQuery( function ( $ ) {
 	$( 'body' ).on( 'woocommerce-product-type-change', function () {
 		$.showHideSubscriptionMeta();
 		$.showHideVariableSubscriptionMeta();
+		$.enableProductFields();
 		$.showHideSyncOptions();
 		$.showHideSubscriptionsPanels();
 	} );
 
+	// WC Core enable/disable product fields when saving attributes. We need to make sure we re-enable our fields.
+	$( document.body ).on( 'woocommerce_attributes_saved', function () {
+		$.enableProductFields();
+	} );
+
+	/**
+	 * This function is called after WC Core fetches new attribute HTML and appends the elements asynchronously.
+	 * It triggers relevant functions to hide/show and enable/disable fields.
+	 *
+	 * @see add_attribute_to_list() in assets/js/admin/meta-boxes-product.js
+	 *
+	 * Since there is no specific event to hook into when the async call is resolved, we rely on WC clicking
+	 * the attribute metabox heading after fetching the HTML but before disabling the product fields.
+	 * We take advantage of this by attaching a click event listener to the '.woocommerce_attribute.wc-metabox h3'
+	 * element and waiting a short time before re-enabling the product fields.
+	 */
+	$( document ).on( 'click', '.woocommerce_attribute.wc-metabox h3', function() {
+		setTimeout( function() {
+			$.showHideSubscriptionMeta();
+			$.showHideVariableSubscriptionMeta();
+			$.enableProductFields();
+		}, 100 );
+	});
+
 	$( 'input#_downloadable, input#_virtual' ).on( 'change', function () {
+
 		$.showHideSubscriptionMeta();
 		$.showHideVariableSubscriptionMeta();
 	} );

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -86,13 +86,14 @@ jQuery( function ( $ ) {
 					.addClass( 'form-row-last' );
 			}
 		},
-		enableProductFields: function () {
+		enableSubscriptionProductFields: function () {
 			product_type = $( 'select#product-type' ).val();
 			enable_type  = '';
 
-			if ( product_type == 'variable-subscription' ) {
+			// Variable subscriptions need to enable variable product fields and subscriptions products need to enable simple product fields.
+			if ( 'variable-subscription' === product_type ) {
 				enable_type = 'variable'
-			} else {
+			} else if ( 'subscription' === product_type ) {
 				enable_type = 'simple';
 			}
 
@@ -737,14 +738,14 @@ jQuery( function ( $ ) {
 	$( 'body' ).on( 'woocommerce-product-type-change', function () {
 		$.showHideSubscriptionMeta();
 		$.showHideVariableSubscriptionMeta();
-		$.enableProductFields();
+		$.enableSubscriptionProductFields();
 		$.showHideSyncOptions();
 		$.showHideSubscriptionsPanels();
 	} );
 
 	// WC Core enable/disable product fields when saving attributes. We need to make sure we re-enable our fields.
 	$( document.body ).on( 'woocommerce_attributes_saved', function () {
-		$.enableProductFields();
+		$.enableSubscriptionProductFields();
 	} );
 
 	/**
@@ -762,7 +763,7 @@ jQuery( function ( $ ) {
 		setTimeout( function() {
 			$.showHideSubscriptionMeta();
 			$.showHideVariableSubscriptionMeta();
-			$.enableProductFields();
+			$.enableSubscriptionProductFields();
 		}, 100 );
 	});
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.0.0 - 2023-xx-xx =
+* Fix - Resolve an issue that prevented the "Used for variations" checkbox from being enabled on the variable subscription product edit screen on WC version v7.9.0.
+
 = 5.9.0 - 2023-07-14 =
 * Fix - Ensure when a customer changes the shipping method on cart and checkout that the recurring totals correctly reflect the chosen method.
 


### PR DESCRIPTION
Fixes #476

## Description

In WC 7.9 (released today) they introduced a new concept for HTML elements on the edit product page to be enabled and disabled based on the product type. eg `enable_if_variable`. This builds on the existing `show_if_variable`. 

However, WC core would only enable these fields based on the product type. This meant that the `enable_if_variable` elements, which variable subscription products are supposed to inherit, were being left disabled. 

This PR fixes that by making sure we enable these fields after WC enables/disables them. 

## How to test this PR

1. Make sure you're running WC 7.9
2. Create a variable subscription product.
3. Go to the attributes tab
    - on `trunk` you'll notice the "Used for variations" checkbox is disabled.
    - on this branch it should be enabled and can be checked/unchecked. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
