### PR TITLE
[HPOS] Fixes the quick-edit subscription status links on the admin list table when running WC 8.1+

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@
 * Fix - Resolve an issue that would cause 3rd party plugin edit product fields with the show_if_variable-subscription class to be incorrectly hidden.
 * Fix - Allow gateways to execute action on payment method deletion before updating the subscription.
 * Fix - Ensure subscriptions have a date created that correctly accounts for the site's timezone. Fixes issues with subscriptions having a date created double the site's UTC offset.
-* Fix - When HPOS is enabled, fix quick editing the subscription statuses on the subscriptions list table.
+* Fix - When HPOS is enabled, fix quick-editing the subscription statuses on the admin list table.
 * Dev - Updated the hooks for Checkout Blocks, replacing the deprecated `woocommerce_blocks_checkout_` prefixed hooks with `woocommerce_store_api_checkout`.
 * Dev - PHP 8.2: Fix "Creation of dynamic property" warnings.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Resolve an issue that would cause 3rd party plugin edit product fields with the show_if_variable-subscription class to be incorrectly hidden.
 * Fix - Allow gateways to execute action on payment method deletion before updating the subscription.
 * Fix - Ensure subscriptions have a date created that correctly accounts for the site's timezone. Fixes issues with subscriptions having a date created double the site's UTC offset.
+* Fix - When HPOS is enabled, fix quick editing the subscription statuses on the subscriptions list table.
 * Dev - Updated the hooks for Checkout Blocks, replacing the deprecated `woocommerce_blocks_checkout_` prefixed hooks with `woocommerce_store_api_checkout`.
 * Dev - PHP 8.2: Fix "Creation of dynamic property" warnings.
 

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1315,8 +1315,9 @@ class WCS_Admin_Post_Types {
 
 		// On HPOS environments, WC expects a slightly different format for the bulk actions.
 		if ( $is_hpos_enabled ) {
+			$id_key          = wcs_is_woocommerce_pre( '8.1' ) ? 'order' : 'id';
 			$action_url_args = [
-				'order'    => [ $subscription->get_id() ],
+				$id_key    => $subscription->get_id(),
 				'_wpnonce' => wp_create_nonce( 'bulk-orders' ),
 			];
 		} else {

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1317,7 +1317,7 @@ class WCS_Admin_Post_Types {
 		if ( $is_hpos_enabled ) {
 			$id_key          = wcs_is_woocommerce_pre( '8.1' ) ? 'order' : 'id';
 			$action_url_args = [
-				$id_key    => $subscription->get_id(),
+				$id_key    => [ $subscription->get_id() ],
 				'_wpnonce' => wp_create_nonce( 'bulk-orders' ),
 			];
 		} else {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4573

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

WooCommerce 8.1 (https://github.com/woocommerce/woocommerce/pull/39524) introduced a change to the way they fetch order/subscription IDs from the ListTable bulk-edit request and instead of using `$REQUEST['order']`, they now use `$REQUEST['id']`. This broke the bulk-edit and quick-edit features on the subscriptions admin list table i.e. these links:

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/81898ee3-f87b-4915-ade9-8358990519d1)

If you install WC 8.1 and have HPOS enabled, these links no longer work.

![](https://github.com/woocommerce/woocommerce-subscriptions/assets/8490476/e4bcb8c5-5391-43af-a4b0-9a4de80ca297)

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install WC 8.1+ and make sure HPOS is enabled.
3. Navigate to the the **WooCommerce > Subscriptions** list table. 
4. Try to suspend a subscription using the quick links.
5. On `trunk` notice the subscription doesn't update
6. On this branch the subscription is updated.
7. Test the bulk actions drop-down continues to work 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
