### PR TITLE
Delete the needs_processing transient after copying line items to subscription orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.3.0 - xxxx-xx-xx =
 * Fix - When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.
 * Fix - Resolved an issue that caused paying for failed/pending parent orders that include Product Add-ons to not calculate the correct total.
+* Fix - Ensure the order needs processing transient is deleted when a subscription order (eg renewal) is created. Fixes issues with renewal orders going straight to a completed status.
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
 
 = 6.2.0 - 2023-08-10 =

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -215,6 +215,9 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		// If we got here, the subscription was created without problems
 		$transaction->commit();
 
+		// Delete the transient that caches whether the order needs processing. Because we've added line items, the order may now need processing.
+		delete_transient( 'wc_order_' . $new_order->get_id() . '_needs_processing' );
+
 		/**
 		 * Filters the new order created from the subscription.
 		 *


### PR DESCRIPTION
Fixes #517

## Description

There exists a small chance that appears to have affected a handful of stores where renewal orders go straight to completed status rather than processing. We haven't been able to find the root cause of this but based on the theory outlined by @kaushikasomaiya in the issue description, it may be caused by code calling the `needs_processing()` function after we've created the order but before we've added the line items. 

This causes WC to cache the `needs_processing` value in a transient, and therefore incorrectly determine that the order doesn't need processing even though the line items have changed since that original determination. 

## How to test this PR

1. Purchase a subscription with a product that does need processing (not downloadable). 
2. Run the following code snippet. 

```php
// Hook into the order being created and call $order->needs_processing(); so it caches a false value (before items are added)
add_action( 'woocommerce_before_order_object_save', function( $order ) {
    $order->needs_processing();
} );

// Create a renewal order. Replace the ID with your local Subscription ID.
$renewal_order = wcs_create_order_from_subscription( wcs_get_subscription( 4436 ), 'renewal_order' );

// Confirm the order needs processing. 
var_export( $renewal_order->needs_processing() ); // False on `trunk` true on this branch.
```

3. On `trunk` you'll get the order doesn't need processing (`false`) and a completed order.
4. On this branch it will be `true` and the order will be processing as expected.

<img width="1398" alt="Screenshot 2023-09-29 at 6 27 48 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/3c1b7eaf-f9c3-4bb4-acfe-b375f49031f9">


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
