### PR TITLE
Fix issues with sorting the subscriptions list table on HPOS enabled sites

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.6.0 - xxxx-xx-xx =
 * Fix - When using the checkout block to pay for renewal orders, ensure the order's cart hash is updated to make sure the existing order can be used.
 * Fix - Prevents a PHP fatal error that occurs when the cart contains a renewal order item that no longer exists.
+* Fix - Resolved an issue that caused ordering the Admin Subscriptions List Table to not work when HPOS is enabled.
 
 = 6.5.0 - 2023-11-09 =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1790,8 +1790,6 @@ class WCS_Admin_Post_Types {
 	 *  - High performance: This method uses a temporary table to store the last payment date for each subscription.
 	 *  - Low performance: This method uses a subquery to get the last payment date for each subscription.
 	 *
-	 * This function is the lower performance method and is a HPOS version of @see self::posts_clauses_low_performance().
-	 *
 	 * @param string[]         $pieces Associative array of the clauses for the query.
 	 * @param OrdersTableQuery $query  The query object.
 	 * @param array            $args   Query args.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1850,7 +1850,7 @@ class WCS_Admin_Post_Types {
 	/**
 	 * Adds Order table query clauses to order the subscriptions list table by last payment date.
 	 *
-	 * This function is the high performance method and is a HPOS version of @see self::orders_table_clauses_high_performance().
+	 * This function is the high performance method and is a HPOS version of @see self::posts_clauses_high_performance().
 	 *
 	 * @param string[] $pieces Associative array of the clauses for the query.
 	 * @return string[] $pieces

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1821,12 +1821,13 @@ class WCS_Admin_Post_Types {
 	}
 
 	/**
-	 * Adds Order table query clauses to order the subscriptions list table by last payment date.
+	 * Adds order table query clauses to sort the subscriptions list table by last payment date.
 	 *
-	 * This function is the lower performance method and is a HPOS version of @see self::posts_clauses_low_performance().
+	 * This function provides a lower performance method using a subquery to sort by last payment date.
+	 * It is a HPOS version of @see self::posts_clauses_low_performance().
 	 *
 	 * @param string[] $pieces Associative array of the clauses for the query.
-	 * @return string[] $pieces
+	 * @return string[] $pieces Updated associative array of clauses for the query.
 	 */
 	private function orders_table_clauses_low_performance( $pieces ) {
 		$order_datastore = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::class );
@@ -1848,12 +1849,13 @@ class WCS_Admin_Post_Types {
 	}
 
 	/**
-	 * Adds Order table query clauses to order the subscriptions list table by last payment date.
+	 * Adds order table query clauses to sort the subscriptions list table by last payment date.
 	 *
-	 * This function is the high performance method and is a HPOS version of @see self::posts_clauses_high_performance().
+	 * This function provides a higher performance method using a temporary table to sort by last payment date.
+	 * It is a HPOS version of @see self::posts_clauses_high_performance().
 	 *
 	 * @param string[] $pieces Associative array of the clauses for the query.
-	 * @return string[] $pieces
+	 * @return string[] $pieces Updated associative array of clauses for the query.
 	 */
 	private function orders_table_clauses_high_performance( $pieces ) {
 		global $wpdb;

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -204,7 +204,6 @@ class WCS_Admin_Post_Types {
 		return $pieces;
 	}
 
-
 	/**
 	 * Displays the dropdown for the product filter
 	 *
@@ -880,6 +879,7 @@ class WCS_Admin_Post_Types {
 		$request_query = $this->set_filter_by_customer_query( $request_query );
 		$request_query = $this->set_filter_by_product_query( $request_query );
 		$request_query = $this->set_filter_by_payment_method_query( $request_query );
+		$request_query = $this->set_order_by_query_args( $request_query );
 
 		return $request_query;
 	}
@@ -1016,6 +1016,36 @@ class WCS_Admin_Post_Types {
 			];
 		} else {
 			$request_query['payment_method'] = $payment_method;
+		}
+
+		return $request_query;
+	}
+
+	/**
+	 * Sets the order by query args for the subscriptions list table request on HPOS enabled sites.
+	 *
+	 * This function is similar to the posts table equivalent function (self::request_query()) except it only sets the order by.
+	 *
+	 * @param array $request_query The query args sent to wc_get_orders() to populate the list table.
+	 * @return array $request_query
+	 */
+	private function set_order_by_query_args( $request_query ) {
+
+		if ( ! isset( $request_query['orderby'] ) ) {
+			return $request_query;
+		}
+
+		switch ( $request_query['orderby'] ) {
+			case 'last_payment_date':
+				add_filter( 'woocommerce_orders_table_query_clauses', [ $this, 'orders_table_query_clauses' ], 10, 3 );
+				break;
+			case 'start_date':
+			case 'trial_end_date':
+			case 'next_payment_date':
+			case 'end_date':
+				$request_query['meta_key'] = sprintf( '_schedule_%s', str_replace( '_date', '', $request_query['orderby'] ) );
+				$request_query['orderby']  = 'meta_value';
+				break;
 		}
 
 		return $request_query;
@@ -1751,5 +1781,104 @@ class WCS_Admin_Post_Types {
 			} );
 		</script>
 		<?php
+	}
+
+	/**
+	 * Adds Order table query clauses to order the subscriptions list table by last payment date.
+	 *
+	 * There are 2 methods we use to order the subscriptions list table by last payment date:
+	 *  - High performance: This method uses a temporary table to store the last payment date for each subscription.
+	 *  - Low performance: This method uses a subquery to get the last payment date for each subscription.
+	 *
+	 * This function is the lower performance method and is a HPOS version of @see self::posts_clauses_low_performance().
+	 *
+	 * @param string[]         $pieces Associative array of the clauses for the query.
+	 * @param OrdersTableQuery $query  The query object.
+	 * @param array            $args   Query args.
+	 *
+	 * @return string[] $pieces Associative array of the clauses for the query.
+	 */
+	public function orders_table_query_clauses( $pieces, $query, $args ) {
+
+		if ( ! is_admin() || ! isset( $args['type'] ) || 'shop_subscription' !== $args['type']  ) {
+			return $pieces;
+		}
+
+		// Let's check whether we even have the privileges to do the things we want to do
+		if ( $this->is_db_user_privileged() ) {
+			$pieces = self::orders_table_clauses_high_performance( $pieces );
+		} else {
+			$pieces = self::orders_table_clauses_low_performance( $pieces );
+		}
+
+		$query_order = strtoupper( $args['order'] );
+
+		// fields and order are identical in both cases
+		$pieces['fields'] .= ', COALESCE(lp.last_payment, orders.date_created_gmt, 0) as lp';
+		$pieces['orderby'] = "CAST(lp AS DATETIME) {$query_order}";
+
+		return $pieces;
+	}
+
+	/**
+	 * Adds Order table query clauses to order the subscriptions list table by last payment date.
+	 *
+	 * This function is the lower performance method and is a HPOS version of @see self::posts_clauses_low_performance().
+	 *
+	 * @param string[] $pieces Associative array of the clauses for the query.
+	 * @return string[] $pieces
+	 */
+	private function orders_table_clauses_low_performance( $pieces ) {
+		$order_datastore = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::class );
+		$order_table     = $order_datastore::get_orders_table_name();
+		$meta_table      = $order_datastore::get_meta_table_name();
+
+		$pieces['join'] .= "LEFT JOIN
+				(SELECT
+					MAX( orders.date_created_gmt ) as last_payment,
+					order_meta.meta_value
+				FROM {$meta_table} as order_meta
+				LEFT JOIN {$order_table} orders ON orders.id = order_meta.order_id
+				WHERE order_meta.meta_key = '_subscription_renewal'
+				GROUP BY order_meta.meta_value) lp
+			ON {$order_table}.id = lp.meta_value
+			LEFT JOIN {$order_table} orders on {$order_table}.parent_order_id = orders.ID";
+
+		return $pieces;
+	}
+
+	/**
+	 * Adds Order table query clauses to order the subscriptions list table by last payment date.
+	 *
+	 * This function is the high performance method and is a HPOS version of @see self::orders_table_clauses_high_performance().
+	 *
+	 * @param string[] $pieces Associative array of the clauses for the query.
+	 * @return string[] $pieces
+	 */
+	private function orders_table_clauses_high_performance( $pieces ) {
+		global $wpdb;
+
+		$order_datastore = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::class );
+		$order_table     = $order_datastore::get_orders_table_name();
+		$meta_table      = $order_datastore::get_meta_table_name();
+		$session         = wp_get_session_token();
+
+		$table_name = substr( "{$wpdb->prefix}tmp_{$session}_lastpayment", 0, 64 );
+
+		// Create a temporary table, drop the previous one.
+		$wpdb->query( "DROP TEMPORARY TABLE IF EXISTS {$table_name}" );
+
+		$wpdb->query(
+			"CREATE TEMPORARY TABLE {$table_name} (id INT PRIMARY KEY, last_payment DATETIME) AS
+			 SELECT order_meta.meta_value as id, MAX( orders.date_created_gmt ) as last_payment FROM {$meta_table} order_meta
+			 LEFT JOIN {$order_table} as orders ON orders.id = order_meta.order_id
+			 WHERE order_meta.meta_key = '_subscription_renewal'
+			 GROUP BY order_meta.meta_value" );
+
+		$pieces['join'] .= "LEFT JOIN {$table_name} lp
+			ON {$order_table}.id = lp.id
+			LEFT JOIN {$order_table} orders on {$order_table}.parent_order_id = orders.id";
+
+		return $pieces;
 	}
 }

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1866,7 +1866,7 @@ class WCS_Admin_Post_Types {
 		$table_name = substr( "{$wpdb->prefix}tmp_{$session}_lastpayment", 0, 64 );
 
 		// Create a temporary table, drop the previous one.
-		$wpdb->query( $wpdb->prepare( "DROP TEMPORARY TABLE IF EXISTS %s", $table_name ) );
+		$wpdb->query( $wpdb->prepare( 'DROP TEMPORARY TABLE IF EXISTS %s', $table_name ) );
 
 		$wpdb->query(
 			$wpdb->prepare(
@@ -1874,11 +1874,11 @@ class WCS_Admin_Post_Types {
 				SELECT order_meta.meta_value as id, MAX( orders.date_created_gmt ) as last_payment FROM %s order_meta
 				LEFT JOIN %s as orders ON orders.id = order_meta.order_id
 				WHERE order_meta.meta_key = '_subscription_renewal'
-				GROUP BY order_meta.meta_value"
-			),
-			$table_name,
-			$meta_table,
-			$order_table
+				GROUP BY order_meta.meta_value",
+				$table_name,
+				$meta_table,
+				$order_table
+			)
 		);
 
 		$pieces['join'] .= "LEFT JOIN {$table_name} lp


### PR DESCRIPTION
Fixes #200 
Fixes #471 

## Description

On HPOS enabled sites, filtering the subscriptions list table by the subscription's next payment, start, end, trial end, or last payment date all failed to correctly sort the table. 

This originally required changes to WC core to fix, however with https://github.com/woocommerce/woocommerce/pull/36403 merged and released for some time, ordering the list table by meta value is now possible. 

This PR makes use of those changes in WC to make sure we format the meta query args to ensure the list table is sorted by those meta values. Specially making sure we set the `meta_key` and `meta_value` order by properties. 

eg: 

```php
array (
    ['limit'] => 20
    ['page'] => 1
    ['paginate'] => 1
    ['type'] => 'shop_subscription'
    ['orderby'] => 'meta_value' // <-- 
    ['order'] => 'DESC'
    ['meta_key'] => '_schedule_next_payment' // <--
)
```

## How to test this PR

1. Enable HPOS if it's not already enabled.
2. Purchase a couple of subscriptions with various properties, end dates, varying next payment dates.
3. Go to the admin subscriptions list table and order the list table by any of the columns.
   - eg next payment dates, end dates, last payment dates.
4. On `trunk` you'll notice the table isn't correctly ordered.
5. On this branch all ordering should work as expected. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
