### PR TITLE
When creating subscriptions convert subscription date created to a timestamp so it is treated as UTC 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.4.0 - xxxx-xx-xx =
 * Add - Use admin theme color and the correct WooCommerce colors.
+* Fix - Ensure subscriptions have a date created that correctly accounts for the site's timezone. Fixes issues with subscriptions having a date created double the site's UTC offset.
 
 = 6.3.0 - 2023-10-06 =
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -174,7 +174,7 @@ function wcs_create_subscription( $args = array() ) {
 
 	$subscription->set_customer_note( $args['customer_note'] ?? '' );
 	$subscription->set_customer_id( $args['customer_id'] );
-	$subscription->set_date_created( $args['date_created'] );
+	$subscription->set_date_created( wcs_date_to_time( $args['date_created'] ) );
 	$subscription->set_created_via( $args['created_via'] );
 	$subscription->set_currency( $args['currency'] );
 	$subscription->set_prices_include_tax( 'no' !== $args['prices_include_tax'] );


### PR DESCRIPTION
## Description

When a WP site has a timezone set in the settings, subscriptions created via the checkout have a date created that is offset by the timezone incorrectly. 

This is caused by a bug in the `wcs_create_subscription()` function where it passes a UTC mysql date string (`2023-10-12 14:53:24`) to `$subscription->set_date_created()` but if you look at the [description of that function](https://github.com/woocommerce/woocommerce/blob/2f47695ebc566f19b1a6bdd5daed6e1534a7756b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php#L687-L695) you'll notice that it says that: 

> If the DateTime string has no timezone or offset, WordPress site timezone will be assumed.

This means that when we pass a mysql date format, it assumes the date is in the site's local time. 

This PR fixes it by converting the mysql date into a timestamp which the `set_date_created()` will assume is in UTC.  

## How to test this PR

1. Go to the WordPress admin dashboard.
2. Go to **Settings → General** and set the site's timezone (eg UTC+10)

<img width="908" alt="Screenshot 2023-10-12 at 4 41 54 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/d150e6b7-aec0-4bc1-b7e7-e1c370aef257">

4.Purchase a subscription through the checkout. 
5. Go to the admin |Orders list table.
6. Edit the newly created order and scroll down to the related orders table. 
   - On `develop` note the subscription has a created date -10 hours.
   - On this branch it should be correct.

<img width="932" alt="Screenshot 2023-10-12 at 5 10 14 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/b91ffb1a-5b3f-4b9f-a8fd-aed6e9d7c8dd">

You can also check the date created in the database and you'll notice that on `develop` the GMT date is double the expected offset (eg -20 hours). 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
