### PR TITLE
Allow admin users to turn on automatic renewals if the subscription has a saved payment method

### DIFF
--- a/assets/js/admin/meta-boxes-subscription.js
+++ b/assets/js/admin/meta-boxes-subscription.js
@@ -351,4 +351,17 @@ jQuery( function ( $ ) {
 			);
 		}
 	} );
+
+	/**
+	 * When the auto-renewal is toggled on or off, show or hide the chosen payment methods meta fields.
+	 */
+	$( '#wc-subscription-auto-renew' ).on( 'change', function() {
+		var $payment_method_meta_elements = $( '#wcs_' + $( '#_payment_method' ).val() + '_fields' );
+
+		if ( $( this ).is( ':checked' ) ) {
+			$payment_method_meta_elements.fadeIn();
+		} else {
+			$payment_method_meta_elements.fadeOut();
+		}
+	} );
 } );

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 6.5.0 - xxxx-xx-xx =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
-* Add - Enable admin users to turn on automatic payments for a subscription via the Edit Subscription page if the subscription has a payment method saved.
+* Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.
 
 = 6.4.0 - 2023-10-18 =
 * Add - Use admin theme color and the correct WooCommerce colors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.5.0 - xxxx-xx-xx =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
+* Add - Enable admin users to turn on automatic payments for a subscription via the Edit Subscription page if the subscription has a payment method saved.
 
 = 6.4.0 - 2023-10-18 =
 * Add - Use admin theme color and the correct WooCommerce colors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.5.0 - xxxx-xx-xx =
+* Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
+
 = 6.4.0 - 2023-10-18 =
 * Add - Use admin theme color and the correct WooCommerce colors.
 * Fix - Resolve an issue that would cause 3rd party plugin edit product fields with the show_if_variable-subscription class to be incorrectly hidden.

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -185,7 +185,7 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 							echo '<p><strong>' . esc_html( $field['label'] ) . ':</strong> ' . wp_kses_post( make_clickable( esc_html( $field_value ) ) ) . '</p>';
 						}
 
-						echo '<p' . ( ( '' != $subscription->get_payment_method() ) ? ' class="' . esc_attr( $subscription->get_payment_method() ) . '"' : '' ) . '><strong>' . esc_html__( 'Payment Method', 'woocommerce-subscriptions' ) . ':</strong>' . wp_kses_post( nl2br( $subscription->get_payment_method_to_display() ) ); // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+						echo '<p' . ( ( '' != $subscription->get_payment_method() ) ? ' class="' . esc_attr( $subscription->get_payment_method() ) . '"' : '' ) . '><strong>' . esc_html__( 'Payment method', 'woocommerce-subscriptions' ) . ':</strong>' . wp_kses_post( nl2br( $subscription->get_payment_method_to_display() ) ); // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 
 						// Display help tip
 						if ( '' != $subscription->get_payment_method() && ! $subscription->is_manual() ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -150,7 +150,8 @@ class WCS_Change_Payment_Method_Admin {
 
 		$payment_gateway = ( 'manual' != $payment_method ) ? $payment_gateways[ $payment_method ] : '';
 
-		if ( isset( $_POST['wc-subscription-auto-renew'] ) && $_POST['wc-subscription-auto-renew'] ) {
+		// If the auto renewal toggle is checked. Enable auto renewals. We don't need to handle unchecked values as that's the default.
+		if ( isset( $_POST['wc-subscription-auto-renew'] ) && (bool) $_POST['wc-subscription-auto-renew'] ) {
 			$subscription->set_requires_manual_renewal( false );
 			$subscription->add_order_note( __( 'Admin turned on automatic renewals via the Edit Subscription screen.', 'woocommerce-subscriptions' ), false, true );
 		}

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -142,6 +142,13 @@ class WCS_Change_Payment_Method_Admin {
 
 		// Update the payment method for manual only if it has changed.
 		if ( ! $subscription->is_manual() || 'manual' !== $payment_method ) {
+			// If the subscription is being changed away from manual and it is flagged as requiring manual payments turn on automatic renewals.
+			if ( 'manual' !== $payment_method && $subscription->get_requires_manual_renewal() && ! wcs_is_manual_renewal_required() && $payment_gateway->supports( 'subscriptions' ) ) {
+				$subscription->set_requires_manual_renewal( false );
+				// Translators: Placeholder is the payment gateway title.
+				$subscription->add_order_note( sprintf( __( 'Admin turned on automatic renewals by changing payment method to "%s" via the Edit Subscription screen.', 'woocommerce-subscriptions' ), $payment_gateway->get_title() ), false, true );
+			}
+
 			$subscription->set_payment_method( $payment_gateway, $payment_method_meta );
 			$subscription->save();
 		}

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -18,7 +18,6 @@ class WCS_Change_Payment_Method_Admin {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
 	public static function display_fields( $subscription ) {
-
 		$payment_method        = $subscription->get_payment_method();
 		$valid_payment_methods = self::get_valid_payment_methods( $subscription );
 
@@ -36,7 +35,7 @@ class WCS_Change_Payment_Method_Admin {
 		if ( count( $valid_payment_methods ) > 1 ) {
 
 			$found_method = false;
-			echo '<label>' . esc_html__( 'Payment Method', 'woocommerce-subscriptions' ) . ':</label>';
+			echo '<label>' . esc_html__( 'Payment method', 'woocommerce-subscriptions' ) . '</label>';
 			echo '<select class="wcs_payment_method_selector" name="_payment_method" id="_payment_method" class="first">';
 
 			foreach ( $valid_payment_methods as $gateway_id => $gateway_title ) {
@@ -49,7 +48,7 @@ class WCS_Change_Payment_Method_Admin {
 			echo '</select>';
 
 		} elseif ( count( $valid_payment_methods ) == 1 ) {
-			echo '<strong>' . esc_html__( 'Payment Method', 'woocommerce-subscriptions' ) . ':</strong><br/>' . esc_html( current( $valid_payment_methods ) );
+			echo '<strong>' . esc_html__( 'Payment method', 'woocommerce-subscriptions' ) . '</strong><br/>' . esc_html( current( $valid_payment_methods ) );
 			// translators: %s: gateway ID.
 			echo wcs_help_tip( sprintf( _x( 'Gateway ID: [%s]', 'The gateway ID displayed on the Edit Subscriptions screen when editing payment method.', 'woocommerce-subscriptions' ), key( $valid_payment_methods ) ) );
 			echo '<input type="hidden" value="' . esc_attr( key( $valid_payment_methods ) ) . '" id="_payment_method" name="_payment_method">';

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -33,17 +33,13 @@ class WCS_Change_Payment_Method_Admin {
 		echo '<p class="form-field form-field-wide">';
 
 		if ( count( $valid_payment_methods ) > 1 ) {
-
-			$found_method = false;
 			echo '<label>' . esc_html__( 'Payment method', 'woocommerce-subscriptions' ) . '</label>';
 			echo '<select class="wcs_payment_method_selector" name="_payment_method" id="_payment_method" class="first">';
 
-			foreach ( $valid_payment_methods as $gateway_id => $gateway_title ) {
+			$selected_payment_method = $subscription->get_requires_manual_renewal() ? 'manual' : $subscription->get_payment_method();
 
-				echo '<option value="' . esc_attr( $gateway_id ) . '" ' . selected( $payment_method, $gateway_id, false ) . '>' . esc_html( $gateway_title ) . '</option>';
-				if ( $payment_method == $gateway_id ) {
-					$found_method = true;
-				}
+			foreach ( $valid_payment_methods as $gateway_id => $gateway_title ) {
+				echo '<option value="' . esc_attr( $gateway_id ) . '" ' . selected( $selected_payment_method, $gateway_id, false ) . '>' . esc_html( $gateway_title ) . '</option>';
 			}
 			echo '</select>';
 

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -100,7 +100,7 @@ class WCS_Change_Payment_Method_Admin {
 				'wc-subscription-auto-renew',
 				[
 					'type'    => 'checkbox',
-					'label'   => esc_html__( 'Auto renew', 'woocommerce-subscriptions' ) . wcs_help_tip( __( "This subscription has automatic renewals turned off. Use this option to turn them on.", 'woocommerce-subscriptions' ) ),
+					'label'   => esc_html__( 'Auto renew', 'woocommerce-subscriptions' ) . wcs_help_tip( __( 'This subscription has automatic renewals turned off. Use this option to turn them on.', 'woocommerce-subscriptions' ) ),
 					'default' => false,
 				]
 			);

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -89,20 +89,6 @@ class WCS_Change_Payment_Method_Admin {
 			}
 		}
 
-		// If the subscription has a payment method but has turned off auto-renewal, display a checkbox so automatic renewals can be resumed.
-		if ( $subscription->get_requires_manual_renewal() && ! empty( $payment_method ) && ! wcs_is_manual_renewal_required() ) {
-			echo '<p class="form-field form-field-wide">';
-			woocommerce_form_field(
-				'wc-subscription-auto-renew',
-				[
-					'type'    => 'checkbox',
-					'label'   => esc_html__( 'Auto renew', 'woocommerce-subscriptions' ) . wcs_help_tip( __( 'This subscription has automatic renewals turned off. Use this option to turn them on.', 'woocommerce-subscriptions' ) ),
-					'default' => false,
-				]
-			);
-			echo '</p>';
-		}
-
 		wp_nonce_field( 'wcs_change_payment_method_admin', '_wcsnonce' );
 	}
 
@@ -145,12 +131,6 @@ class WCS_Change_Payment_Method_Admin {
 		}
 
 		$payment_gateway = ( 'manual' != $payment_method ) ? $payment_gateways[ $payment_method ] : '';
-
-		// If the auto renewal toggle is checked. Enable auto renewals. We don't need to handle unchecked values as that's the default.
-		if ( isset( $_POST['wc-subscription-auto-renew'] ) && (bool) $_POST['wc-subscription-auto-renew'] ) {
-			$subscription->set_requires_manual_renewal( false );
-			$subscription->add_order_note( __( 'Admin turned on automatic renewals via the Edit Subscription screen.', 'woocommerce-subscriptions' ), false, true );
-		}
 
 		if ( ! $subscription->is_manual() && ( '' == $payment_gateway || $subscription->get_payment_method() != $payment_gateway->id ) ) {
 			// Before updating to a new payment gateway make sure the subscription status is updated with the current gateway

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -94,7 +94,7 @@ class WCS_Change_Payment_Method_Admin {
 		}
 
 		// If the subscription has a payment method but has turned off auto-renewal, display a checkbox so automatic renewals can be resumed.
-		if ( $subscription->get_requires_manual_renewal() && ! empty( $payment_method ) ) {
+		if ( $subscription->get_requires_manual_renewal() && ! empty( $payment_method ) && ! wcs_is_manual_renewal_required() ) {
 			echo '<p class="form-field form-field-wide">';
 			woocommerce_form_field(
 				'wc-subscription-auto-renew',

--- a/includes/class-wcs-change-payment-method-admin.php
+++ b/includes/class-wcs-change-payment-method-admin.php
@@ -90,12 +90,24 @@ class WCS_Change_Payment_Method_Admin {
 				}
 
 				echo '</div>';
-
 			}
 		}
 
-		wp_nonce_field( 'wcs_change_payment_method_admin', '_wcsnonce' );
+		// If the subscription has a payment method but has turned off auto-renewal, display a checkbox so automatic renewals can be resumed.
+		if ( $subscription->get_requires_manual_renewal() && ! empty( $payment_method ) ) {
+			echo '<p class="form-field form-field-wide">';
+			woocommerce_form_field(
+				'wc-subscription-auto-renew',
+				[
+					'type'    => 'checkbox',
+					'label'   => esc_html__( 'Auto renew', 'woocommerce-subscriptions' ) . wcs_help_tip( __( "This subscription has automatic renewals turned off. Use this option to turn them on.", 'woocommerce-subscriptions' ) ),
+					'default' => false,
+				]
+			);
+			echo '</p>';
+		}
 
+		wp_nonce_field( 'wcs_change_payment_method_admin', '_wcsnonce' );
 	}
 
 	/**
@@ -137,6 +149,11 @@ class WCS_Change_Payment_Method_Admin {
 		}
 
 		$payment_gateway = ( 'manual' != $payment_method ) ? $payment_gateways[ $payment_method ] : '';
+
+		if ( isset( $_POST['wc-subscription-auto-renew'] ) && $_POST['wc-subscription-auto-renew'] ) {
+			$subscription->set_requires_manual_renewal( false );
+			$subscription->add_order_note( __( 'Admin turned on automatic renewals via the Edit Subscription screen.', 'woocommerce-subscriptions' ), false, true );
+		}
 
 		if ( ! $subscription->is_manual() && ( '' == $payment_gateway || $subscription->get_payment_method() != $payment_gateway->id ) ) {
 			// Before updating to a new payment gateway make sure the subscription status is updated with the current gateway

--- a/includes/class-wcs-my-account-auto-renew-toggle.php
+++ b/includes/class-wcs-my-account-auto-renew-toggle.php
@@ -98,6 +98,7 @@ class WCS_My_Account_Auto_Renew_Toggle {
 
 		if ( $subscription && self::can_user_toggle_auto_renewal( $subscription ) ) {
 			$subscription->set_requires_manual_renewal( true );
+			$subscription->add_order_note( __( 'Customer turned off automatic renewals via their My Account page.', 'woocommerce-subscriptions' ) );
 			$subscription->save();
 
 			self::send_ajax_response( $subscription );
@@ -122,6 +123,7 @@ class WCS_My_Account_Auto_Renew_Toggle {
 
 		if ( wc_get_payment_gateway_by_order( $subscription ) && self::can_user_toggle_auto_renewal( $subscription ) ) {
 			$subscription->set_requires_manual_renewal( false );
+			$subscription->add_order_note( __( 'Customer turned on automatic renewals via their My Account page.', 'woocommerce-subscriptions' ) );
 			$subscription->save();
 
 			self::send_ajax_response( $subscription );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4094
Fixes https://github.com/Automattic/woocommerce-subscriptions-core/issues/519

## Description

There's a feature in Woo Subscriptions that enables customers to switch between automatic and manual renewals. This is known as the auto renewal toggle.

| Auto-renewals off | Auto-renewals on |
|--------|--------|
| <img width="841" alt="Screenshot 2023-10-31 at 12 40 39 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/2b5c37f1-f026-4705-b861-caa6921bde09"> | <img width="830" alt="Screenshot 2023-10-31 at 12 41 08 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/6051b2ca-e0aa-4b30-b768-b277f9775364"> | 

When a customer turns off automatic renewals in this way, admin users are unable to switch it back to automatic renewals. This is because this toggle sets the `_requires_manual_renewal` flag which there's is no UI element for. 

This PR fixes that by adding a new checkbox on the edit subscription screen to allow them to turn automatic renewals back on.

https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/c4e2cea8-8d5b-4f27-9a9f-c570b964a9c7

<p align="center"><sup>The new "Auto renew" checkbox</sup></p>

## How to test this PR

1. Make sure you have Woo Subscriptions installed. 
2. Install this version of subscriptions-core (reminder: you can clone this repo and treat it like a plugin). 
3. Go to **WooCommerce → Settings → Subscriptions** 
4. Make sure the **Auto Renewal Toggle** setting is on.
5. Purchase a subscription using WooPayments, Stripe or any automatic payment method. 
6. Go to the My Account View Subscription page.
7. Click the Auto renewal toggle.
8. As admin go to **WooCommerce → Subscriptions** and edit the subscription.
   1. On `trunk` you'll notice that there's nothing you can do to turn automatic payments back on. Editing the billing details, doesn't enable you to set the auto renewal flag. 
   2. On this branch, you'll notice two things. 
       1. There are Subscription notes now added when the customer toggles auto renewal.
       2. If you edit the billing details, you will see a checkbox enabling you to turn on automatic renewals. (see video example above). 

<p align="center">
<img width="270" alt="Screenshot 2023-10-31 at 1 20 14 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/c336ceaa-ce94-4c7b-92cd-935781910c50">
</br>
<sup>Subscription notes</sup>
</p>

## Product impact 
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
