### PR TITLE
Fixed issue that would turn subscriptions into manual renewals when a payment method got deleted

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.4.0 - xxxx-xx-xx =
 * Add - Use admin theme color and the correct WooCommerce colors.
+* Fix - Allow gateways to execute action on payment method deletion before updating the subscription.
 
 = 6.3.0 - 2023-10-06 =
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.

--- a/includes/class-wcs-my-account-payment-methods.php
+++ b/includes/class-wcs-my-account-payment-methods.php
@@ -21,7 +21,9 @@ class WCS_My_Account_Payment_Methods {
 		}
 
 		add_filter( 'woocommerce_payment_methods_list_item', array( __CLASS__, 'flag_subscription_payment_token_deletions' ), 10, 2 );
-		add_action( 'woocommerce_payment_token_deleted', array( __CLASS__, 'maybe_update_subscriptions_payment_meta' ), 10, 2 );
+
+		// This needs to run after the payment plugins had a chance to execute their delete actions.
+		add_action( 'woocommerce_payment_token_deleted', array( __CLASS__, 'maybe_update_subscriptions_payment_meta' ), 11, 2 );
 		add_action( 'woocommerce_payment_token_set_default', array( __CLASS__, 'display_default_payment_token_change_notice' ), 10, 2 );
 		add_action( 'wp', array( __CLASS__, 'update_subscription_tokens' ) );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/7457

## Description
This PR fixes a bug that would happen in WooPayments when a card that was being used by a subscription got deleted. This happened because the subscription payment method was updated while the old payment method still existed in cache and in Stripe.

Basically [this function](https://github.com/Automattic/woocommerce-subscriptions-core/blob/e8e078043a18e363c95b02030584741895567d58/includes/class-wcs-my-account-payment-methods.php#L101) executed before [this one](https://github.com/Automattic/woocommerce-payments/blob/a150749aeede5dd981510c1cb2edf47a69471040/includes/class-wc-payments-token-service.php#L220)

There is another PR trying to fix this issue in WooPayments side which is probably better https://github.com/Automattic/woocommerce-payments/pull/7472



## How to test this PR

- Place a subscription order using card `5555555555554444`
- Place another subscription using card `4242424242424242`
- Go to My Account > Payment Methods
- Delete the card `4242424242424242`
- Notice the message says the subscriptions got updated to use the other payment method
- Go to My Account > Subscriptions
- Make sure the subscriptions use `5555555555554444` now

## Product impact
- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
