### PR TITLE
Enable the "used for variations" checkbox on page load

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -667,6 +667,7 @@ jQuery( function ( $ ) {
 	if ( $( '.options_group.pricing' ).length > 0 ) {
 		$.setSalePeriod();
 		$.showHideSubscriptionMeta();
+		$.enableSubscriptionProductFields();
 		$.showHideVariableSubscriptionMeta();
 		$.setSubscriptionLengths();
 		$.setTrialPeriods();

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 
 = 6.1.0 - 2023-xx-xx =
+* Fix - Resolved an issue that prevented the "Used for variations" checkbox to not be enabled on the edit product page load causing variations to be deleted erroneously.
 * Dev - Fixed wcs_get_subscription_orders() returning an empty list when querying parent orders when HPOS is enabled with data syncing off.
 
 = 6.0.0 - 2023-07-18 =


### PR DESCRIPTION
Fixes #480 

## Description

When WC loads the product page the "Used for variations" checkbox is [disabled by default](https://github.com/woocommerce/woocommerce/blob/9b7570f8b21fff1bc133913a0339724bc2d124ae/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php#L96).

In WC they then enable this checkbox on page load depending on the product type by [triggering a product type dropdown change event](https://github.com/woocommerce/woocommerce/blob/9b7570f8b21fff1bc133913a0339724bc2d124ae/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js#L158-L187). Note the `.trigger( 'change' );`

This change event runs before our JS is loaded and so we can't rely on this event for our `product-type` callback to run on. 

So, to make sure we enable the "used for variations" checkbox on page load, I've added a `$.enableSubscriptionProductFields();` function call to the list of functions that run on page load.

Note: This function is called behind a `if ( $( '.options_group.pricing' ).length > 0 ) {` condition. I don't know what the historic purpose is of this but it does appear that all product pages have at least `.options_group.pricing` element so might be a proxy for "is edit product page"? 🤷 

## How to test this PR

1. Make sure you don't have Square active as it triggers JS events that causes this bug to not be reproducible. 
1. Create a variable subscription product using at least 1 attribute
2. Publish it, everything is good up to this point
3. Press "Update" button repeatedly without changing anything in the Product data area. (Avoid viewing Attributes or variations tab)
4. See the issue.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
