### PR TITLE
Make `WCS_Array_Property_Post_Meta_Black_Magic` PHP 8.1 compatible

### DIFF
--- a/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
+++ b/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
@@ -72,7 +72,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	/**
 	 * Nothing to do here as we access post meta directly.
 	 */
-	#[ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $key ) {
 	}
 

--- a/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
+++ b/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
@@ -54,7 +54,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	 * @param string $key
 	 * @param mixed $value
 	 */
-	#[ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $key, $value ) {
 		update_post_meta( $this->product_id, $this->maybe_prefix_meta_key( $key ), $value );
 	}

--- a/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
+++ b/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
@@ -44,7 +44,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	 * @param string $key
 	 * @return mixed
 	 */
-	#[ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $key ) {
 		return get_post_meta( $this->product_id, $this->maybe_prefix_meta_key( $key ) );
 	}

--- a/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
+++ b/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
@@ -44,6 +44,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	 * @param string $key
 	 * @return mixed
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet( $key ) {
 		return get_post_meta( $this->product_id, $this->maybe_prefix_meta_key( $key ) );
 	}
@@ -53,6 +54,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	 * @param string $key
 	 * @param mixed $value
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet( $key, $value ) {
 		update_post_meta( $this->product_id, $this->maybe_prefix_meta_key( $key ), $value );
 	}
@@ -62,6 +64,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	 * @param string $key
 	 * @return bool
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists( $key ) {
 		return metadata_exists( 'post', $this->product_id, $this->maybe_prefix_meta_key( $key ) );
 	}
@@ -69,6 +72,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	/**
 	 * Nothing to do here as we access post meta directly.
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset( $key ) {
 	}
 

--- a/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
+++ b/includes/legacy/class-wcs-array-property-post-meta-black-magic.php
@@ -64,7 +64,7 @@ class WCS_Array_Property_Post_Meta_Black_Magic implements ArrayAccess {
 	 * @param string $key
 	 * @return bool
 	 */
-	#[ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $key ) {
 		return metadata_exists( 'post', $this->product_id, $this->maybe_prefix_meta_key( $key ) );
 	}


### PR DESCRIPTION
Fixes #436

## Description

This update adds the `ReturnTypeWillChange` attribute to methods in the `WCS_Array_Property_Post_Meta_Black_Magic` class. This change will make `ArrayAccess` implementations compatible with PHP 8.1 and above. By using the attribute instead of changing the method signatures, we can maintain compatibility with older PHP versions (i.e., PHP 7.x). 

As developers of the WooCommerce Zapier plugin, which adds Zapier integration to Subscriptions, we have a vested interest in ensuring that our code and tests are compatible with newer PHP versions.

By design, adding this attribute will appear like a comment in older PHP versions, so we do not anticipate any code-breaking changes. 

Without this change, in PHP 8.1, if you try to create Variable Subscriptions, a deprecation notice occurs:

```
Deprecated: Return type of WCS_Array_Property_Post_Meta_Black_Magic::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/legacy/class-wcs-array-property-post-meta-black-magic.php on line 65
```

## How to Test This PR

1. Use PHP 8.1.
2. Enable `WP_DEBUG` and `WP_DEBUG_DISPLAY`
3. Create a subscription product.
4. Observe the deprecated message.

## Product Impact

<!-- What products will this PR ship in? -->

- [x] Changelog does not apply.
- [x] This PR will affect WooCommerce Subscriptions (no issue has been raised there).
- [x] This PR will not affect WooCommerce Payments.