### PR TITLE
Address PHP 8.2 Warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.4.0 - xxxx-xx-xx =
 * Add - Use admin theme color and the correct WooCommerce colors.
+* Dev - PHP 8.2: Fix "Creation of dynamic property" warnings.
 
 = 6.3.0 - 2023-10-06 =
 * Add - Introduce the "Subscription Relationship" column under the Orders list admin page when HPOS is enabled.

--- a/includes/emails/class-wcs-email-completed-renewal-order.php
+++ b/includes/emails/class-wcs-email-completed-renewal-order.php
@@ -34,11 +34,6 @@ class WCS_Email_Completed_Renewal_Order extends WC_Email_Customer_Completed_Orde
 		$this->template_plain = 'emails/plain/customer-completed-renewal-order.php';
 		$this->template_base  = WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' );
 
-		// Other settings
-		$this->heading_downloadable = $this->get_option( 'heading_downloadable', _x( 'Your subscription renewal order is complete - download your files', 'Default email heading for email with downloadable files in it', 'woocommerce-subscriptions' ) );
-		// translators: $1: {blogname}, $2: {order_date}, variables will be substituted when email is sent out
-		$this->subject_downloadable = $this->get_option( 'subject_downloadable', sprintf( _x( 'Your %1$s subscription renewal order from %2$s is complete - download your files', 'Default email subject for email with downloadable files in it', 'woocommerce-subscriptions' ), '{blogname}', '{order_date}' ) );
-
 		// Triggers for this email
 		add_action( 'woocommerce_order_status_completed_renewal_notification', array( $this, 'trigger' ) );
 
@@ -167,5 +162,27 @@ class WCS_Email_Completed_Renewal_Order extends WC_Email_Customer_Completed_Orde
 			'',
 			$this->template_base
 		);
+	}
+
+	/**
+	 * Gets the deprecated public variables for backwards compatibility.
+	 *
+	 * @param string $key Key.
+	 *
+	 * @return string|null
+	 */
+	public function __get( $key ) {
+		if ( 'heading_downloadable' === $key ) {
+			wcs_deprecated_argument( __CLASS__ . '::$' . $key, '5.6.0', 'The heading_downloadable property used for emails with downloadable files was removed in WooCommerce 3.1. Use the heading property instead.' );
+			return $this->get_option( 'heading_downloadable', _x( 'Your subscription renewal order is complete - download your files', 'Default email heading for email with downloadable files in it', 'woocommerce-subscriptions' ) );
+
+		} elseif ( 'subject_downloadable' === $key ) {
+			wcs_deprecated_argument( __CLASS__ . '::$' . $key, '5.6.0', 'The subject_downloadabl property used for emails with downloadable files was removed in WooCommerce 3.1. Use the subject property instead.' );
+			// translators: $1: {blogname}, $2: {order_date}, variables will be substituted when email is sent out
+			return $this->get_option( 'subject_downloadable', sprintf( _x( 'Your %1$s subscription renewal order from %2$s is complete - download your files', 'Default email subject for email with downloadable files in it', 'woocommerce-subscriptions' ), '{blogname}', '{order_date}' ) );
+
+		} else {
+			return;
+		}
 	}
 }

--- a/includes/emails/class-wcs-email-completed-switch-order.php
+++ b/includes/emails/class-wcs-email-completed-switch-order.php
@@ -17,6 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WCS_Email_Completed_Switch_Order extends WC_Email_Customer_Completed_Order {
 
 	/**
+	 * @var array Subscriptions linked to the switch order.
+	 */
+	public $subscriptions;
+
+	/**
 	 * Constructor
 	 */
 	function __construct() {

--- a/includes/emails/class-wcs-email-completed-switch-order.php
+++ b/includes/emails/class-wcs-email-completed-switch-order.php
@@ -34,10 +34,6 @@ class WCS_Email_Completed_Switch_Order extends WC_Email_Customer_Completed_Order
 		$this->template_plain = 'emails/plain/customer-completed-switch-order.php';
 		$this->template_base  = WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' );
 
-		// Other settings
-		$this->heading_downloadable = $this->get_option( 'heading_downloadable', __( 'Your subscription change is complete - download your files', 'woocommerce-subscriptions' ) );
-		$this->subject_downloadable = $this->get_option( 'subject_downloadable', __( 'Your {blogname} subscription change from {order_date} is complete - download your files', 'woocommerce-subscriptions' ) );
-
 		// Triggers for this email
 		add_action( 'woocommerce_subscriptions_switch_completed_switch_notification', array( $this, 'trigger' ) );
 
@@ -170,5 +166,26 @@ class WCS_Email_Completed_Switch_Order extends WC_Email_Customer_Completed_Order
 			'',
 			$this->template_base
 		);
+	}
+
+	/**
+	 * Gets the deprecated public variables for backwards compatibility.
+	 *
+	 * @param string $key Key.
+	 *
+	 * @return string|null
+	 */
+	public function __get( $key ) {
+		if ( 'heading_downloadable' === $key ) {
+			wcs_deprecated_argument( __CLASS__ . '::$' . $key, '5.6.0', 'The heading_downloadable property used for emails with downloadable files was removed in WooCommerce 3.1. Use the heading property instead.' );
+			return $this->get_option( 'heading_downloadable', __( 'Your subscription change is complete - download your files', 'woocommerce-subscriptions' ) );
+
+		} elseif ( 'subject_downloadable' === $key ) {
+			wcs_deprecated_argument( __CLASS__ . '::$' . $key, '5.6.0', 'The subject_downloadable property used for emails with downloadable files was removed in WooCommerce 3.1. Use the subject property instead.' );
+			return $this->get_option( 'subject_downloadable', __( 'Your {blogname} subscription change from {order_date} is complete - download your files', 'woocommerce-subscriptions' ) );
+
+		} else {
+			return;
+		}
 	}
 }

--- a/includes/emails/class-wcs-email-new-switch-order.php
+++ b/includes/emails/class-wcs-email-new-switch-order.php
@@ -14,6 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WCS_Email_New_Switch_Order extends WC_Email_New_Order {
 
 	/**
+	 * @var array Subscriptions linked to the switch order.
+	 */
+	public $subscriptions;
+
+	/**
 	 * Constructor
 	 */
 	function __construct() {


### PR DESCRIPTION
Fixes #325 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

After updating to PHP 8.2 there are a number of warnings coming from Subscriptions Core files:

```
[13-Oct-2023 02:38:45 UTC] PHP Deprecated:  Creation of dynamic property WCS_Email_Completed_Renewal_Order::$heading_downloadable is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/emails/class-wcs-email-completed-renewal-order.php on line 38
[13-Oct-2023 02:38:45 UTC] PHP Deprecated:  Creation of dynamic property WCS_Email_Completed_Renewal_Order::$subject_downloadable is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/emails/class-wcs-email-completed-renewal-order.php on line 40
[13-Oct-2023 02:38:45 UTC] PHP Deprecated:  Creation of dynamic property WCS_Email_Completed_Switch_Order::$heading_downloadable is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/emails/class-wcs-email-completed-switch-order.php on line 38
[13-Oct-2023 02:38:45 UTC] PHP Deprecated:  Creation of dynamic property WCS_Email_Completed_Switch_Order::$subject_downloadable is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/emails/class-wcs-email-completed-switch-order.php on line 39
[13-Oct-2023 02:38:45 UTC] PHP Deprecated:  Creation of dynamic property WCS_Email_New_Switch_Order::$subscriptions is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/emails/class-wcs-email-new-switch-order.php on line 95
[13-Oct-2023 02:38:45 UTC] PHP Deprecated:  Creation of dynamic property WCS_Email_Completed_Switch_Order::$subscriptions is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/emails/class-wcs-email-completed-switch-order.php on line 99
```

The `$heading_downloadable` and `$subject_downloadable` parameters were removed in WooCommerce 3.1 (see https://github.com/woocommerce/woocommerce/commit/adc679633bdb627bbebab5c0f537e5dad856ca4e) so I've opted to deprecate and remove these parameters but maintain backward compatibility using `__get()` function.


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Update your local dev environment to PHP 8.2 and enable `WP_DEBUG`
2. Make sure you have Woo Subscriptions installed and active
3. Enable Completed Renewal Order and Completed Switch Order emails
4. Process a switch and confirm the emails were sent properly.
5. On `trunk` you will see the above warnings
6. On this branch you shouldn't see any deprecation warnings coming from `subscriptions-core`

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
