### PR TITLE
Fix subscription needs payment to exclude early renewal orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.3.0 - 2023-xx-xx =
+* Fix - Resolved an issue that caused subscriptions with an unpaid early renewal order to be incorrectly considered as needing payment.
+
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.
 * Fix - Ensure subscription checkout and cart block integrations are loaded on store environments where WooPayments is not enabled.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -270,9 +270,10 @@ class WC_Subscription extends WC_Order {
 		if ( parent::needs_payment() ) {
 			$needs_payment = true;
 		} elseif ( $parent_order && ( $parent_order->needs_payment() || $parent_order->has_status( array( 'on-hold', 'cancelled' ) ) ) ) {
+			// If the subscription has an unpaid parent order, it needs payment.
 			$needs_payment = true;
 		} else {
-			// Lastly check if last (non-early) renewal order needs payment.
+			// Lastly, check if the last non-early renewal order needs payment.
 			$order = wcs_get_last_non_early_renewal_order( $this );
 
 			if ( $order && ( $order->needs_payment() || $order->has_status( array( 'on-hold', 'failed', 'cancelled' ) ) ) ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -251,31 +251,29 @@ class WC_Subscription extends WC_Order {
 	}
 
 	/**
-	 * Checks if the subscription has an unpaid order or renewal order (and therefore, needs payment).
+	 * Checks if the subscription needs payment.
 	 *
-	 * @param string $subscription_key A subscription key of the form created by @see self::get_subscription_key()
-	 * @param int $user_id The ID of the user who owns the subscriptions. Although this parameter is optional, if you have the User ID you should pass it to improve performance.
-	 * @return bool True if the subscription has an unpaid renewal order, false if the subscription has no unpaid renewal orders.
+	 * A subscription requires payment if it:
+	 *  - is pending or failed,
+	 *  - has an unpaid parent order, or
+	 *  - has an unpaid order or renewal order (and therefore, needs payment)
+	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+	 *
+	 * @return bool True if the subscription requires payment, otherwise false.
 	 */
 	public function needs_payment() {
-
 		$needs_payment = false;
+		$parent_order  = $this->get_parent();
 
-		// First check if the subscription is pending or failed or is for $0
+		// If the subscription is pending or failed and it has a total > 0, it needs payment.
 		if ( parent::needs_payment() ) {
-
 			$needs_payment = true;
-
-		// Now make sure the parent order doesn't need payment
-		} elseif ( ( $parent_order = $this->get_parent() ) && ( $parent_order->needs_payment() || $parent_order->has_status( array( 'on-hold', 'cancelled' ) ) ) ) {
-
+		} elseif ( $parent_order && ( $parent_order->needs_payment() || $parent_order->has_status( array( 'on-hold', 'cancelled' ) ) ) ) {
 			$needs_payment = true;
-
-		// And finally, check that the latest order (switch or renewal) doesn't need payment
 		} else {
-
-			$order = $this->get_last_order( 'all', array( 'renewal', 'switch' ) );
+			// Lastly check if last (non-early) renewal order needs payment.
+			$order = wcs_get_last_non_early_renewal_order( $this );
 
 			if ( $order && ( $order->needs_payment() || $order->has_status( array( 'on-hold', 'failed', 'cancelled' ) ) ) ) {
 				$needs_payment = true;

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1755,7 +1755,9 @@ class WCS_Cart_Renewal {
 			// Guard against infinite loops in WC 3.0+ where default order staus is set in WC_Abstract_Order::__construct()
 			remove_filter( 'woocommerce_default_order_status', array( &$this, __FUNCTION__ ), 10 );
 
-			if ( $order_id > 0 && ( $order = wc_get_order( $order_id ) ) && wcs_order_contains_renewal( $order ) && $order->has_status( 'failed' ) ) {
+			$order = $order_id > 0 ? wc_get_order( $order_id ) : null;
+
+			if ( $order && wcs_order_contains_renewal( $order ) && $order->has_status( 'failed' ) ) {
 				$order_status = 'failed';
 			}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -35,9 +35,6 @@ class WCS_Cart_Renewal {
 		// Remove order action buttons from the My Account page
 		add_filter( 'woocommerce_my_account_my_orders_actions', array( &$this, 'filter_my_account_my_orders_actions' ), 10, 2 );
 
-		// When a failed renewal order is paid for via checkout, make sure WC_Checkout::create_order() preserves its "failed" status until it is paid
-		add_filter( 'woocommerce_default_order_status', array( &$this, 'maybe_preserve_order_status' ) );
-
 		// When a failed/pending renewal order is paid for via checkout, ensure a new order isn't created due to mismatched cart hashes
 		add_filter( 'woocommerce_create_order', array( &$this, 'update_cart_hash' ), 10, 1 );
 
@@ -633,33 +630,6 @@ class WCS_Cart_Renewal {
 		}
 
 		return $actions;
-	}
-
-	/**
-	 * When a failed renewal order is being paid for via checkout, make sure WC_Checkout::create_order() preserves its
-	 * status as 'failed' until it is paid. By default, it will always set it to 'pending', but we need it left as 'failed'
-	 * so that we can correctly identify the status change in @see self::maybe_change_subscription_status().
-	 *
-	 * @param string Default order status for orders paid for via checkout. Default 'pending'
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
-	 */
-	public function maybe_preserve_order_status( $order_status ) {
-
-		if ( null !== WC()->session && 'failed' !== $order_status ) {
-
-			$order_id = absint( WC()->session->order_awaiting_payment );
-
-			// Guard against infinite loops in WC 3.0+ where default order staus is set in WC_Abstract_Order::__construct()
-			remove_filter( 'woocommerce_default_order_status', array( &$this, __FUNCTION__ ), 10 );
-
-			if ( $order_id > 0 && ( $order = wc_get_order( $order_id ) ) && wcs_order_contains_renewal( $order ) && $order->has_status( 'failed' ) ) {
-				$order_status = 'failed';
-			}
-
-			add_filter( 'woocommerce_default_order_status', array( &$this, __FUNCTION__ ) );
-		}
-
-		return $order_status;
 	}
 
 	/**
@@ -1764,5 +1734,34 @@ class WCS_Cart_Renewal {
 				}
 			}
 		}
+	}
+
+	/**
+	 * When a failed renewal order is being paid for via checkout, make sure WC_Checkout::create_order() preserves its
+	 * status as 'failed' until it is paid. By default, it will always set it to 'pending', but we need it left as 'failed'
+	 * so that we can correctly identify the status change in @see self::maybe_change_subscription_status().
+	 *
+	 * @param string Default order status for orders paid for via checkout. Default 'pending'
+	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+	 *
+	 * @deprecated 6.3.0
+	 */
+	public function maybe_preserve_order_status( $order_status ) {
+		wcs_deprecated_function( __METHOD__, '6.3.0' );
+		if ( null !== WC()->session && 'failed' !== $order_status ) {
+
+			$order_id = absint( WC()->session->order_awaiting_payment );
+
+			// Guard against infinite loops in WC 3.0+ where default order staus is set in WC_Abstract_Order::__construct()
+			remove_filter( 'woocommerce_default_order_status', array( &$this, __FUNCTION__ ), 10 );
+
+			if ( $order_id > 0 && ( $order = wc_get_order( $order_id ) ) && wcs_order_contains_renewal( $order ) && $order->has_status( 'failed' ) ) {
+				$order_status = 'failed';
+			}
+
+			add_filter( 'woocommerce_default_order_status', array( &$this, __FUNCTION__ ) );
+		}
+
+		return $order_status;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4404

## Description

The `$subscription->needs_payment()` function use to check the last renewal or switch even if the last renewal order was an early renewal order. 

Early renewal orders are optional and so should not have any bearing on whether a subscription needs payment. 

If you look at the uses of `needs_payment()`, it's currently only used in a handful of places. 

- when determining if a subscription can be reactivated if it is suspended. 
- when determining if a subscription can be auto switched.
- when determining if a limited product is purchasable. 

In my opinion none of these should use early renewal orders to determine if the subscription requires payment. 

## How to test this PR

1. Purchase a subscription.
2. Enable early renewal. 
3. On the subscription's my account page, click the renew early button.
4. On checkout use a failing payment method. eg `4000000000000002`
5. Don't complete the payment.
6. Go to the subscription my account page:
   - On `trunk` you cannot reactivate. 
   - On this branch you can.

> [!important]
> The subscription is on-hold but this won't be the case with the changes being introduced in https://github.com/woocommerce/woocommerce-subscriptions/pull/4545 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
