### PR TITLE
Fixes missing styles on the Edit Subscription page when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Ensure the order needs processing transient is deleted when a subscription order (eg renewal) is created. Fixes issues with renewal orders going straight to a completed status.
 * Fix - Store the correct subscription start date in postmeta and ordermeta when HPOS and data syncing is being used.
 * Fix - When HPOS is enabled, deleting a customer will now delete their subscriptions.
+* Fix - Missing styles on the Edit Subscription page when HPOS is enabled.
 
 = 6.2.0 - 2023-08-10 =
 * Add - Introduce an updated empty state screen for the WooCommerce > Subscriptions list table.

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -943,7 +943,7 @@ class WC_Subscriptions_Admin {
 		}
 
 		if ( $is_woocommerce_screen || 'edit-product' == $screen->id || ( isset( $_GET['page'], $_GET['tab'] ) && 'wc-reports' === $_GET['page'] && 'subscriptions' === $_GET['tab'] ) ) {
-			wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WC_Subscriptions_Core_Plugin::instance()->get_library_version() );
+			wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', [ 'wc-components' ], WC_Subscriptions_Core_Plugin::instance()->get_library_version() );
 			wp_enqueue_style( 'woocommerce_subscriptions_admin', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/css/admin.css' ), array( 'woocommerce_admin_styles' ), WC_Subscriptions_Core_Plugin::instance()->get_library_version() );
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4563

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

For stores with HPOS enabled, there are some styles missing on the Edit Subscription page which is noticeable when trying to update the subscription status:

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/2c0d0aaf-6812-4603-bf99-6b54603301b2)

This issue is caused by a missing dependency (`wc-components`) when registering our admin stylesheet.

Expected look:
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/d6b340b9-931e-4fe1-aea1-fa6226a326f6)


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!WARNING]  
> Some plugins like **WP Console** seem to load this dependency, therefore while testing this PR, make sure every plugin is deactivated apart from WooCommerce and Woo Subscriptions.

1. Enable HPOS on your store (WC > Settings > Advanced)
2. View an Edit Subscription page (WC > Subscriptions > view a subscription)
3. Click on the status drop-down menu
   1. On `trunk` you should notice no borders or on-hover styles
   2. On this branch the drop-down menu should be styled the same as the Edit Order page

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
