### PR TITLE
Fix deprecation warnings on blocks checkout

### DIFF
--- a/assets/src/js/filters/index.js
+++ b/assets/src/js/filters/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { __experimentalRegisterCheckoutFilters } from '@woocommerce/blocks-checkout';
+import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ import {
  * If an error is thrown, it would be visible for store managers only.
  */
 export const registerFilters = () => {
-	__experimentalRegisterCheckoutFilters( 'woocommerce-subscriptions', {
+	registerCheckoutFilters( 'woocommerce-subscriptions', {
 		// subscriptions data here comes from register_endpoint_data /cart registration.
 		totalLabel: ( label, { subscriptions } ) => {
 			if ( 0 < subscriptions?.length ) {


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
Update the deprecated `__experimentalRegisterCheckoutFilters` to `registerCheckoutFilters` to prevent console warnings on blocks checkout.

<img width="487" alt="Screenshot 2023-08-25 at 22 32 08" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/1693223/5d7a5edd-1a60-4d68-beb8-f703fc7610fa">

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With a merchant store with WCPay:

* Build the woocommerce-subscription-core (`npm install && npm run build`)
* [Install it](https://github.com/Automattic/woocommerce-subscriptions-core#development) as a plugin on your store with the `woocommerce-subscription-core` slug.
* Add an item to the cart.
* Access blocks checkout.
* Access DevTools console.
* The `__experimentalRegisterCheckoutFilters` warning should not appear.
* Place order.
* The order should be processed as usual.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
