### PR TITLE
Properly migrate subscription dates from postmeta to wc_orders_meta to fix syncing issues and prevent infinite `order.updated` webhooks being sent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.6.0 - xxxx-xx-xx =
 * Fix - When using the checkout block to pay for renewal orders, ensure the order's cart hash is updated to make sure the existing order can be used.
 * Fix - Prevents a PHP fatal error that occurs when the cart contains a renewal order item that no longer exists.
+* Fix - When HPOS is enabled and data compatibilty mode is turned on, make sure subscription date changes made to postmeta are synced to orders_meta table.
 
 = 6.5.0 - 2023-11-09 =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -950,8 +950,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule trial end date.
 	 *
-	 * This function should not be used. It only exists to support setting the start date on subscription creation without
-	 * having to call update_dates() which results in a save.
+	 * This function should not be used. It only exists to support setting the trial end date prop from the data store.
 	 *
 	 * @param string $schedule_trial_end
 	 */
@@ -962,8 +961,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule next payment date.
 	 *
-	 * This function should not be used. It only exists to support setting the start date on subscription creation without
-	 * having to call update_dates() which results in a save.
+	 * This function should not be used. It only exists to support setting the next payment date prop from the data store.
 	 *
 	 * @param string $schedule_next_payment
 	 */
@@ -974,8 +972,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule cancelled date.
 	 *
-	 * This function should not be used. It only exists to support setting the start date on subscription creation without
-	 * having to call update_dates() which results in a save.
+	 * This function should not be used. It only exists to support setting the cancelled end date prop from the data store.
 	 *
 	 * @param string $schedule_cancelled
 	 */
@@ -986,8 +983,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule end date.
 	 *
-	 * This function should not be used. It only exists to support setting the start date on subscription creation without
-	 * having to call update_dates() which results in a save.
+	 * This function should not be used. It only exists to support setting the end end date prop from the data store.
 	 *
 	 * @param string $schedule_end
 	 */
@@ -998,8 +994,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule payment retry date.
 	 *
-	 * This function should not be used. It only exists to support setting the start date on subscription creation without
-	 * having to call update_dates() which results in a save.
+	 * This function should not be used. It only exists to support setting the payment retry date prop from the data store.
 	 *
 	 * @param string $schedule_payment_retry
 	 */

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -948,6 +948,66 @@ class WC_Subscription extends WC_Order {
 	}
 
 	/**
+	 * Set schedule trial end date.
+	 *
+	 * This function should not be used. It only exists to support setting the start date on subscription creation without
+	 * having to call update_dates() which results in a save.
+	 *
+	 * @param string $schedule_trial_end
+	 */
+	public function set_trial_end_date( $schedule_trial_end ) {
+		$this->set_prop( 'schedule_trial_end', $schedule_trial_end );
+	}
+
+	/**
+	 * Set schedule next payment date.
+	 *
+	 * This function should not be used. It only exists to support setting the start date on subscription creation without
+	 * having to call update_dates() which results in a save.
+	 *
+	 * @param string $schedule_next_payment
+	 */
+	public function set_next_payment_date( $schedule_next_payment ) {
+		$this->set_prop( 'schedule_next_payment', $schedule_next_payment );
+	}
+
+	/**
+	 * Set schedule cancelled date.
+	 *
+	 * This function should not be used. It only exists to support setting the start date on subscription creation without
+	 * having to call update_dates() which results in a save.
+	 *
+	 * @param string $schedule_cancelled
+	 */
+	public function set_cancelled_date( $schedule_cancelled ) {
+		$this->set_prop( 'schedule_cancelled', $schedule_cancelled );
+	}
+
+	/**
+	 * Set schedule end date.
+	 *
+	 * This function should not be used. It only exists to support setting the start date on subscription creation without
+	 * having to call update_dates() which results in a save.
+	 *
+	 * @param string $schedule_end
+	 */
+	public function set_end_date( $schedule_end ) {
+		$this->set_prop( 'schedule_end', $schedule_end );
+	}
+
+	/**
+	 * Set schedule payment retry date.
+	 *
+	 * This function should not be used. It only exists to support setting the start date on subscription creation without
+	 * having to call update_dates() which results in a save.
+	 *
+	 * @param string $schedule_payment_retry
+	 */
+	public function set_payment_retry_date( $schedule_payment_retry ) {
+		$this->set_prop( 'schedule_payment_retry', $schedule_payment_retry );
+	}
+
+	/**
 	 * Set parent order ID. We don't use WC_Abstract_Order::set_parent_id() because we want to allow false
 	 * parent IDs, like 0.
 	 *

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -950,7 +950,11 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule trial end date.
 	 *
-	 * This function should not be used. It only exists to support setting the trial end date prop from the data store.
+	 * Note: This function is intended for internal use only and should not be accessed directly.
+	 * It only exists to support setting the trial end date prop from the data store.
+	 * Calling this function does not automatically schedule the trial end date as a Scheduled Action.
+	 *
+	 * Use WC_Subscription::update_dates() instead.
 	 *
 	 * @param string $schedule_trial_end
 	 */
@@ -961,7 +965,11 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule next payment date.
 	 *
-	 * This function should not be used. It only exists to support setting the next payment date prop from the data store.
+	 * Note: This function is intended for internal use only and should not be accessed directly.
+	 * It only exists to support setting the next payment date prop from the data store.
+	 * Calling this function does not automatically schedule the next payment date as a Scheduled Action.
+	 *
+	 * Use WC_Subscription::update_dates() instead.
 	 *
 	 * @param string $schedule_next_payment
 	 */
@@ -972,7 +980,10 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule cancelled date.
 	 *
-	 * This function should not be used. It only exists to support setting the cancelled end date prop from the data store.
+	 * Note: This function is intended for internal use only and should not be accessed directly.
+	 * It only exists to support setting the cancelled date prop from the data store.
+	 *
+	 * Use WC_Subscription::update_dates() instead.
 	 *
 	 * @param string $schedule_cancelled
 	 */
@@ -983,7 +994,11 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule end date.
 	 *
-	 * This function should not be used. It only exists to support setting the end end date prop from the data store.
+	 * Note: This function is intended for internal use only and should not be accessed directly.
+	 * It only exists to support setting the end date prop from the data store.
+	 * Calling this function does not automatically schedule the end date as a Scheduled Action.
+	 *
+	 * Use WC_Subscription::update_dates() instead.
 	 *
 	 * @param string $schedule_end
 	 */
@@ -994,7 +1009,11 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Set schedule payment retry date.
 	 *
-	 * This function should not be used. It only exists to support setting the payment retry date prop from the data store.
+	 * Note: This function is intended for internal use only and should not be accessed directly.
+	 * It only exists to support setting the payment retry date prop from the data store.
+	 * Calling this function does not automatically schedule the payment retry date as a Scheduled Action.
+	 *
+	 * Use WC_Subscription::update_dates() instead.
 	 *
 	 * @param string $schedule_payment_retry
 	 */

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -990,4 +990,70 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	public function get_switch_order_ids_cache( $subscription ) {
 		return $subscription->get_meta( '_subscription_switch_order_ids_cache' );
 	}
+
+	/**
+	 * Sets the subscription's start date prop.
+	 * Called by @see OrdersTableDataStore::set_order_prop() when syncing/migrating internal meta key data.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $date         The date to set.
+	 */
+	public function set_schedule_start( $subscription, $date ) {
+		$subscription->set_start_date( $date );
+	}
+
+	/**
+	 * Sets the subscription's trial end date prop.
+	 * Called by @see OrdersTableDataStore::set_order_prop() when syncing/migrating internal meta key data.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $date         The date to set.
+	 */
+	public function set_schedule_trial_end( $subscription, $date ) {
+		$subscription->set_trial_end_date( $date );
+	}
+
+	/**
+	 * Sets the subscription's next payment date prop.
+	 * Called by @see OrdersTableDataStore::set_order_prop() when syncing/migrating internal meta key data.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $date         The date to set.
+	 */
+	public function set_schedule_next_payment( $subscription, $date ) {
+		$subscription->set_next_payment_date( $date );
+	}
+
+	/**
+	 * Sets the subscription's cancelled date prop.
+	 * Called by @see OrdersTableDataStore::set_order_prop() when syncing/migrating internal meta key data.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $date         The date to set.
+	 */
+	public function set_schedule_cancelled( $subscription, $date ) {
+		$subscription->set_cancelled_date( $date );
+	}
+
+	/**
+	 * Sets the subscription's end date prop.
+	 * Called by @see OrdersTableDataStore::set_order_prop() when syncing/migrating internal meta key data.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $date         The date to set.
+	 */
+	public function set_schedule_end( $subscription, $date ) {
+		$subscription->set_end_date( $date );
+	}
+
+	/**
+	 * Sets the subscription's payment retry date prop.
+	 * Called by @see OrdersTableDataStore::set_order_prop() when syncing/migrating internal meta key data.
+	 *
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $date         The date to set.
+	 */
+	public function set_schedule_payment_retry( $subscription, $date ) {
+		$subscription->set_payment_retry_date( $date );
+	}
 }


### PR DESCRIPTION
Fixes #547 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR is fixing an issue where trying to sync/migrate our `_scheduled_{date_type}` metadata from the `wp_postmeta` table over to HPOS `wc_orders_meta` table does not work and results in a continuously attempting to sync subscription data each time it's read into memory.

This issue severely impacts stores that are using the `order.updated` webhook because when building the webhook payload, a subscription object is read into memory, attempts to sync data and fails, which then results in a new webhook payload being scheduled. Because the subscription remains out of the sync, the next webhook payload will repeat the same process resulting in an infinite loop of the `order.updated` webhook being sent.

---


When WooCommerce attempts to sync/migrate postmeta over to the orders_meta table, it calls [`migrate_post_record()`](https://github.com/woocommerce/woocommerce/blob/d57b9e1d05ab66849c31dba338d2937647ad2735/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1436) which uses two methods to sync the data:
1. `migrate_meta_data_from_post_order()`, and
2. `set_order_prop()`

The first method calls [`OrdersTableDataStore::get_diff_meta_data_between_orders( $order, $post_order )`](https://github.com/woocommerce/woocommerce/blob/d57b9e1d05ab66849c31dba338d2937647ad2735/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1368) which returns an array of meta keys/value that are different between the two objects. This function strictly [ignores any meta that is listed in `$internal_meta_keys`](https://github.com/woocommerce/woocommerce/blob/d57b9e1d05ab66849c31dba338d2937647ad2735/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1376) which means the following subscription meta won't be synced by this function:

- `_billing_period`
- `_billing_interval`
- `_suspension_count`
- `_cancelled_email_sent`
- `_requires_manual_renewal`
- `_trial_period`
- `_schedule_trial_end`
- `_schedule_next_payment`
- `_schedule_cancelled`
- `_schedule_end`
- `_schedule_payment_retry`
- `_schedule_start`
- `_subscription_switch_data`

The second method [`set_order_prop()`](https://github.com/woocommerce/woocommerce/blob/d57b9e1d05ab66849c31dba338d2937647ad2735/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L1500-L1508) attempts to call `$subscription->set_{meta_key}()` and then tries `WCS_Orders_Table_Subscription_Data_Store->set_{meta_key}()` to sync meta.

Out of the above internal meta keys, the only meta keys that don't have setters are:

- `_schedule_trial_end`
- `_schedule_next_payment`
- `_schedule_cancelled`
- `_schedule_end`
- `_schedule_payment_retry`
- `_schedule_start`

Given this, the solution I've opted to go with in this PR is to add these setters.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Get into the infinite loop

1. Check out `trunk` of this repo.
2. Install the latest Woo and enable HPOS with syncing enabled.
3. Open `https://public.requestbin.com/r` and spin up a fresh endpoint to send webhooks to
4. Go to **WC > Settings > Advanced > Webhooks** and create an `order.updated` webhook
6. Purchase a subscription product
7. Inside the `wc_orders_meta` table, search for the subscription ID and delete the value stored next to `_schedule_next_payment` (can be any other date value)
8. Trigger the `order.updated` event for the parent order for this subscription by running something like:

```
$parent_order = wc_get_order( 123 );
$parent_order->save();
```

9. Visit Tools > Action Scheduler and manually run the `woocommerce_deliver_webhook_async` action for the parent order.
10. Notice that after running the action, another `woocommerce_deliver_webhook_async` for the same parent order is scheduled.
11. Check the `wc_orders_meta` table and confirm the `_schedule_next_payment` is still empty.
12. Keep running the webhook action and notice it's creating a new webhook to be sent off again.

#### Confirm the fix

1. Checkout this branch
2. Re-run `woocommerce_deliver_webhook_async` again
3. Notice a new async webhook event is not longer scheduled
4. Check the `wc_orders_meta` table and confirm the `_schedule_next_payment` has been synced/migrated from the postmeta table


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
