### PR TITLE
With HPOS + compatibility mode enabled, manually created subscriptions don't have a start date in the new order tables

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.
 * Fix - Resolved an issue that caused paying for failed/pending parent orders that include Product Add-ons to not calculate the correct total.
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
+* Fix - Store the correct subscription start date in postmeta and ordermeta when HPOS and data syncing is being used.
 
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -609,6 +609,11 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 			];
 
 			if ( empty( $existing_meta_data ) ) {
+				// If we're saving a start date for the first time and it's empty, set it to the created date as a default.
+				if ( '_schedule_start' === $new_meta_data['key'] && empty( $new_meta_data['value'] ) ) {
+					$new_meta_data['value'] = $subscription->get_date( 'date_created' );
+				}
+
 				$this->data_store_meta->add_meta( $subscription, (object) $new_meta_data );
 			} elseif ( $existing_meta_data->meta_value !== $new_meta_data['value'] ) {
 				$new_meta_data['id'] = $existing_meta_data->meta_id;
@@ -649,7 +654,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 				continue;
 			}
 
-			// If we're setting the start date and it's missing, we set it to the created date.
+			// If we're reading in the start date and it's missing, set it in memory to the created date.
 			if ( 'schedule_start' === $prop_key && empty( $meta_data[ $meta_key ] ) ) {
 				$meta_data[ $meta_key ] = $subscription->get_date( 'date_created' );
 			}

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -221,6 +221,10 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		foreach ( $this->get_props_to_update( $subscription, $this->subscription_meta_keys_to_props ) as $meta_key => $prop ) {
 			$meta_value = ( 'schedule_' == substr( $prop, 0, 9 ) ) ? $subscription->get_date( $prop ) : $subscription->{"get_$prop"}( 'edit' );
 
+			if ( 'schedule_start' === $prop && ! $meta_value ) {
+				$meta_value = $subscription->get_date( 'date_created' );
+			}
+
 			// Store as a string of the boolean for backward compatibility (yep, it's gross)
 			if ( 'requires_manual_renewal' === $prop ) {
 				$meta_value = $meta_value ? 'true' : 'false';


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4560

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

When a store has both HPOS and compatibility mode enabled, there is some odd behaviour where new subscriptions are getting created with `_scheduled_start` meta stored as `0` in the `wp_wc_orders_meta` table and the correct start date in the `wp_postmeta`.

| WP Posts Table | WC Orders Table |
|--------|--------|
| ![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/2f61bd1d-299f-4750-9444-5881e0766890) | ![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/27d544f2-e6af-4101-9866-fed17c14048c) | 

With HPOS enabled and compatibility mode disabled, the correct `_scheduled_start` is stored in `wp_wc_orders_meta` so this issue just impacts those with the compatibility mode feature.

The approach I've taken in this PR is to fix this by updating the `persist_order_to_db()` function inside our Subscriptions OrdersTable datastore class so that if the `schedule_start` prop needs to be updated and it's empty, use the subscription's created date instead.

We do similar behavior already in [`init_order_record()`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/88cc564fdbcd6f926ef04c894859556e0fb823af/includes/data-stores/class-wcs-orders-table-subscription-data-store.php#L652-L655) however, this function doesn't write the dates to the database as it's surrounded by `$subscription->set_object_read( false );`.


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Not sure if this is necessary but to flick between the different HPOS and compatibility mode settings, rather than waiting for the order data sync to finish, I just wipe my orders and subscriptions from the DB using the following queries:

```
TRUNCATE TABLE `wp_wc_orders`;
TRUNCATE TABLE `wp_wc_orders_meta`;
TRUNCATE TABLE `wp_wc_order_addresses`;
TRUNCATE TABLE `wp_wc_order_operational_data`;


DELETE FROM wp_posts WHERE post_type = 'shop_subscription' OR post_type = 'shop_order';
DELETE pm
FROM wp_postmeta pm
LEFT JOIN wp_posts wp ON wp.ID = pm.post_id
WHERE wp.ID IS NULL;

DELETE FROM wp_usermeta WHERE meta_key = '_wcs_subscription_ids_cache';
```

1. Enable HPOS and sync (compatibility mode) in **WC > Settings > Advanced > Features**
2. Go to **WC > Subscriptions** and click **Add Subscription**
3. Enter any details but do not change the status from "Pending"
4. Click Update
5. Using phpMyAdmin or some other DB tool:
   1. On `trunk` verify that `_scheduled_start` is set to `0` in the `wc_orders_meta` table but it is set to the correct value in the `wp_postmeta` table for that same subscription
   2. On this branch create a new subscription and verify that `_scheduled_start` has the same value in `wc_orders_meta` and `wp_postmeta` tables

**Other tests:**
- 1. Keep HPOS on but with compatibility mode disabled and confirm new subscriptions have the correct `_schedule_start`
- 2. With HPOS + compatibility mode enabled/disabled, purchase a subscription from the checkout.
- 3. With HPOS + compatibility mode enabled/disabled, manually create a subscription using the following snippet. On `trunk` you'll notice there's no start date, on this branch there will be:
```
$subscription = new WC_Subscription();
$subscription = $subscription->save();
```

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
