### PR TITLE
Update the cart hash when paying for renewal orders on checkout block

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.6.0 - xxxx-xx-xx =
+* Fix - When using the checkout block to pay for renewal orders, ensure the order's cart hash is updated to make sure the existing order can be used.
+
 = 6.5.0 - 2023-11-09 =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
 * Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1609,16 +1609,18 @@ class WCS_Cart_Renewal {
 		 * this is the status check in DraftOrderTrait::is_valid_draft_order()) and the order doesn't have that status. Orders
 		 * which already have the checkout-draft status don't need to be updated to bypass the checkout block logic.
 		 */
-		if ( $has_status || ! $order || 'checkout-draft' !== $status ) {
+		if ( $has_status || 'checkout-draft' !== $status ) {
 			return $has_status;
 		}
 
-		$cart_order = $this->get_order();
-
 		// If the order being validated is the order in the cart, then we need to update the cart hash so it can be resumed.
-		if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
-			// Note: We need to pass the order object so the order instance WooCommerce uses will have the updated hash.
-			$this->set_cart_hash( $order );
+		if ( $order && $order->get_id() === (int) WC()->session->get( 'store_api_draft_order', 0 ) ) {
+			$cart_order = $this->get_order();
+
+			if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
+				// Note: We need to pass the order object so the order instance WooCommerce uses will have the updated hash.
+				$this->set_cart_hash( $order );
+			}
 		}
 
 		return $has_status;

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1609,26 +1609,16 @@ class WCS_Cart_Renewal {
 		 * this is the status check in DraftOrderTrait::is_valid_draft_order()) and the order doesn't have that status. Orders
 		 * which already have the checkout-draft status don't need to be updated to bypass the checkout block logic.
 		 */
-		if ( $has_status || 'checkout-draft' !== $status ) {
+		if ( $has_status || ! $order || 'checkout-draft' !== $status ) {
 			return $has_status;
 		}
 
-		/**
-		 * This function is only concerned with updating the order cart hash during REST API requests - which is the request
-		 * context where the Store API Checkout Block validates the order for payment resumption.
-		 */
-		if ( ! WC()->is_rest_api_request() ) {
-			return $has_status;
-		}
+		$cart_order = $this->get_order();
 
 		// If the order being validated is the order in the cart, then we need to update the cart hash so it can be resumed.
-		if ( $order && $order->get_id() === WC()->session->get( 'store_api_draft_order', 0 ) ) {
-			$cart_order = $this->get_order();
-
-			if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
-				// Note: We need to pass the order object so the order instance WooCommerce uses will have the updated hash.
-				$this->set_cart_hash( $order );
-			}
+		if ( $cart_order && $cart_order->get_id() === $order->get_id() ) {
+			// Note: We need to pass the order object so the order instance WooCommerce uses will have the updated hash.
+			$this->set_cart_hash( $order );
 		}
 
 		return $has_status;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4592

## Description

When paying for a renewal orders via the block checkout there's still a bug that can cause new orders to be created and those orders aren't associated with any subscription. 

From testing I discovered that this occurs because the WC core function that determines if a new order needs to be created, it calls (`is_valid_draft_order()`), inside that function is a `$order->has_status( 'checkout-draft' )` and then a cart hash check. 

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/498 we attempted to fix this by introducing a new function hooked into that checkout-draft check to make sure it would update the cart hash prior to the cart hash check, however that function had additional logic to target the very specific flow. That logic included a `is_rest_api` check and a check on whether a session variable matches the orders ID. 

Both those checks failed, that caused the cart hash to not update and resulted in an new order being created. 

This PR fixes that by making removing those stricter checks.

However, this effectively means that any `has_status( 'checkout-draft' )` will attempt to check if the cart contains a renewal order that matches the order being checked. 

I'm sure how we can make this logic tighter. 

## How to test this PR

I'm not entirely sure what causes the cart hash to be mismatched so I've included all the things I think may be relevant, some may not be. 


1. Enable shipping and taxes.
2. Create a block checkout page.
3. Add shipping methods for different zones. eg free shipping for x country and flat rate for another country.
4. Purchase any subscription product. 
5. Go to the edit subscription screen and create a pending renewal order.
6. Attempt to pay for the renewal order via the block checkout. 
   8. On trunk you'll notice that a new order is created and its unlinked to a subscription.
   9. On this branch the paid order ID should match the one you created in step 5 and it should be linked to a renewal order. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
