### PR TITLE
Fix issues where edit product fields were incorrectly being hidden if they had the show_if_variable_subscription class

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -40,21 +40,14 @@ jQuery( function ( $ ) {
 				'hide_if_variable-subscription'
 			);
 
-			/**
-			 * WC core will hide and show product specific fields in show_and_hide_panels(), however that function only runs on specific events, but not
-			 * when variations are added or loaded. To make sure our subscription-related fields aren't shown by default when a variation is added, we set
-			 * subscription pricing elements "base" cases here.
-			 *
-			 * Note: show() being called on the 'hide_if_' fields and vice versa is intentional. All fields are set in their inverse state first, and
-			 * then shown/hidden by product type afterwards.
-			 */
-			$( '.hide_if_variable-subscription' ).show();
-			$( '.show_if_variable-subscription' ).hide();
+			var product_type = $( 'select#product-type' ).val();
 
-			if ( $( 'select#product-type' ).val() == 'variable-subscription' ) {
+			if ( 'variable-subscription' === product_type ) {
+				// Hide and show subscription fields when variable subscription is selected
 				$( 'input#_downloadable' ).prop( 'checked', false );
 				$( 'input#_virtual' ).prop( 'checked', false );
 
+				// Variable subscriptions inherit fields from variable products.
 				$( '.show_if_variable' ).show();
 				$( '.hide_if_variable' ).hide();
 				$( '.show_if_variable-subscription' ).show();

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -60,14 +60,7 @@ jQuery( function ( $ ) {
 					.addClass( 'form-row-full' )
 					.removeClass( 'form-row-last' );
 			} else {
-				if ( 'variable' === $( 'select#product-type' ).val() ) {
-					$( '.show_if_variable-subscription' ).hide();
-					$( '.show_if_variable' ).show();
-					$( '.hide_if_variable' ).hide();
-					$.showOrHideStockFields();
-				}
-
-				if ( 'subscription' === $( 'select#product-type' ).val() ) {
+				if ( 'subscription' === product_type ) {
 					$( '.show_if_subscription' ).show();
 					$( '.hide_if_subscription' ).hide();
 				}

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.4.0 - xxxx-xx-xx =
 * Add - Use admin theme color and the correct WooCommerce colors.
+* Fix - Resolve an issue that would cause 3rd party plugin edit product fields with the show_if_variable-subscription class to be incorrectly hidden.
 * Dev - Updated the hooks for Checkout Blocks, replacing the deprecated `woocommerce_blocks_checkout_` prefixed hooks with `woocommerce_store_api_checkout`.
 
 = 6.3.0 - 2023-10-06 =

--- a/includes/class-wcs-template-loader.php
+++ b/includes/class-wcs-template-loader.php
@@ -13,8 +13,6 @@ class WCS_Template_Loader {
 	 * @var array[] Array of file names and their directory found in templates/
 	 */
 	private static $relocated_templates = [
-		'html-variation-price.php'                => 'admin/deprecated/',
-		'html-variation-synchronisation.php'      => 'admin/deprecated/',
 		'order-shipping-html.php'                 => 'admin/deprecated/',
 		'order-tax-html.php'                      => 'admin/deprecated/',
 		'html-admin-notice.php'                   => 'admin/',

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div class="variable_subscription_trial variable_subscription_pricing_2_3 show_if_variable-subscription variable_subscription_trial_sign_up">
+<div class="variable_subscription_trial variable_subscription_pricing_2_3 show_if_variable-subscription variable_subscription_trial_sign_up" style="display: none">
 	<p class="form-row form-row-first form-field show_if_variable-subscription sign-up-fee-cell">
 		<label for="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]"><?php printf( esc_html__( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) ); ?></label>
 		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ); ?>">
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</select>
 	</p>
 </div>
-<div class="variable_subscription_pricing variable_subscription_pricing_2_3 show_if_variable-subscription">
+<div class="variable_subscription_pricing variable_subscription_pricing_2_3 show_if_variable-subscription" style="display: none">
 	<p class="form-row form-row-first form-field show_if_variable-subscription _subscription_price_field">
 		<label for="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]">
 			<?php
@@ -61,7 +61,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</select>
 
 	</p>
-	<p class="form-row form-row-last show_if_variable-subscription _subscription_length_field">
+	<p class="form-row form-row-last show_if_variable-subscription _subscription_length_field" style="display: none">
 		<label for="variable_subscription_length[<?php echo esc_attr( $loop ); ?>]">
 			<?php esc_html_e( 'Expire after', 'woocommerce-subscriptions' ); ?>
 			<?php echo wcs_help_tip( _x( 'Automatically expire the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'Subscription Length dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ) ); ?>

--- a/templates/admin/html-variation-synchronisation.php
+++ b/templates/admin/html-variation-synchronisation.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $wp_locale;
 
 ?>
-<div class="variable_subscription_sync show_if_variable-subscription variable_subscription_pricing_2_3">
+<div class="variable_subscription_sync show_if_variable-subscription variable_subscription_pricing_2_3" style="display: none">
 	<div class="form-row form-row-full">
 		<div class="subscription_sync_week_month" style="<?php echo esc_attr( $display_week_month_select ); ?>">
 			<label for="variable_subscription_payment_sync_date[<?php echo esc_attr( $loop ); ?>]">


### PR DESCRIPTION
Fixes #190
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4313
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4352

## Description

On the edit product page, product fields added by third-party plugins (like WP Job manager) that have the `show_if_variable-subscription` class were being hidden incorrectly.

The reason this occurs is because we had code (see below) which had the effect of hiding all `show_if_variable-subscription` and then only showing them, if the product had a variable-subscription type. 

```js
$( '.hide_if_variable-subscription' ).show();
$( '.show_if_variable-subscription' ).hide();
```

If a product field has two "show if" criteria (eg `show_if_variable-subscription` and `show_if_simple`), this code would cause it to be hidden for all product types except variable subscriptions. ie, not shown for simple products. 

This PR fixes that by:

1. Removing that code I mentioned above. 
2. Removing code that handled (standard) variable products. We should only handle our product types and as far as I could tell, this wasn't necessary because WC hides and shows these fields automatically and we didn't need it. 
3. Hiding the `show_if_variable-subscription` fields on load and then rely on them being shown when the product type matches. This was necessary because it's currently not possible to hide these fields after the fact (ie when creating variations) because doing so would require us to do a `$( '.show_if_variable-subscription' ).hide();` and that reintroduces the issue. 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Standard tests

1. Create products, change the product type, and create variations and make sure there aren't product fields shown or hidden incorrectly. 
2. Edit an existing product, change the product type, and create variations and make sure there aren't product fields shown or hidden incorrectly.

### Custom field (#190)

1. Add the following code to your site. 
2. Create a new product, choose the simple product type.
4. On `trunk` you'll notice on the Inventory tab that there's no **Dummy Checkbox** field. 
5. On this branch there should be - note the `show_if_simple`. 
6. Change the product type to variable-subscription. 
7. On `trunk` and this branch the field would be shown. 
8. Change the product type to any product type and verify that on this branch it is only shown for variable subscriptions, simple and simple subscriptions ([simple subscriptions inherit simple fields](https://github.com/Automattic/woocommerce-subscriptions-core/blob/6.3.0/assets/js/admin/admin.js#L20-L22)). 

```php 
add_action( 'woocommerce_product_options_stock_status', 'sw_add_dummy_checkbox', 20 );
function sw_add_dummy_checkbox() {

	global $product_object;
	if ( ! is_a( $product_object, 'WC_Product' ) ) {
		return;
	}

	woocommerce_wp_checkbox(
		array(
			'id'            => '_wc_dummy_checkbox',
			'label'         => __( 'Dummy Checkbox', 'somewherewarm' ),
			'value'         => 'yes',
			'wrapper_class' => 'form-field show_if_simple  show_if_variable-subscription',
			'description'   => __( 'Dummy Checkbox Description', 'somewherewarm' ),
		)
	);
}
```

### Custom product type (https://github.com/woocommerce/woocommerce-subscriptions/pull/4215) 

The original changes removed by this PR were introduced in https://github.com/woocommerce/woocommerce-subscriptions/pull/4215 and were designed to fix an issue with subscription fields being shown on custom product types. 

1. Add the code snippet provided below to your site.
2. On this branch create a product. 
3. Choose "New Variable" - the product type added by the code snippet. 
4. Add at least 1 attribute. 
5. Create variations. 
6. Confirm that the variation product fields don't include any subscription product fields. 

<details><summary>code</summary>
<p>

```php
/**
 * Add option to product type selector.
 */
function kia_new_variable_product_type( $product_types ){
    $product_types[ 'new-variable' ] = 'New Variable';
    return $product_types;
}
add_filter( 'product_type_selector', 'kia_new_variable_product_type' );

/**
 * Define new product class.
 */
function kia_create_new_product_class(){
    class WC_Product_New_Variable extends WC_Product_Variable {


        public function __construct( $product ) {

            $this->product_type = 'new-variable';
            parent::__construct( $product );

        }

        public function get_type() {
            return 'new-variable'; // so you can use $product = wc_get_product(); $product->get_type()
        }

    }
}
add_action( 'woocommerce_loaded', 'kia_create_new_product_class' );

/**
 * Custom JS for metaboxes.
 */
function kia_producttype_custom_js() {

	wp_add_inline_script( 'wc-admin-product-meta-boxes', '
		jQuery( function( $ ) {
				$( ".variations_tab" ).addClass( "show_if_new-variable" );

				$( document.body ).on( "woocommerce_added_attribute", function() {
					$( ".enable_variation" ).addClass( "show_if_new-variable" );

					if ( "new-variable" === $( "select#product-type" ).val() ) {
						$( ".enable_variation" ).show();
					}
				});
			} );
	', 'before' );
}
add_action( 'admin_enqueue_scripts', 'kia_producttype_custom_js', 99 );

/**
 * Use existing data store.
 */
function kia_new_variable_data_store( $stores ) {
    $stores['product-new-variable'] = 'WC_Product_Variable_Data_Store_CPT';
    return $stores;
}
add_filter( 'woocommerce_data_stores', 'kia_new_variable_data_store' );
```
</p>
</details> 

### WP Job manager (https://github.com/woocommerce/woocommerce-subscriptions/issues/4313)

1. Install WP Job Manager
    - [WP Job Manager](https://github.com/Automattic/WP-Job-Manager)
    - [WP Job Manager WC Paid Listings](https://github.com/Automattic/wp-job-manager-wc-paid-listings).
2. Go to **Products → Add new**
3. Select **Job Package Subscription** product type.
4. Go to **Advanced** tab.
5. On `trunk` you'll notice there's on **Limit subscription** field. 
6. On this branch there should be. 




## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)