### PR TITLE
After processing an early renewal, make sure the suspension count meta is reset to 0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.5.0 - xxxx-xx-xx =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
 * Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.
+* Fix - When processing an early renewal order, make sure the suspension count is reset back to 0 on payment complete.
 * Dev - Introduce a new wcs_get_subscription_grouping_key() function to generate a unique key for a subscription based on its billing schedule. This function uses the existing recurring cart key concept.
 * Dev - Deprecate the WC_Subscriptions_Synchroniser::add_to_recurring_cart_key(). Use WC_Subscriptions_Synchroniser::add_to_recurring_product_grouping_key() instead.
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1778,7 +1778,12 @@ class WC_Subscription extends WC_Order {
 		// Add order note depending on initial payment
 		$this->add_order_note( __( 'Payment status marked complete.', 'woocommerce-subscriptions' ) );
 
-		$this->update_status( 'active' ); // also saves the subscription
+		// $this->update_status() only calls save if the status has changed.
+		if ( 'active' !== $this->get_status( 'edit' ) ) {
+			$this->update_status( 'active' );
+		} else {
+			$this->save();
+		}
 
 		do_action( 'woocommerce_subscription_payment_complete', $this );
 


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

In Woo Subscriptions we have a setting that limits the number of times a customer can suspend their subscription:
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/a10ce4ed-eb5a-4efd-abf6-0d17eb5dd096)

We store the number of times a subscription is suspended in meta `_suspension_count` and whenever we process a renewal order, we reset this count back to 0. While testing 4584-gh-woocommerce/woocommerce-subscriptions I noticed that early renewals do not reset the `_suspension_count` meta because even though inside `$subscription->payment_complete_for_order()` we're calling `$this->set_suspension_count( 0 );`, we never actually call `$subscription->save()`...

The issue is we relied on `$subscription->update_status( 'active' );` to call `save()` however this function only calls save if the status is actually updated and in the case of early renewals, the subscription status is not changed.

To fix this I've manually called save if we don't need to update the status of the subscription.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. From the **WC > Settings > Subscriptions** page, enable early renewals and update the Customer Suspensions setting to any number greater than 1.
2. Purchase an active subscription, then from the My Account > Subscriptions > view subscription, click on the  "Suspend" action.
3. Open the DB and confirm `_suspension_count` meta is `1`.
4. Reactivate the subscription and click on "Renew now" action.
5. After renewing the subscription early, check in the DB to confirm the `_suspension_count` has been reset to 0.
6. On `trunk` this number will remain 1, but on this branch it'll be reset back to 0.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
