### PR TITLE
 Added shipping_phone field to be copied in new order

### DIFF
--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -106,6 +106,7 @@ function wcs_copy_order_address( $from_order, $to_order, $address_type = 'all' )
 		$to_order->set_shipping_state( $from_order->get_shipping_state() );
 		$to_order->set_shipping_postcode( $from_order->get_shipping_postcode() );
 		$to_order->set_shipping_country( $from_order->get_shipping_country() );
+		$to_order->set_shipping_phone( $from_order->get_shipping_phone() );
 	}
 
 	if ( 'all' === $address_type || 'billing' === $address_type ) {


### PR DESCRIPTION
Fixes #
Fixed issue that prevent shipping_phone field copy to new order when subscription renews.
## Description

## How to test this PR
Create subscription and renew it then check if phone number is copied from parent/old order.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [X ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
