### PR TITLE
Add the 'contains_subscription' column to the Orders admin page when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.3.0 - xxxx-xx-xx =
+* Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
+
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.
 * Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -415,12 +415,13 @@ class WC_Subscriptions_Order {
 	}
 
 	/**
-	* Add column content to the WooCommerce -> Orders admin screen to indicate whether an
-	* order is a parent of a subscription, a renewal order for a subscription, or a
-	* regular order.
-	*
-	* @param string $column The string of the current column
-	* @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.1
+	 * Add column content to the WooCommerce -> Orders admin screen to indicate whether an
+	 * order is a parent of a subscription, a renewal order for a subscription, or a regular order.
+	 *
+	 * @see add_contains_subscription_column_content_orders_table For when HPOS is enabled.
+	 *
+	 * @param string $column The string of the current column
+	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.1
 	*/
 	public static function add_contains_subscription_column_content( $column ) {
 		global $post;
@@ -431,9 +432,10 @@ class WC_Subscriptions_Order {
 	}
 
 	/**
-	 * For HPOS - Add column content to the WooCommerce -> Orders admin screen to indicate whether an
-	 * order is a parent of a subscription, a renewal order for a subscription, or a
-	 * regular order.
+	 * Add column content to the WooCommerce -> Orders admin screen to indicate whether an
+	 * order is a parent of a subscription, a renewal order for a subscription, or a regular order.
+	 *
+	 * @see add_contains_subscription_column_content For when HPOS is disabled.
 	 *
 	 * @since 6.3.0
 	 *

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -32,6 +32,10 @@ class WC_Subscriptions_Order {
 		add_filter( 'manage_edit-shop_order_columns', __CLASS__ . '::add_contains_subscription_column' );
 		add_action( 'manage_shop_order_posts_custom_column', __CLASS__ . '::add_contains_subscription_column_content', 10, 1 );
 
+		// HPOS - Add column that indicates whether an order is parent or renewal for a subscription.
+		add_filter( 'woocommerce_shop_order_list_table_columns', __CLASS__ . '::add_contains_subscription_column' );
+		add_action( 'woocommerce_shop_order_list_table_custom_column', __CLASS__ . '::add_contains_subscription_column_content_hpos', 10, 2 );
+
 		// Record initial payment against the subscription & set start date based on that payment
 		add_action( 'woocommerce_order_status_changed', __CLASS__ . '::maybe_record_subscription_payment', 9, 3 );
 
@@ -421,16 +425,24 @@ class WC_Subscriptions_Order {
 	public static function add_contains_subscription_column_content( $column ) {
 		global $post;
 
-		if ( 'subscription_relationship' == $column ) {
-			if ( wcs_order_contains_subscription( $post->ID, 'renewal' ) ) {
-				echo '<span class="subscription_renewal_order tips" data-tip="' . esc_attr__( 'Renewal Order', 'woocommerce-subscriptions' ) . '"></span>';
-			} elseif ( wcs_order_contains_subscription( $post->ID, 'resubscribe' ) ) {
-				echo '<span class="subscription_resubscribe_order tips" data-tip="' . esc_attr__( 'Resubscribe Order', 'woocommerce-subscriptions' ) . '"></span>';
-			} elseif ( wcs_order_contains_subscription( $post->ID, 'parent' ) ) {
-				echo '<span class="subscription_parent_order tips" data-tip="' . esc_attr__( 'Parent Order', 'woocommerce-subscriptions' ) . '"></span>';
-			} else {
-				echo '<span class="normal_order">&ndash;</span>';
-			}
+		if ( 'subscription_relationship' === $column ) {
+			self::render_contains_subscription_column_content( $post->ID );
+		}
+	}
+
+	/**
+	 * For HPOS - Add column content to the WooCommerce -> Orders admin screen to indicate whether an
+	 * order is a parent of a subscription, a renewal order for a subscription, or a
+	 * regular order.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string   $column_name Identifier for the custom column.
+	 * @param WC_Order $order       Current WooCommerce order object.
+	 */
+	public static function add_contains_subscription_column_content_hpos( string $column_name, WC_Order $order ) {
+		if ( 'subscription_relationship' === $column_name ) {
+			self::render_contains_subscription_column_content( $order->get_id() );
 		}
 	}
 
@@ -2279,5 +2291,27 @@ class WC_Subscriptions_Order {
 		}
 
 		return $meta_value;
+	}
+
+	/**
+	 * Renders the contents of the "contains_subscription" column.
+	 *
+	 * This column indicates whether an order is a parent of a subscription,
+	 * a renewal order for a subscription, or a regular order.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param integer $order_id The ID of the order in the current row.
+	 */
+	private static function render_contains_subscription_column_content( int $order_id ) {
+		if ( wcs_order_contains_subscription( $order_id, 'renewal' ) ) {
+			echo '<span class="subscription_renewal_order tips" data-tip="' . esc_attr__( 'Renewal Order', 'woocommerce-subscriptions' ) . '"></span>';
+		} elseif ( wcs_order_contains_subscription( $order_id, 'resubscribe' ) ) {
+			echo '<span class="subscription_resubscribe_order tips" data-tip="' . esc_attr__( 'Resubscribe Order', 'woocommerce-subscriptions' ) . '"></span>';
+		} elseif ( wcs_order_contains_subscription( $order_id, 'parent' ) ) {
+			echo '<span class="subscription_parent_order tips" data-tip="' . esc_attr__( 'Parent Order', 'woocommerce-subscriptions' ) . '"></span>';
+		} else {
+			echo '<span class="normal_order">&ndash;</span>';
+		}
 	}
 }

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -34,7 +34,7 @@ class WC_Subscriptions_Order {
 
 		// HPOS - Add column that indicates whether an order is parent or renewal for a subscription.
 		add_filter( 'woocommerce_shop_order_list_table_columns', __CLASS__ . '::add_contains_subscription_column' );
-		add_action( 'woocommerce_shop_order_list_table_custom_column', __CLASS__ . '::add_contains_subscription_column_content_hpos', 10, 2 );
+		add_action( 'woocommerce_shop_order_list_table_custom_column', __CLASS__ . '::add_contains_subscription_column_content_orders_table', 10, 2 );
 
 		// Record initial payment against the subscription & set start date based on that payment
 		add_action( 'woocommerce_order_status_changed', __CLASS__ . '::maybe_record_subscription_payment', 9, 3 );
@@ -440,7 +440,7 @@ class WC_Subscriptions_Order {
 	 * @param string   $column_name Identifier for the custom column.
 	 * @param WC_Order $order       Current WooCommerce order object.
 	 */
-	public static function add_contains_subscription_column_content_hpos( string $column_name, WC_Order $order ) {
+	public static function add_contains_subscription_column_content_orders_table( string $column_name, WC_Order $order ) {
 		if ( 'subscription_relationship' === $column_name ) {
 			self::render_contains_subscription_column_content( $order->get_id() );
 		}


### PR DESCRIPTION
Fixes #499
Fixes #469 

## Description

This PR includes the "contains_subscription" column to the Orders list admin page when HPOS is enabled.

- Introduce `WC_Subscriptions_Order::add_contains_subscription_column_content_hpos`, which does the same as `WC_Subscriptions_Order::add_contains_subscription_column_content` but expects the arguments provided by the HPOS-specific hook.
- Hook the method mentioned above to the `woocommerce_shop_order_list_table_custom_column` action, which is specific for HPOS and analogous to `manage_shop_order_posts_custom_column` for non-HPOS.
- Hook `WC_Subscriptions_Order::add_contains_subscription_column` to the HPOS-specific action `woocommerce_shop_order_list_table_columns`. This action is analogous to the `manage_edit-shop_order_columns` for non-HPOS.

<img width="1963" alt="image" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/41606954/9c28cb74-f57f-4401-9335-beeab6739aed">

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

1. Go to WooCommerce -> Settings -> Advanced -> Features. `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Under Experimental features, select "High performance order storage (new)", enable "Keep the posts and orders tables in sync (compatibility mode)", and save
3. As a shopper, get the following if you don't have them already:
  - A subscription
  - A renewal for the subscription
  - A resubscribed subscription
  - An order with a non-subscription product
4. Go to WooCommerce -> Orders. `/wp-admin/admin.php?page=wc-orders`
5. Confirm that the column has the same behavior as when HPOS is disabled:
  - There's a column between the "Status" and "Total" columns
  - Its title is the subscription icon and has "Subscription Relationship" tooltip
  - The value in this column for each row matches the order type (Subscription, renewal, resubscription, regular order)

**Regression tests**
- With HPOS disabled, confirm the column continues to be displayed, and its values match the order type for each row.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
