### PR TITLE
Add HPOS compatibility for the `orders_by_type_query` filter box in the order listing screen

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.3.0 - xxxx-xx-xx =
+* Fix - When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.
+
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.
 * Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -744,7 +744,7 @@ class WC_Subscriptions_Order {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v1.5
 	 */
 	public static function orders_by_type_query( $vars ) {
-		global $typenow, $wpdb;
+		global $typenow;
 
 		if ( 'shop_order' === $typenow ) {
 			return self::maybe_modify_orders_by_type_query_from_request( $vars );

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -44,6 +44,9 @@ class WC_Subscriptions_Order {
 		// Add dropdown to admin orders screen to filter on order type
 		add_action( 'restrict_manage_posts', __CLASS__ . '::restrict_manage_subscriptions', 50 );
 
+		// For HPOS - Add dropdown to admin orders screen to filter on order type.
+		add_action( 'woocommerce_order_list_table_restrict_manage_orders', __CLASS__ . '::restrict_manage_subscriptions_hpos' );
+
 		// Add filter to queries on admin orders screen to filter on order type. To avoid WC overriding our query args, we need to hook on after them on 10.
 		add_filter( 'request', __CLASS__ . '::orders_by_type_query', 11 );
 
@@ -712,36 +715,22 @@ class WC_Subscriptions_Order {
 			return;
 		}
 
-		$order_types = apply_filters(
-			'woocommerce_subscriptions_order_type_dropdown',
-			array(
-				'original'    => _x( 'Original', 'An order type', 'woocommerce-subscriptions' ),
-				'parent'      => _x( 'Subscription Parent', 'An order type', 'woocommerce-subscriptions' ),
-				'renewal'     => _x( 'Subscription Renewal', 'An order type', 'woocommerce-subscriptions' ),
-				'resubscribe' => _x( 'Subscription Resubscribe', 'An order type', 'woocommerce-subscriptions' ),
-				'switch'      => _x( 'Subscription Switch', 'An order type', 'woocommerce-subscriptions' ),
-				'regular'     => _x( 'Non-subscription', 'An order type', 'woocommerce-subscriptions' ),
-			)
-		);
+		self::render_restrict_manage_subscriptions_dropdown();
+	}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$selected_shop_order_subtype = isset( $_GET['shop_order_subtype'] ) ? wc_clean( wp_unslash( $_GET['shop_order_subtype'] ) ) : '';
+	/**
+	 * When HPOS is active, adds admin dropdown for order types to Woocommerce -> Orders screen
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $order_type The order type.
+	 */
+	public static function restrict_manage_subscriptions_hpos( string $order_type ) {
+		if ( 'shop_order' !== $order_type ) {
+			return;
+		}
 
-		?>
-		<select name='shop_order_subtype' id='dropdown_shop_order_subtype'>
-			<option value=""><?php esc_html_e( 'All orders types', 'woocommerce-subscriptions' ); ?></option>
-
-			<?php foreach ( $order_types as $order_type_key => $order_type_description ) : ?>
-				<option
-					value="<?php echo esc_attr( $order_type_key ); ?>"
-					<?php selected( $selected_shop_order_subtype, $order_type_key ); ?>
-				>
-					<?php echo esc_html( $order_type_description ); ?>
-				</option>
-			<?php endforeach; ?>
-
-		</select>
-		<?php
+		self::render_restrict_manage_subscriptions_dropdown();
 	}
 
 	/**
@@ -2286,5 +2275,43 @@ class WC_Subscriptions_Order {
 		}
 
 		return $meta_value;
+	}
+
+	/**
+	 * Prints the HTML for the admin dropdown for order types to Woocommerce -> Orders screen.
+	 *
+	 * @since 6.3.0
+	 */
+	private static function render_restrict_manage_subscriptions_dropdown() {
+		$order_types = apply_filters(
+			'woocommerce_subscriptions_order_type_dropdown',
+			array(
+				'original'    => _x( 'Original', 'An order type', 'woocommerce-subscriptions' ),
+				'parent'      => _x( 'Subscription Parent', 'An order type', 'woocommerce-subscriptions' ),
+				'renewal'     => _x( 'Subscription Renewal', 'An order type', 'woocommerce-subscriptions' ),
+				'resubscribe' => _x( 'Subscription Resubscribe', 'An order type', 'woocommerce-subscriptions' ),
+				'switch'      => _x( 'Subscription Switch', 'An order type', 'woocommerce-subscriptions' ),
+				'regular'     => _x( 'Non-subscription', 'An order type', 'woocommerce-subscriptions' ),
+			)
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$selected_shop_order_subtype = isset( $_GET['shop_order_subtype'] ) ? wc_clean( wp_unslash( $_GET['shop_order_subtype'] ) ) : '';
+
+		?>
+		<select name='shop_order_subtype' id='dropdown_shop_order_subtype'>
+			<option value=""><?php esc_html_e( 'All orders types', 'woocommerce-subscriptions' ); ?></option>
+
+			<?php foreach ( $order_types as $order_type_key => $order_type_description ) : ?>
+				<option
+					value="<?php echo esc_attr( $order_type_key ); ?>"
+					<?php selected( $selected_shop_order_subtype, $order_type_key ); ?>
+				>
+					<?php echo esc_html( $order_type_description ); ?>
+				</option>
+			<?php endforeach; ?>
+
+		</select>
+		<?php
 	}
 }

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -762,7 +762,7 @@ class WC_Subscriptions_Order {
 	 *
 	 * @return array
 	 */
-	public function maybe_modify_orders_by_type_query_from_request( array $order_query_args ): array {
+	public static function maybe_modify_orders_by_type_query_from_request( array $order_query_args ): array {
 		// The order subtype selected by the user in the dropdown.
 		$selected_shop_order_subtype = isset( $_GET['shop_order_subtype'] ) ? wc_clean( wp_unslash( $_GET['shop_order_subtype'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -711,7 +711,7 @@ class WC_Subscriptions_Order {
 	public static function restrict_manage_subscriptions() {
 		global $typenow;
 
-		if ( 'shop_order' != $typenow ) {
+		if ( 'shop_order' !== $typenow ) {
 			return;
 		}
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -710,30 +710,37 @@ class WC_Subscriptions_Order {
 
 		if ( 'shop_order' != $typenow ) {
 			return;
-		}?>
-		<select name='shop_order_subtype' id='dropdown_shop_order_subtype'>
-			<option value=""><?php esc_html_e( 'All orders types', 'woocommerce-subscriptions' ); ?></option>
-			<?php
-			$order_types = apply_filters( 'woocommerce_subscriptions_order_type_dropdown', array(
+		}
+
+		$order_types = apply_filters(
+			'woocommerce_subscriptions_order_type_dropdown',
+			array(
 				'original'    => _x( 'Original', 'An order type', 'woocommerce-subscriptions' ),
 				'parent'      => _x( 'Subscription Parent', 'An order type', 'woocommerce-subscriptions' ),
 				'renewal'     => _x( 'Subscription Renewal', 'An order type', 'woocommerce-subscriptions' ),
 				'resubscribe' => _x( 'Subscription Resubscribe', 'An order type', 'woocommerce-subscriptions' ),
 				'switch'      => _x( 'Subscription Switch', 'An order type', 'woocommerce-subscriptions' ),
 				'regular'     => _x( 'Non-subscription', 'An order type', 'woocommerce-subscriptions' ),
-			) );
+			)
+		);
 
-			foreach ( $order_types as $order_type_key => $order_type_description ) {
-				echo '<option value="' . esc_attr( $order_type_key ) . '"';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$selected_shop_order_subtype = isset( $_GET['shop_order_subtype'] ) ? wc_clean( wp_unslash( $_GET['shop_order_subtype'] ) ) : '';
 
-				if ( isset( $_GET['shop_order_subtype'] ) && $_GET['shop_order_subtype'] ) {
-					selected( $order_type_key, $_GET['shop_order_subtype'] );
-				}
+		?>
+		<select name='shop_order_subtype' id='dropdown_shop_order_subtype'>
+			<option value=""><?php esc_html_e( 'All orders types', 'woocommerce-subscriptions' ); ?></option>
 
-				echo '>' . esc_html( $order_type_description ) . '</option>';
-			}
-			?>
-			</select>
+			<?php foreach ( $order_types as $order_type_key => $order_type_description ) : ?>
+				<option
+					value="<?php echo esc_attr( $order_type_key ); ?>"
+					<?php selected( $selected_shop_order_subtype, $order_type_key ); ?>
+				>
+					<?php echo esc_html( $order_type_description ); ?>
+				</option>
+			<?php endforeach; ?>
+
+		</select>
 		<?php
 	}
 


### PR DESCRIPTION
Fixes #496 

## Description

- Display the "shop_order_subtype" filter dropdown when HPOS is enabled. We're using the HPOS-specific `woocommerce_order_list_table_restrict_manage_orders` action to hook the same functionality that `WC_Subscriptions_Order::restrict_manage_subscriptions` has.
- Filter the arguments passed to `wc_get_orders()` when a value from the dropdown is selected and HPOS is enabled. We're using the HPOS-specific `woocommerce_{ order type }_list_table_prepare_items_query_args` filter for this, to perform the same functionality that `WC_Subscriptions_Order::orders_by_type_query()` does.

<img width="2379" alt="image" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/41606954/1709aa5b-fd27-4610-8e78-510cd0dc06d3">

## How to test this PR

1. Go to WooCommerce -> Settings -> Advanced -> Features. `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Under Experimental features, select "High performance order storage (new)", enable "Keep the posts and orders tables in sync (compatibility mode)", and save
3. Go to WooCommerce -> Orders. `/wp-admin/admin.php?page=wc-orders`
4. Confirm that the "shop_order_subtype" dropdown filter shows up next to "Filter by registered customer"
5. As a shopper, get the following if you don't have them already:
  - A subscription
  - A renewal for the subscription
  - A resubscribed subscription
  - An order with a non-subscription product
  - A switched subscription
6. Go to WooCommerce -> Orders
7. Filter by each option from the dropdown and confirm that the results match the filter. Because we're missing the "Subscription relationship" column, I used the results from when "WordPress post tables" is enabled instead of HPOS as a reference

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
