### PR TITLE
Always attach our Checkout Blocks integration to fix issues when Subscriptions is loaded before WooCommerce

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-
 = 6.1.0 - 2023-xx-xx =
+* Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.
 * Dev - Fixed wcs_get_subscription_orders() returning an empty list when querying parent orders when HPOS is enabled with data syncing off.
 
 = 6.0.0 - 2023-07-18 =

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -153,11 +153,9 @@ class WC_Subscriptions_Core_Plugin {
 		// Initialise the cache.
 		$this->cache = WCS_Cache_Manager::get_instance();
 
-		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '4.4.0', '>' ) ) {
-			// When WooCommerceBlocks is loaded, set up the Integration class.
-			add_action( 'woocommerce_blocks_loaded', array( $this, 'setup_blocks_integration' ) );
-			add_action( 'woocommerce_blocks_loaded', array( 'WC_Subscriptions_Extend_Store_Endpoint', 'init' ) );
-		}
+		// When WooCommerceBlocks is loaded, set up the Integration class.
+		add_action( 'woocommerce_blocks_loaded', array( $this, 'setup_blocks_integration' ) );
+		add_action( 'woocommerce_blocks_loaded', array( 'WC_Subscriptions_Extend_Store_Endpoint', 'init' ) );
 
 		if ( ! $payment_gateways_handler::are_zero_total_subscriptions_allowed() ) {
 			WC_Subscriptions_Gateway_Restrictions_Manager::init();
@@ -560,6 +558,9 @@ class WC_Subscriptions_Core_Plugin {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v4.0.0
 	 */
 	public function setup_blocks_integration() {
+		if ( ! class_exists( 'Automattic\WooCommerce\Blocks\Package' ) || ! version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '4.4.0', '>' ) ) {
+			return;
+		}
 		/**
 		 * Filter the compatible blocks for WooCommerce Subscriptions.
 		 */

--- a/includes/class-wc-subscriptions-extend-store-endpoint.php
+++ b/includes/class-wc-subscriptions-extend-store-endpoint.php
@@ -49,6 +49,10 @@ class WC_Subscriptions_Extend_Store_Endpoint {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions
 	 */
 	public static function init() {
+		if ( ! class_exists( 'Automattic\WooCommerce\Blocks\Package' ) || ! version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '4.4.0', '>' ) ) {
+			return;
+		}
+
 		self::$schema             = class_exists( 'Automattic\WooCommerce\StoreApi\StoreApi' ) ? Automattic\WooCommerce\StoreApi\StoreApi::container()->get( Automattic\WooCommerce\StoreApi\SchemaController::class ) : Package::container()->get( Automattic\WooCommerce\Blocks\StoreApi\SchemaController::class );
 		self::$money_formatter    = function_exists( 'woocommerce_store_api_get_formatter' ) ? woocommerce_store_api_get_formatter( 'money' ) : Package::container()->get( ExtendRestApi::class )->get_formatter( 'money' );
 		self::$currency_formatter = function_exists( 'woocommerce_store_api_get_formatter' ) ? woocommerce_store_api_get_formatter( 'currency' ) : Package::container()->get( ExtendRestApi::class )->get_formatter( 'currency' );


### PR DESCRIPTION
Fixes #486 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

There's an issue where the Checkout Block is not properly showing the subscription recurring totals on the checkout and are instead being rendered as simple/single prices.

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/ecf33a86-ec4f-43e2-a65f-712e849f296c)

After some investigation, I found out this was being caused by our Checkout Blocks support code never being attached because at the time of initing WC Subscriptions, the `Automattic\WooCommerce\Blocks\Package` class doesn't exist yet.

To fix this, I've made sure we're always attaching our `woocommerce_blocks_loaded` code and then moved our version checks to happen inside those callbacks.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Activate WooCommerce 7.9, Subscriptions 5.3.1 & the latest Stripe
2. Add a Checkout Block page
3. Add a subscription product to your cart
4. On `trunk` you'll see a non-recurring total on the checkout
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/4e4ac76a-e9a7-487a-9930-bfd4fdce7b50)
5. On this branch you should see the correct recurring totals:
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/4269d168-2825-4f00-ae9c-b578a3730a8f)


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
