### PR TITLE
Prevents a PHP fatal error that occurs when the cart contains a renewal order item that no longer exists

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.6.0 - 2023-xx-xx =
+* Fix - Prevents a PHP fatal error that occurs when the cart contains a renewal order item that no longer exists.
+
 = 6.5.0 - 2023-11-09 =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.
 * Fix - When a subscription is flagged as requiring manual payments, allow admin users to turn on automatic payments for a subscription via the Edit Subscription page by selecting a new payment method.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -427,6 +427,7 @@ class WCS_Cart_Renewal {
 
 			if ( $subscription ) {
 				$subscription_items = $subscription->get_items();
+				$item_to_renew      = [];
 
 				/**
 				 * Find the subscription or order line item that represents this cart item.
@@ -444,6 +445,11 @@ class WCS_Cart_Renewal {
 						}
 					}
 				}
+
+				// If we can't find the item to renew, return the cart item session data as is.
+				// if ( empty( $item_to_renew ) ) {
+				// 	return $cart_item_session_data;
+				// }
 
 				$price = $item_to_renew['line_subtotal'];
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -447,9 +447,9 @@ class WCS_Cart_Renewal {
 				}
 
 				// If we can't find the item to renew, return the cart item session data as is.
-				// if ( empty( $item_to_renew ) ) {
-				// 	return $cart_item_session_data;
-				// }
+				if ( empty( $item_to_renew ) ) {
+					return $cart_item_session_data;
+				}
 
 				$price = $item_to_renew['line_subtotal'];
 


### PR DESCRIPTION
Fixes #537 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Inside subscriptions we have code that makes sure that if a cart contains a renewal item, we should make sure we're honoring the price of the subscription/renewal order and not the new price if it's been updated etc.

When the cart contains an item that no longer exists on the order, we get the following fatal errors that occur:

```
[20-Nov-2023 05:57:18 UTC] PHP Warning:  Undefined array key "line_subtotal" in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wcs-cart-renewal.php on line 454
[20-Nov-2023 05:57:18 UTC] PHP Warning:  Undefined array key "taxes" in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wcs-cart-renewal.php on line 469
[20-Nov-2023 05:57:18 UTC] PHP Warning:  Trying to access array offset on value of type null in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wcs-cart-renewal.php on line 469
[20-Nov-2023 05:57:18 UTC] PHP Fatal error:  Uncaught TypeError: array_sum(): Argument #1 ($array) must be of type array, null given in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wcs-cart-renewal.php:469
Stack trace:
#0 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wcs-cart-renewal.php(469): array_sum(NULL)
#1 /Users/matt/local/woo/wp-includes/class-wp-hook.php(310): WCS_Cart_Renewal->get_cart_item_from_session(Array, Array, 'e4097d961260a5e...')
#2 /Users/matt/local/woo/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#3 /Users/matt/local/woo/wp-content/plugins/woocommerce/includes/class-wc-cart-session.php(206): apply_filters('woocommerce_get...', Array, Array, 'e4097d961260a5e...')
#4 /Users/matt/local/woo/wp-includes/class-wp-hook.php(310): WC_Cart_Session->get_cart_from_session('')
#5 /Users/matt/local/woo/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters(NULL, Array)
#6 /Users/matt/local/woo/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#7 /Users/matt/local/woo/wp-settings.php(654): do_action('wp_loaded')
#8 /Users/matt/local/woo/wp-config.php(101): require_once('/Users/matt/loc...')
#9 /Users/matt/local/woo/wp-load.php(50): require_once('/Users/matt/loc...')
#10 /Users/matt/local/woo/wp-admin/admin-ajax.php(22): require_once('/Users/matt/loc...')
#11 /Users/matt/.composer/vendor/laravel/valet/server.php(110): require('/Users/matt/loc...')
#12 {main}
```

This PR fixes this issue by making sure we're only honoring subscription prices on cart items that still belong to the order/subscription. If the cart item cannot be found on the order, we simply return the default.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Purchase a subscription product to create a subscription
2. Process a pending renewal order using the drop-down actions
3. Go to **My Account > Subscriptions** and click on the **Pay** button next to the pending order to add it to you cart
4. Go to the **WP Admin > WC > Orders** and find the new pending order
5. Delete the order item and save the order.
6. While on `trunk` if you refresh the page and you should see the above fatal errors

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
