### PR TITLE
Backfill subscription dates and cache metadata to the postmeta table when syncing 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.5.0 - xxxx-xx-xx =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
 * Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.
+* Fix - Fetch and update the `_cancelled_email_sent` meta in a HPOS compatibile way.
 
 = 6.4.0 - 2023-10-18 =
 * Add - Use admin theme color and the correct WooCommerce colors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.5.0 - xxxx-xx-xx =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
 * Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.
+* Fix - Ensure proper backfilling of subscription metadata (i.e. dates and cache) to the postmeta table when HPOS is enabled and compatibility mode (data syncing) is turned on.
 * Fix - Fetch and update the `_cancelled_email_sent` meta in a HPOS compatibile way.
 
 = 6.4.0 - 2023-10-18 =

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"phpunit/phpunit": "9.5.14",
 		"woocommerce/woocommerce-sniffs": "0.1.0",
 		"dave-liddament/sarb": "^1.1",
-		"yoast/phpunit-polyfills": "1.0.3"
+		"yoast/phpunit-polyfills": "1.1.0"
 	},
 	"scripts": {
 		"phpcs": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b59327d741ea9498d9f1b278dae50ea5",
+    "content-hash": "4cd4c7d25ece957ea841b92cb1646a67",
     "packages": [
         {
             "name": "composer/installers",
@@ -4009,16 +4009,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -4026,13 +4026,12 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -4066,7 +4065,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],
@@ -4081,5 +4080,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -110,7 +110,7 @@ class WC_Subscriptions_Email {
 	public static function send_cancelled_email( $subscription ) {
 		WC()->mailer();
 
-		if ( $subscription->has_status( array( 'pending-cancel', 'cancelled' ) ) && 'true' !== get_post_meta( $subscription->get_id(), '_cancelled_email_sent', true ) ) {
+		if ( $subscription->has_status( array( 'pending-cancel', 'cancelled' ) ) && 'true' !== $subscription->get_cancelled_email_sent() ) {
 			do_action( 'cancelled_subscription_notification', $subscription );
 		}
 	}

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -889,7 +889,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 *
-	 * @return DateTime|null
+	 * @return string
 	 */
 	public function get_schedule_start( $subscription ) {
 		return $subscription->get_date( 'start' );
@@ -901,7 +901,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 *
-	 * @return DateTime|null
+	 * @return string
 	 */
 	public function get_schedule_trial_end( $subscription ) {
 		return $subscription->get_date( 'trial_end' );
@@ -913,7 +913,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 *
-	 * @return DateTime|null
+	 * @return string
 	 */
 	public function get_schedule_next_payment( $subscription ) {
 		return $subscription->get_date( 'next_payment' );
@@ -925,7 +925,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 *
-	 * @return DateTime|null
+	 * @return string
 	 */
 	public function get_schedule_cancelled( $subscription ) {
 		return $subscription->get_date( 'cancelled' );
@@ -937,7 +937,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 *
-	 * @return DateTime|null
+	 * @return string
 	 */
 	public function get_schedule_end( $subscription ) {
 		return $subscription->get_date( 'end' );
@@ -949,7 +949,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	 *
 	 * @param \WC_Subscription $subscription Subscription object.
 	 *
-	 * @return DateTime|null
+	 * @return string
 	 */
 	public function get_schedule_payment_retry( $subscription ) {
 		return $subscription->get_date( 'payment_retry' );

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -882,4 +882,112 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 
 		return $results ? array_combine( array_column( $results, 'status' ), array_map( 'absint', array_column( $results, 'cnt' ) ) ) : array();
 	}
+
+	/**
+	 * Fetches the subscription's start date.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_schedule_start( $subscription ) {
+		return $subscription->get_date( 'start' );
+	}
+
+	/**
+	 * Fetches the subscription's trial end date.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_schedule_trial_end( $subscription ) {
+		return $subscription->get_date( 'trial_end' );
+	}
+
+	/**
+	 * Fetches the subscription's next payment date.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_schedule_next_payment( $subscription ) {
+		return $subscription->get_date( 'next_payment' );
+	}
+
+	/**
+	 * Fetches the subscription's cancelled date.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_schedule_cancelled( $subscription ) {
+		return $subscription->get_date( 'cancelled' );
+	}
+
+	/**
+	 * Fetches the subscription's end date.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_schedule_end( $subscription ) {
+		return $subscription->get_date( 'end' );
+	}
+
+	/**
+	 * Fetches the subscription's payment retry date.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_schedule_payment_retry( $subscription ) {
+		return $subscription->get_date( 'payment_retry' );
+	}
+
+	/**
+	 * Returns a list of subscriptions's renewal order IDs stored in cache meta.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return array
+	 */
+	public function get_renewal_order_ids_cache( $subscription ) {
+		return $subscription->get_meta( '_subscription_renewal_order_ids_cache' );
+	}
+
+	/**
+	 * Returns a list of subscriptions's resubscribe order IDs stored in cache meta.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return array
+	 */
+	public function get_resubscribe_order_ids_cache( $subscription ) {
+		return $subscription->get_meta( '_subscription_resubscribe_order_ids_cache' );
+	}
+
+	/**
+	 * Returns a list of subscriptions's switch order IDs stored in cache meta.
+	 * This method is called by @see parent::backfill_post_record() when backfilling subscriptions details to WP_Post DB.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 *
+	 * @return array
+	 */
+	public function get_switch_order_ids_cache( $subscription ) {
+		return $subscription->get_meta( '_subscription_switch_order_ids_cache' );
+	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -720,7 +720,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param array           $resubscribe_order_ids
 	 */
 	public function set_resubscribe_order_ids_cache( $subscription, $resubscribe_order_ids ) {
 		update_post_meta( $subscription->get_id(), '_subscription_resubscribe_order_ids_cache', $resubscribe_order_ids );

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -61,6 +61,23 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	);
 
 	/**
+	 * Custom setters for subscription internal props in the form meta_key => set_|get_{value}.
+	 *
+	 * @var string[]
+	 */
+	protected $internal_data_store_key_getters = array(
+		'_schedule_start'                           => 'schedule_start',
+		'_schedule_trial_end'                       => 'schedule_trial_end',
+		'_schedule_next_payment'                    => 'schedule_next_payment',
+		'_schedule_cancelled'                       => 'schedule_cancelled',
+		'_schedule_end'                             => 'schedule_end',
+		'_schedule_payment_retry'                   => 'schedule_payment_retry',
+		'_subscription_renewal_order_ids_cache'     => 'renewal_order_ids_cache',
+		'_subscription_resubscribe_order_ids_cache' => 'resubscribe_order_ids_cache',
+		'_subscription_switch_order_ids_cache'      => 'switch_order_ids_cache',
+	);
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -603,5 +620,122 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 */
 	public function get_subscriptions_count_by_status() {
 		return (array) wp_count_posts( 'shop_subscription' );
+	}
+
+	/**
+	 * Sets the subscription's start date.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_schedule_start( $subscription, $date ) {
+		update_post_meta( $subscription->get_id(), '_schedule_start', $date );
+	}
+
+	/**
+	 * Sets the subscription's trial end date.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_schedule_trial_end( $subscription, $date ) {
+		update_post_meta( $subscription->get_id(), '_schedule_trial_end', $date );
+	}
+
+	/**
+	 * Sets the subscription's next payment date.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_schedule_next_payment( $subscription, $date ) {
+		update_post_meta( $subscription->get_id(), '_schedule_next_payment', $date );
+	}
+
+	/**
+	 * Sets the subscription's cancelled date.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_schedule_cancelled( $subscription, $date ) {
+		update_post_meta( $subscription->get_id(), '_schedule_cancelled', $date );
+	}
+
+	/**
+	 * Sets the subscription's end date.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_schedule_end( $subscription, $date ) {
+		update_post_meta( $subscription->get_id(), '_schedule_end', $date );
+	}
+
+	/**
+	 * Sets the subscription's payment retry date.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_schedule_payment_retry( $subscription, $date ) {
+		update_post_meta( $subscription->get_id(), '_schedule_payment_retry', $date );
+	}
+
+	/**
+	 * Manually sets the list of subscription's renewal order IDs stored in cache.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_renewal_order_ids_cache( $subscription, $renewal_order_ids ) {
+		update_post_meta( $subscription->get_id(), '_subscription_renewal_order_ids_cache', $renewal_order_ids );
+	}
+
+	/**
+	 * Manually sets the list of subscription's resubscribe order IDs stored in cache.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_resubscribe_order_ids_cache( $subscription, $resubscribe_order_ids ) {
+		update_post_meta( $subscription->get_id(), '_subscription_resubscribe_order_ids_cache', $resubscribe_order_ids );
+	}
+
+	/**
+	 * Manually sets the list of subscription's switch order IDs stored in cache.
+	 *
+	 * This method is not intended for public use and is called by @see OrdersTableDataStore::backfill_post_record()
+	 * when backfilling subscription data to the WP_Post database.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param DateTime|string $date
+	 */
+	public function set_switch_order_ids_cache( $subscription, $switch_order_ids ) {
+		update_post_meta( $subscription->get_id(), '_subscription_switch_order_ids_cache', $switch_order_ids );
 	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -733,7 +733,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param array           $switch_order_ids
 	 */
 	public function set_switch_order_ids_cache( $subscription, $switch_order_ids ) {
 		update_post_meta( $subscription->get_id(), '_subscription_switch_order_ids_cache', $switch_order_ids );

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -707,7 +707,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param array           $renewal_order_ids
 	 */
 	public function set_renewal_order_ids_cache( $subscription, $renewal_order_ids ) {
 		update_post_meta( $subscription->get_id(), '_subscription_renewal_order_ids_cache', $renewal_order_ids );

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -629,7 +629,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param string $date
 	 */
 	public function set_schedule_start( $subscription, $date ) {
 		update_post_meta( $subscription->get_id(), '_schedule_start', $date );
@@ -642,7 +642,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param string $date
 	 */
 	public function set_schedule_trial_end( $subscription, $date ) {
 		update_post_meta( $subscription->get_id(), '_schedule_trial_end', $date );
@@ -655,7 +655,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param string $date
 	 */
 	public function set_schedule_next_payment( $subscription, $date ) {
 		update_post_meta( $subscription->get_id(), '_schedule_next_payment', $date );
@@ -668,7 +668,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param string $date
 	 */
 	public function set_schedule_cancelled( $subscription, $date ) {
 		update_post_meta( $subscription->get_id(), '_schedule_cancelled', $date );
@@ -681,7 +681,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param string $date
 	 */
 	public function set_schedule_end( $subscription, $date ) {
 		update_post_meta( $subscription->get_id(), '_schedule_end', $date );
@@ -694,7 +694,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 * when backfilling subscription data to the WP_Post database.
 	 *
 	 * @param WC_Subscription $subscription
-	 * @param DateTime|string $date
+	 * @param string $date
 	 */
 	public function set_schedule_payment_retry( $subscription, $date ) {
 		update_post_meta( $subscription->get_id(), '_schedule_payment_retry', $date );

--- a/includes/emails/class-wcs-email-cancelled-subscription.php
+++ b/includes/emails/class-wcs-email-cancelled-subscription.php
@@ -83,7 +83,9 @@ class WCS_Email_Cancelled_Subscription extends WC_Email {
 			return;
 		}
 
-		update_post_meta( $subscription->get_id(), '_cancelled_email_sent', 'true' );
+		$subscription->set_cancelled_email_sent( 'true' );
+		$subscription->save();
+
 		$this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4572

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

With custom order tables (HPOS) and compatibility mode (data syncing) enabled, some subscription metadata is not correctly backfilled to the postmeta table, namely all of our `_schedule_{date_type}` meta and our `_subscription_{order_type}_order_ids_cache` meta. Here's a full list:

- `_schedule_start`
- `_schedule_trial_end`
- `_schedule_next_payment`
- `_schedule_cancelled`
- `_schedule_end`
- `_schedule_payment_retry`
- `_subscription_renewal_order_ids_cache`
- `_subscription_resubscribe_order_ids_cache`
- `_subscription_switch_order_ids_cache`

Here's a screenshot from `trunk` of the subscriptions meta in the WC orders meta and WP posts meta tables after a subscription is synced. Notice how the dates are set to 0 and notice how the cache meta is completely missing:

|`wp_wc_orders_meta`|`wp_postmeta`|
|:-----------------:|:-----------:|
|![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/0377721b-4b47-433d-9fcc-27417c43fb6d)|![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/f65d422c-bca3-4edc-9bd1-ab607ce65c8a)|

### Why is this meta not backfilled?
During the backfill process, the [`OrdersTableDataStore::backfill_post_record()`](https://github.com/woocommerce/woocommerce/blob/8d80436d45baf67d903e2efb672d57c77b890263/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L576) function calls `$post_order->set_props( $order->get_data() );` which gets all of the data stored on the order object and tries to call the setter methods for each prop. Because we don't have setters for our dates and cache metadata this data is not set.

There's a bit more to it related to [`Abstract_WC_Order_Data_Store_CPT->update_order_meta_from_object()`](https://github.com/woocommerce/woocommerce/blob/8d80436d45baf67d903e2efb672d57c77b890263/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php#L709) and `get_internal_data_store_key_getters()` but that's the crux of it 


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go **WC > Settings > Advanced > Features** and enable HPOS without compatibility mode
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/12a01378-7464-4b36-81ca-c025bbe60982)
2. Purchase a subscription product
3. Populate the renewal order IDs cache meta by processing a renewal order for this subscription
4. Open the HPOS settings again and enable compatibility mode and save the settings
5. If the sync process is slow to kick-off here are some steps to manually run it:
   1. Run the `wc_schedule_pending_batch_processes` pending scheduled action
   2. Then run the new `wc_run_batch_process` scheduled action
6. Open your DB and search `wp_postmeta` for the subscription ID
7. Confirm the dates and cache meta is correctly synced from `wc_orders_meta` to `wp_postmeta`![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/7202e0e1-a2dd-4a3d-b9c8-d75a129331b5)


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
