### PR TITLE
Update trash_users_subscriptions() to properly delete subscriptions in HPOS environments.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,12 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 6.3.0 - xxxx-xx-xx =
+* Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
 * Fix - When HPOS is enabled, make the orders_by_type_query filter box work in the WooCommerce orders screen.
 * Fix - Ensure renewal orders paid via the Block Checkout are correctly linked to their subscription.
 * Fix - Resolved an issue that caused paying for failed/pending parent orders that include Product Add-ons to not calculate the correct total.
-* Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.
 * Fix - Store the correct subscription start date in postmeta and ordermeta when HPOS and data syncing is being used.
+* Fix - When HPOS is enabled, deleting a customer will now delete their subscriptions.
 
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -1001,7 +1001,7 @@ class WC_Subscriptions_Manager {
 					}
 				}
 
-				wp_delete_post( $subscription->get_id() );
+				$subscription->delete( true );
 			}
 		}
 	}


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

When a user/subscriber is deleted, we hook onto the `delete_user` hook and delete all subscriptions that belong to this user. This function was still using `wp_post_delete()` which doesn't work in a HPOS environment resulting in subscriptions remaining without a customer attached.

This PR updates the `trash_users_subscriptions()` function and replaces the `wp_post_delete( $id )` method with `$subscription->delete( true )` so work in both HPOS & WP Posts environments.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable High-performance order storage on your store (found: WC > Settings > Advanced > Features)
2. Create a throw-away user by going to WP Admin > Users > Add New
3. Create the user with the minimum details i.e. customer1 customer1@example.com and default password
4. Go to WC > Subscriptions > Add New
5. Create a basic subscription for this new customer and use the actions drop-down to create a pending parent order.
6. Go to WP Admin > Users and delete the user.
7. On `trunk` you will notice the subscription still exists without a customer and the parent order will have a note saying the subscription was deleted.
8. On this branch the subscription will be removed.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes
