### PR TITLE
Fix manual renewal order payments via the checkout block not associating with the subscription

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.3.0 - xxxx-xx-xx =
 * Fix - When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.
+* Fix - Ensure renewal orders paid via the Block Checkout are correctly linked to their subscription.
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
 
 = 6.2.0 - 2023-08-10 =

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1638,25 +1638,27 @@ class WCS_Cart_Renewal {
 	 * @return bool Whether the order has the status. Unchanged by this function.
 	 */
 	public function set_renewal_order_cart_hash_on_block_checkout( $has_status, $order, $status ) {
-		// If the order already has the checkout-draft status, then we don't need to update the cart hash.
+		// If the order already has the checkout-draft status, then we don't need to update the cart hash to bypass the
+		// logic in DraftOrderTrait::is_valid_draft_order().
 		if ( $has_status ) {
 			return $has_status;
 		}
 
-		// We only need to update the order cart hash on has_status check if the status is 'checkout-draft' - indicating checkout block code is validating the order.
+		// We only need to update the order cart hash on has_status check if the status is 'checkout-draft' - indicating
+		// checkout block code is validating the order.
 		if ( 'checkout-draft' !== $status ) {
 			return $has_status;
 		}
 
 		/**
-		 * This function is only interested in updating the order hash value during REST API requests - which is the request context where
-		 * the Store API Checkout Block validates the order for payment resumption.
+		 * This function is only interested in updating the order hash value during REST API requests - which is the request context
+		 * where the Store API Checkout Block validates the order for payment resumption.
 		 */
 		if ( ! WC()->is_rest_api_request() ) {
 			return $has_status;
 		}
 
-		// If the order being validated is the order being paid for in the cart, then we need to update the cart hash so it can be resumed.
+		// If the order being validated is the order in the cart, then we need to update the cart hash so it can be resumed.
 		if ( $order && $order->get_id() === WC()->session->get( 'store_api_draft_order', 0 ) ) {
 			$cart_order = $this->get_order();
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1012,7 +1012,8 @@ class WCS_Cart_Renewal {
 			$cart_hash = md5( json_encode( wc_clean( WC()->cart->get_cart_for_session() ) ) . WC()->cart->total );
 		}
 
-		wcs_set_objects_property( $order, 'cart_hash', $cart_hash );
+		$order->set_cart_hash( $cart_hash );
+		$order->save();
 	}
 
 	/**

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -40,6 +40,7 @@ class WCS_Cart_Renewal {
 
 		// When a failed/pending renewal order is paid for via checkout, ensure a new order isn't created due to mismatched cart hashes
 		add_filter( 'woocommerce_create_order', array( &$this, 'update_cart_hash' ), 10, 1 );
+		add_filter( 'woocommerce_order_has_status', array( &$this, 'override_order_status_for_checkout_block' ), 10, 3 );
 
 		// When a user is prevented from paying for a failed/pending renewal order because they aren't logged in, redirect them back after login
 		add_filter( 'woocommerce_login_redirect', array( &$this, 'maybe_redirect_after_login' ), 10, 2 );
@@ -416,6 +417,10 @@ class WCS_Cart_Renewal {
 	 * Restore renewal flag when cart is reset and modify Product object with renewal order related info
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+	 *
+	 * @param array  $cart_item_session_data Cart item session data.
+	 * @param array  $cart_item              Cart item data.
+	 * @param string $key                   Cart item key.
 	 */
 	public function get_cart_item_from_session( $cart_item_session_data, $cart_item, $key ) {
 
@@ -429,7 +434,23 @@ class WCS_Cart_Renewal {
 
 			if ( $subscription ) {
 				$subscription_items = $subscription->get_items();
-				$item_to_renew      = $subscription_items[ $cart_item_session_data[ $this->cart_item_key ]['line_item_id'] ];
+
+				/**
+				 * Find the subscription or order line item that represents this cart item.
+				 *
+				 * If cart item data correctly records a valid line item ID, use that to find the line item.
+				 * Otherwise, use the cart item key stored in line item meta.
+				 */
+				if ( isset( $subscription_items[ $cart_item_session_data[ $this->cart_item_key ]['line_item_id'] ] ) ) {
+					$item_to_renew = $subscription_items[ $cart_item_session_data[ $this->cart_item_key ]['line_item_id'] ];
+				} else {
+					foreach ( $subscription_items as $item ) {
+						if ( $item->get_meta( '_cart_item_key_' . $this->cart_item_key, true ) === $key ) {
+							$item_to_renew = $item;
+							break;
+						}
+					}
+				}
 
 				$price = $item_to_renew['line_subtotal'];
 
@@ -1588,6 +1609,50 @@ class WCS_Cart_Renewal {
 	 */
 	public function validate_current_user( $order ) {
 		return current_user_can( 'pay_for_order', $order->get_id() );
+	}
+
+	/**
+	 * Overrides the order has_status check used in the Store API Checkout Block to determine if an existing order can be resumed.
+	 *
+	 * This hacky overriding of the default logic is only applied during REST API requests, only applies to the 'checkout-draft' status
+	 * and to renewal orders that are currently being paid for in the cart. All other order statuses checks remain unaffected by this function.
+	 *
+	 * This function is necessary to override the default logic in @see DraftOrderTrait::is_valid_draft_order().
+	 *
+	 * @param bool     $has_status Whether the order has the status.
+	 * @param WC_Order $order      The order.
+	 * @param string   $status     The status to check.
+	 *
+	 * @return bool Whether the order has the status.
+	 */
+	public function override_order_status_for_checkout_block( $has_status, $order, $status ) {
+		if ( $has_status ) {
+			return $has_status;
+		}
+
+		// We only need to override 'checkout-draft' statuses which is used only by the checkout block.
+		if ( 'checkout-draft' !== $status ) {
+			return $has_status;
+		}
+
+		/**
+		 * This function is only interested in overriding the `has_status` value during REST API requests - which is the request context where
+		 * the Store API Checkout Block validates the order for payment resumption.
+		 */
+		if ( ! WC()->is_rest_api_request() ) {
+			return $has_status;
+		}
+
+		// If the order being validated is the order being paid for in the cart, then we need to override the has_status( 'checkout-draft' ) check and return true so it can be resumed.
+		if ( $order && $order->get_id() === WC()->session->get( 'store_api_draft_order', 0 ) ) {
+			$cart_order = $this->get_order();
+
+			if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
+				$has_status = true;
+			}
+		}
+
+		return $has_status;
 	}
 
 	/* Deprecated */

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1000,10 +1000,19 @@ class WCS_Cart_Renewal {
 	 * order items haven't changed by checking for a cart hash on the order, so we need to set
 	 * that here. @see WC_Checkout::create_order()
 	 *
+	 * @param WC_Order|int $order The order object or order ID.
+	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0.14
 	 */
-	protected function set_cart_hash( $order_id ) {
-		$order = wc_get_order( $order_id );
+	protected function set_cart_hash( $order ) {
+
+		if ( ! is_a( $order, 'WC_Abstract_Order' ) ) {
+			$order = wc_get_order( $order );
+
+			if ( ! $order ) {
+				return;
+			}
+		}
 
 		// Use cart hash generator introduced in WooCommerce 3.6
 		if ( is_callable( array( WC()->cart, 'get_cart_hash' ) ) ) {
@@ -1651,7 +1660,8 @@ class WCS_Cart_Renewal {
 			$cart_order = $this->get_order();
 
 			if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
-				$this->set_cart_hash( $order->get_id() );
+				// Set the cart hash so that the order can be resumed. Pass the order object so the instance WooCommerce uses will have the updated hash.
+				$this->set_cart_hash( $order );
 			}
 		}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1642,25 +1642,25 @@ class WCS_Cart_Renewal {
 			return $has_status;
 		}
 
-		// We only need to override 'checkout-draft' statuses which is used only by the checkout block.
+		// We only need to update the order cart hash on has_status check if the status is 'checkout-draft' - indicating checkout block code is validating the order.
 		if ( 'checkout-draft' !== $status ) {
 			return $has_status;
 		}
 
 		/**
-		 * This function is only interested in overriding the `has_status` value during REST API requests - which is the request context where
+		 * This function is only interested in updating the order hash value during REST API requests - which is the request context where
 		 * the Store API Checkout Block validates the order for payment resumption.
 		 */
 		if ( ! WC()->is_rest_api_request() ) {
 			return $has_status;
 		}
 
-		// If the order being validated is the order being paid for in the cart, then we need to override the has_status( 'checkout-draft' ) check and return true so it can be resumed.
+		// If the order being validated is the order being paid for in the cart, then we need to update the cart hash so it can be resumed.
 		if ( $order && $order->get_id() === WC()->session->get( 'store_api_draft_order', 0 ) ) {
 			$cart_order = $this->get_order();
 
 			if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
-				// Set the cart hash so that the order can be resumed. Pass the order object so the instance WooCommerce uses will have the updated hash.
+				// Note: We need to pass the order object so the order instance WooCommerce uses will have the updated hash.
 				$this->set_cart_hash( $order );
 			}
 		}

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -420,7 +420,7 @@ class WCS_Cart_Renewal {
 	 *
 	 * @param array  $cart_item_session_data Cart item session data.
 	 * @param array  $cart_item              Cart item data.
-	 * @param string $key                   Cart item key.
+	 * @param string $key                    Cart item key.
 	 */
 	public function get_cart_item_from_session( $cart_item_session_data, $cart_item, $key ) {
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1638,21 +1638,18 @@ class WCS_Cart_Renewal {
 	 * @return bool Whether the order has the status. Unchanged by this function.
 	 */
 	public function set_renewal_order_cart_hash_on_block_checkout( $has_status, $order, $status ) {
-		// If the order already has the checkout-draft status, then we don't need to update the cart hash to bypass the
-		// logic in DraftOrderTrait::is_valid_draft_order().
-		if ( $has_status ) {
-			return $has_status;
-		}
-
-		// We only need to update the order cart hash on has_status check if the status is 'checkout-draft' - indicating
-		// checkout block code is validating the order.
-		if ( 'checkout-draft' !== $status ) {
+		/**
+		 * We only need to update the order's cart hash when the has_status() check is for 'checkout-draft' (indicating
+		 * this is the status check in DraftOrderTrait::is_valid_draft_order()) and the order doesn't have that status. Orders
+		 * which already have the checkout-draft status don't need to be updated to bypass the checkout block logic.
+		 */
+		if ( $has_status || 'checkout-draft' !== $status ) {
 			return $has_status;
 		}
 
 		/**
-		 * This function is only interested in updating the order hash value during REST API requests - which is the request context
-		 * where the Store API Checkout Block validates the order for payment resumption.
+		 * This function is only concerned with updating the order cart hash during REST API requests - which is the request
+		 * context where the Store API Checkout Block validates the order for payment resumption.
 		 */
 		if ( ! WC()->is_rest_api_request() ) {
 			return $has_status;

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1638,6 +1638,7 @@ class WCS_Cart_Renewal {
 	 * @return bool Whether the order has the status. Unchanged by this function.
 	 */
 	public function set_renewal_order_cart_hash_on_block_checkout( $has_status, $order, $status ) {
+		// If the order already has the checkout-draft status, then we don't need to update the cart hash.
 		if ( $has_status ) {
 			return $has_status;
 		}

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1648,7 +1648,7 @@ class WCS_Cart_Renewal {
 			$cart_order = $this->get_order();
 
 			if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
-				$has_status = true;
+				$this->set_cart_hash( $order->get_id() );
 			}
 		}
 


### PR DESCRIPTION
Fixes #456

## Description

When you pay for a failed or manual renewal order Subscriptions does a couple of things to make sure you resume payment of the original order, not create a new one. 

Those two are:

1. Set the `'order_awaiting_payment'` and `'store_api_draft_order'` session keys to set the order being paid. 
2. Ensure that the cart hash is updated in a way that when WC verifies whether the order being paid for is compatible with the cart changes, it returns true. We achieve that by updating the cart has stored on the order right before WC runs that check, effectively bypassing that "feature" completely.

The issue with the block checkout centres on point 2 from above. In the Store API (used by checkout blocks), there are very few hooks that trigger before the cart hash condition that we can use to bypass it. 

So, in order to fix renewal orders being paid via a block checkout, I used the `$order->has_status( 'checkout-draft' )` check [here](https://github.com/woocommerce/woocommerce-blocks/blob/9a8cec35af6fbabfbf4b25a77297d1514387e4e4/src/StoreApi/Utilities/DraftOrderTrait.php#L58-L61).

When the block checkout validates the order being paid for, it [checks if it has a `checkout-draft` status](https://github.com/woocommerce/woocommerce-blocks/blob/4dd92c3e8d047dfead8135575b2d444c2ab3085d/src/StoreApi/Utilities/DraftOrderTrait.php#L59). The order in our case will be pending-payment or failed and so it fails that condition, falling through to the cart hash logic. On `trunk` it fails that one too because of slight changes (eg shipping method) made during the checkout process. 

In order to ensure that the renewal order is valid for payment, this PR uses the `woocommerce_order_has_status` filter to make sure that when a renewal order is checked if it has a `checkout-draft` status, it will update the cart hash ensuring it's valid for payment resumption via a block checkout.

## How to test this PR

1. Create a page with a block checkout.
2. Make sure you have at least 2 shipping methods.
3. Purchase a subscription.
4. Go to the edit admin screen for the subscription.
5. From the actions dropdown select "Create pending renewal order"
6. Save
7. Attempt to pay for the newly created pending renewal order.
9. Make sure to use the checkout block page. 
10. Change the chosen shipping method
    - On `trunk` a new order will be created that isn't linked to the original subscription. And the pending renewal order will be left pending.
    - On this branch, the original renewal order will be paid without creating a new order.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
