### PR TITLE
Copy the shipping phone when creating renewal orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-
 = 6.1.0 - 2023-07-26 =
 * Fix - Resolved an issue that prevented the "Used for variations" checkbox to not be enabled on the edit product page load causing variations to be deleted erroneously.
+* Fix - Ensure the shipping phone number field is copied to subscriptions and their orders when copying address meta.
 * Dev - Fixed wcs_get_subscription_orders() returning an empty list when querying parent orders when HPOS is enabled with data syncing off.
 
 = 6.0.0 - 2023-07-18 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,12 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.2.0 - 2023-xx-xx =
+* Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.
+* Fix - Ensure the shipping phone number field is copied to subscriptions and their orders when copying address meta.
+* Update - When HPOS is disabled, fetch subscriptions by customer_id using the user's subscription cache to improve performance.
+
 = 6.1.0 - 2023-07-26 =
 * Fix - Resolved an issue that prevented the "Used for variations" checkbox to not be enabled on the edit product page load causing variations to be deleted erroneously.
-* Fix - Ensure the shipping phone number field is copied to subscriptions and their orders when copying address meta.
 * Dev - Fixed wcs_get_subscription_orders() returning an empty list when querying parent orders when HPOS is enabled with data syncing off.
 
 = 6.0.0 - 2023-07-18 =

--- a/includes/class-wc-subscriptions-data-copier.php
+++ b/includes/class-wc-subscriptions-data-copier.php
@@ -317,6 +317,7 @@ class WC_Subscriptions_Data_Copier {
 				'_shipping_state'      => $this->from_object->get_shipping_state( 'edit' ),
 				'_shipping_postcode'   => $this->from_object->get_shipping_postcode( 'edit' ),
 				'_shipping_country'    => $this->from_object->get_shipping_country( 'edit' ),
+				'_shipping_phone'      => $this->from_object->get_shipping_phone( 'edit' ),
 			]
 		);
 	}


### PR DESCRIPTION
## Description

This PR adds to the changes made in https://github.com/Automattic/woocommerce-subscriptions-core/pull/492. 

In WC 5.6 (released Aug 2021), functions were added to support a shipping phone field (https://github.com/woocommerce/woocommerce/pull/30097). This field has very little support via the default UI however. There's no shipping phone checkout field for example. There is a field shown on the edit order/subscription screen though.

<p align="center">
<img width="400" alt="Screenshot 2023-08-07 at 2 45 23 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/eb0419f1-2ecc-4790-b492-38bcdd562caa">
<br>
<sup>Shipping phone number field on the edit order/subscriptions screen</sup>
</p>

This shipping phone field wasn't being copied to renewal orders. This PR fixes that.

## How to test this PR

1. Purchase a subscription or create one manually from the admin UI.
2. Edit the subscription shipping address and add a phone number. (see example screenshot above).
3. From the subscription actions select **Process a renewal** and save. 
4. Go to the newly created renewal order screen. 
    - On `trunk` the shipping phone will be empty. 
    - On this branch, the shipping phone should be copied from the subscription. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
