### PR TITLE
Update the checkout blocks hook that's attached to the process checkout flow to use the latest hook

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.4.0 - xxxx-xx-xx =
 * Add - Use admin theme color and the correct WooCommerce colors.
+* Dev - Update the Checkout Blocks hooks used from `woocommerce_blocks_checkout_` to `woocommerce_store_api_checkout`.
 
 = 6.3.0 - 2023-10-06 =
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.

--- a/includes/class-wc-subscriptions-checkout.php
+++ b/includes/class-wc-subscriptions-checkout.php
@@ -24,11 +24,7 @@ class WC_Subscriptions_Checkout {
 		add_action( 'woocommerce_checkout_order_processed', array( __CLASS__, 'process_checkout' ), 100, 2 );
 
 		// Same as above, but this is for the Checkout block.
-		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) && ( version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '6.3.0', '>=' ) || \Automattic\WooCommerce\Blocks\Package::is_experimental_build() ) ) {
-			add_action( 'woocommerce_blocks_checkout_order_processed', array( __CLASS__, 'process_checkout' ), 100, 1 );
-		} else {
-			add_action( '__experimental_woocommerce_blocks_checkout_order_processed', array( __CLASS__, 'process_checkout' ), 100, 1 );
-		}
+		add_action( 'woocommerce_store_api_checkout_order_processed', array( __CLASS__, 'process_checkout' ), 100, 1 );
 
 		// Some callbacks need to hooked after WC has loaded.
 		add_action( 'woocommerce_loaded', array( __CLASS__, 'attach_dependant_hooks' ) );

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -91,11 +91,7 @@ class WCS_Cart_Renewal {
 			add_action( 'woocommerce_checkout_update_order_meta', array( &$this, 'set_order_item_id' ), 10, 2 );
 
 			// After order meta is saved, get the order line item ID for the renewal so we can update it later
-			if ( version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '7.2.0', '>=' ) ) {
-				add_action( 'woocommerce_store_api_checkout_update_order_meta', array( &$this, 'set_order_item_id' ) );
-			} else {
-				add_action( 'woocommerce_blocks_checkout_update_order_meta', array( &$this, 'set_order_item_id' ) );
-			}
+			add_action( 'woocommerce_store_api_checkout_update_order_meta', array( &$this, 'set_order_item_id' ) );
 
 			// Don't display cart item key meta stored above on the Edit Order screen
 			add_action( 'woocommerce_hidden_order_itemmeta', array( &$this, 'hidden_order_itemmeta' ), 10 );


### PR DESCRIPTION
Related issue: https://github.com/woocommerce/woocommerce-subscriptions/issues/4540

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

There is an issue where processing a Switch request on a block checkout results in a new subscription being created instead of the existing subscription being updated. This issue was caused by our `WC_Subscriptions_Checkout` class using a deprecated checkout block hook while our `WC_Subscriptions_Switcher` is using the latest store API hook.

This was causing problems because WooCommerce calls the deprecated hooks first before the latest hook resulting in `WC_Subscriptions_Checkout::process_checkout` running before `WC_Subscriptions_Switcher::process_checkout` which was creating the extra subscription correctly.

It's important that the switcher class processes the checkout first so that it can remove any items from the recurring cart to prevent subscriptions from being created on the switch.

> [!NOTE]
> This PR removes the `version_compare` on `\Automattic\WooCommerce\Blocks\Package::get_version()` because Subscriptions supports WooCommerce 7.7 at a minimum which already comes bundled with Checkout Blocks v10.0.2.
> Therefore I've removed all of the deprecated hooks and conditions checking for older versions of checkout blocks that we no longer support.
>
> I'm not sure if there are any concerns with stores installing an older version of checkout blocks as a standalone plugin but I don't think we should cater to that.
> Open to discuss this :)

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!important]
> To follow these testing instructions you'll need to have the main Woo Subscriptions plugin active to access switching.
> There's also another bug that prevents you from submitting a $0 switch checkout when using the block checkout. This will be addressed in a PR to the main repository.

1. Make sure you have a block checkout page available to test
2. Enable switching between variations in the **WC > Settings > Subscriptions**
3. Purchase a variable subscription product
4. Go to My Account > My Subscription
5. Click on the Upgrade or Downgrade button
6. Select a different variation and complete the switch checkout
7. On `trunk` you'll notice you now have two active subscriptions for the same variable product
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/4ccf1708-d086-4ce0-96eb-068bf0ab1cc0)
8. On this branch, you will only have 1 subscription.
In order to be able to bipass the checkout erroring with "No valid payment method" I had to stub `WC_Subscriptions_Order::order_needs_payment()` to return `false` on the first line.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
