### PR TITLE
Only prevent Product add-ons from adjusting prices if prices are honoured

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.3.0 - 2023-xx-xx =
+* Fix - Resolved an issue that caused paying for failed/pending parent orders that include Product Add-ons to not calculate the correct total.
+
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.
 * Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.

--- a/includes/class-wcs-cart-initial-payment.php
+++ b/includes/class-wcs-cart-initial-payment.php
@@ -134,7 +134,7 @@ class WCS_Cart_Initial_Payment extends WCS_Cart_Renewal {
 	}
 
 	/**
-	 * Deteremines if the cart should honor the granfathered subscription/order line item total.
+	 * Determines if the cart should honor the grandfathered subscription/order line item total.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.10
 	 *

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -946,7 +946,7 @@ class WCS_Cart_Renewal {
 	 */
 	public function product_addons_adjust_price( $adjust_price, $cart_item ) {
 
-		if ( true === $adjust_price && isset( $cart_item[ $this->cart_item_key ] ) ) {
+		if ( true === $adjust_price && isset( $cart_item[ $this->cart_item_key ] ) && $this->should_honor_subscription_prices( $cart_item ) ) {
 			$adjust_price = false;
 		}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1494,7 +1494,7 @@ class WCS_Cart_Renewal {
 
 
 	/**
-	 * Deteremines if the cart should honor the granfathered subscription/order line item total.
+	 * Determines if the cart should honor the grandfathered subscription/order line item total.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.10
 	 *


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-subscriptions/issues/4535

## Description

When using the Product Add-ons plugin and you pay for a subscription renewal, failed initial order or resubscribe, we were telling Product Add-ons to not adjust the price. 

This caused issues when paying for initial parent orders because we (subscriptions) don't automatically grandfather the price and so we need Product Add-ons to actually calculate the add-on prices in that case. 

This PR fixes that by making sure we only tell Product Add-ons to not adjust prices if we're going to honour the order/subscription total. To help explain, this little table explains what the cart product price source should be for the various scenarios: 

| Order type | Price Source |
|--------|--------|
| Parent | product price + Add-ons |
| Parent w' price lock * | subscription/order |
| Renewal | subscription/order |

\* you can lock the parent order price by editing the order and hitting this checkbox
 
<img width="414" alt="Screenshot 2023-09-19 at 2 28 52 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/793d4b81-4b84-4991-a624-235d5b74b641">


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install the WooCommerce Product Add-ons plugin.
2. Create a subscription product with at least 1 product Add-on.
3. Go the product page on the front end, choose an add-on and then add the product to the cart.
4. At checkout fail the payment using a failing payment method. 
5. Go to the My Account Orders page and click the "Pay" link. 
   - On `trunk` you'll notice 2 things. 
      1. The order price will be wrong. It doesn't include the add-on prices.
      2. The add-ons are doubled up ([screenshot](https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/bc5e2064-29b9-476a-b626-399acb18d43f)) - you can ignore this for now. 
   - On this branch the total price should be correct. ie include the add-on(s) prices.
6. Edit the order in the admin dashboard. 
7. Change the order's status to pending. 
8. Edit the line item total and increase the price. 
9. Check the "lock manual price increases" box. 
10. Save
11. Repeat step 5 from above. 
    - On `trunk` the price is correct (the increased price). 
    - On this branch the total price should still be correct (the increased price).
12. Create a pending renewal order for a subscription with product add-ons.
13. Attempt to pay for it through the cart, the cart total should always match subscription/renewal order. 

> The add-ons are doubled up ([screenshot](https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/bc5e2064-29b9-476a-b626-399acb18d43f)) - you can ignore this for now. 

This doubling up of the add-ons will need to be fixed in the Product Add-ons plugin. I've got some working changes that I'll submit to their repo. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
