### PR TITLE
Catch exceptions thrown and caught by WC during subscription-related scheduled actions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.7.0 - 2024-xx-xx =
 * Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.
+* Update - Log all exceptions caught by WooCommerce while processing a subscription scheduled action.
 
 = 6.6.0 - 2023-12-20 =
 * Fix - When using the checkout block to pay for renewal orders, ensure the order's cart hash is updated to make sure the existing order can be used.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,13 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.7.0 - 2024-xx-xx =
+* Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.
+
 = 6.6.0 - 2023-12-20 =
 * Fix - When using the checkout block to pay for renewal orders, ensure the order's cart hash is updated to make sure the existing order can be used.
 * Fix - Prevents a PHP fatal error that occurs when the cart contains a renewal order item that no longer exists.
 * Fix - When HPOS is enabled and data compatibility mode is turned on, make sure subscription date changes made to postmeta are synced to orders_meta table.
 * Fix - Resolved an issue that would cause undefined $current_page, $max_num_pages, and $paginate variable errors when viewing a page with the subscriptions-shortcode.
-* Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.
 
 = 6.5.0 - 2023-11-09 =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -145,8 +145,8 @@ class WC_Subscriptions_Manager {
 				$renewal_order = wcs_create_renewal_order( $subscription );
 
 				if ( is_wp_error( $renewal_order ) ) {
-					// translators: placeholder is an order note.
-					throw new Exception( sprintf( __( 'Error: Unable to create renewal order with note "%s"', 'woocommerce-subscriptions' ), $order_note ) );
+					// translators: placeholder %1 is an order note. %2 is the error message that was thrown.
+					throw new Exception( sprintf( __( 'Error: Unable to create renewal order with note "%1$s". Message: %2$s', 'woocommerce-subscriptions' ), $order_note, $renewal_order->get_error_message() ) );
 				}
 			}
 

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -124,7 +124,7 @@ class WCS_Failed_Scheduled_Action_Manager {
 			}
 
 			// Now that we've logged the exceptions, we can detach the exception listener.
-			$this->clear_exceptions();
+			$this->clear_exceptions_and_detach_listener();
 		}
 	}
 
@@ -140,8 +140,10 @@ class WCS_Failed_Scheduled_Action_Manager {
 			return;
 		}
 
-		// Add an action to detach the exception listener after the scheduled action has been executed.
-		add_action( 'action_scheduler_after_execute', [ $this, 'clear_exceptions' ] );
+		// Add an action to detach the exception listener and clear the caught exceptions after the scheduled action has been executed.
+		add_action( 'action_scheduler_after_execute', [ $this, 'clear_exceptions_and_detach_listener' ] );
+
+		// Attach the exception listener.
 		add_action( 'woocommerce_caught_exception', [ $this, 'handle_exception' ] );
 	}
 
@@ -155,12 +157,13 @@ class WCS_Failed_Scheduled_Action_Manager {
 	}
 
 	/**
-	 * Decommissions the current exception listener.
+	 * Clears the list of exceptions caught by WC and detaches the listener.
 	 *
 	 * This function is attached to an action that runs after a scheduled action has finished being executed.
 	 */
-	public function clear_exceptions() {
+	public function clear_exceptions_and_detach_listener() {
 		$this->exceptions = [];
+		remove_action( 'action_scheduler_after_execute', [ $this, 'handle_exception' ] );
 	}
 
 	/**

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -159,11 +159,11 @@ class WCS_Failed_Scheduled_Action_Manager {
 	/**
 	 * Clears the list of exceptions caught by WC and detaches the listener.
 	 *
-	 * This function is attached to an action that runs after a scheduled action has finished being executed.
+	 * This function is called directly and attached to an action that runs after a scheduled action has finished being executed.
 	 */
 	public function clear_exceptions_and_detach_listener() {
 		$this->exceptions = [];
-		remove_action( 'action_scheduler_after_execute', [ $this, 'handle_exception' ] );
+		remove_action( 'woocommerce_caught_exception', [ $this, 'handle_exception' ] );
 	}
 
 	/**

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -35,6 +35,13 @@ class WCS_Failed_Scheduled_Action_Manager {
 	protected $logger;
 
 	/**
+	 * Exceptions caught by WC while this class is listening to the `woocommerce_caught_exception` action.
+	 *
+	 * @var Exception[]
+	 */
+	protected $exceptions = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WC_Logger_Interface $logger The WC Logger instance.
@@ -55,6 +62,7 @@ class WCS_Failed_Scheduled_Action_Manager {
 		add_action( 'action_scheduler_failed_execution', array( $this, 'log_action_scheduler_failure' ), 10, 2 );
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_action_scheduler_failure' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'maybe_show_admin_notice' ) );
+		add_action( 'action_scheduler_begin_execute', array( $this, 'maybe_attach_exception_listener' ) );
 	}
 
 	/**
@@ -106,6 +114,53 @@ class WCS_Failed_Scheduled_Action_Manager {
 		);
 
 		update_option( WC_Subscriptions_Admin::$option_prefix . '_failed_scheduled_actions', $failed_scheduled_actions );
+
+		// If there is an exception listener and it's caught exceptions, log them for additional debugging.
+		if ( ! empty( $this->exceptions ) ) {
+			foreach ( $this->exceptions as $exception ) {
+				$message = 'Exception: ' . $exception->getMessage() . ' in ' . $exception->getFile() . ':' . $exception->getLine();
+				$this->log( $message . PHP_EOL . $exception->getTraceAsString() );
+				ActionScheduler_Logger::instance()->log( $action_id, $message );
+			}
+
+			// Now that we've logged the exceptions, we can detach the exception listener.
+			$this->clear_exceptions();
+		}
+	}
+
+	/**
+	 * Creates a new exception listener when processing subscription-related scheduled actions.
+	 *
+	 * @param int $action_id The ID of the scheduled action being ran.
+	 */
+	public function maybe_attach_exception_listener( $action_id ) {
+		$action = $this->get_action( $action_id );
+
+		if ( ! $action || ! isset( $this->tracked_scheduled_actions[ $action->get_hook() ] ) ) {
+			return;
+		}
+
+		// Add an action to detach the exception listener after the scheduled action has been executed.
+		add_action( 'action_scheduler_after_execute', [ $this, 'clear_exceptions' ] );
+		add_action( 'woocommerce_caught_exception', [ $this, 'handle_exception' ] );
+	}
+
+	/**
+	 * Adds an exception to the list of exceptions caught by WC.
+	 *
+	 * @param Exception $exception The exception that was caught.
+	 */
+	public function handle_exception( $exception ) {
+		$this->exceptions[] = $exception;
+	}
+
+	/**
+	 * Decommissions the current exception listener.
+	 *
+	 * This function is attached to an action that runs after a scheduled action has finished being executed.
+	 */
+	public function clear_exceptions() {
+		$this->exceptions = [];
 	}
 
 	/**

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -218,6 +218,13 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		// Delete the transient that caches whether the order needs processing. Because we've added line items, the order may now need processing.
 		delete_transient( 'wc_order_' . $new_order->get_id() . '_needs_processing' );
 
+		$order = wc_get_order( $new_order->get_id() );
+
+		if ( ! $order ) {
+			// translators: placeholder %1 is the order type. %2 is the subscription ID we attempted to create the order for.
+			throw new Exception( sprintf( __( 'There was an error fetching the new order (%1$s) for subscription %2$d.', 'woocommerce-subscriptions' ), $type, $subscription->get_id() ) );
+		}
+
 		/**
 		 * Filters the new order created from the subscription.
 		 *
@@ -228,7 +235,7 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		 * @param WC_Subscription $subscription The subscription the order was created from.
 		 * @param string          $type         The type of order being created. Either 'renewal_order' or 'resubscribe_order'.
 		 */
-		return apply_filters( 'wcs_new_order_created', wc_get_order( $new_order->get_id() ), $subscription, $type );
+		return apply_filters( 'wcs_new_order_created', $order, $subscription, $type );
 
 	} catch ( Exception $e ) {
 		// There was an error adding the subscription
@@ -250,7 +257,7 @@ function wcs_get_new_order_title( $type ) {
 	$type = wcs_validate_new_order_type( $type );
 
 	// translators: placeholders are strftime() strings.
-	$order_date = strftime( _x( '%b %d, %Y @ %I:%M %p', 'Used in subscription post title. "Subscription renewal order - <this>"', 'woocommerce-subscriptions' ) ); // phpcs:ignore WordPress.WP.I18n.UnorderedPlaceholdersText
+	$order_date = ( new DateTime( 'now' ) )->format( _x( 'M d, Y @ h:i A', 'Order date parsed by DateTime::format', 'woocommerce-subscriptions' ) );
 
 	switch ( $type ) {
 		case 'renewal_order':

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -218,6 +218,10 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 		// Delete the transient that caches whether the order needs processing. Because we've added line items, the order may now need processing.
 		delete_transient( 'wc_order_' . $new_order->get_id() . '_needs_processing' );
 
+		/*
+		 * Fetch a fresh instance of the order because the current order instance has an empty line item cache generated before we had copied the line items.
+		 * Fetching a new instance will ensure the line items are available via $new_order->get_items().
+		 */
 		$order = wc_get_order( $new_order->get_id() );
 
 		if ( ! $order ) {
@@ -227,9 +231,6 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 
 		/**
 		 * Filters the new order created from the subscription.
-		 *
-		 * Fetches a fresh instance of the order because the current order instance has an empty line item cache generated before we had copied the line items.
-		 * Fetching a new instance will ensure the line items are available via $new_order->get_items().
 		 *
 		 * @param WC_Order        $new_order    The new order created from the subscription.
 		 * @param WC_Subscription $subscription The subscription the order was created from.


### PR DESCRIPTION
Fixes #494

## Description

There are circumstances that can lead to errors like this one when processing renewals.

```
Argument 1 passed to WCS_Related_Order_Store_Cached_CPT::add_relation() must be an instance of WC_Order, bool given, called in /public_html/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/wcs-renewal-functions.php on line 36
```

The cause is unknown. All we know is that for this error to occur `wcs_create_order_from_subscription()` must have failed to load the newly created order with `wc_get_order()` which must have returned `false`. [[code link](https://github.com/woocommerce/woocommerce/blob/49d6b2058ae74913a40aec09787666335cf19e0d/plugins/woocommerce/includes/class-wc-order-factory.php#L54-L57)]

One known reason `wc_get_order()` will return `false` is an exception was thrown in `WC_Order_Factory::get_order()` while the order was being read. What exception? Well we currently don't know because WC catches it, logs it via `wc_caught_exception`. 

This PR improves this by hooking onto `woocommerce_caught_exception` when we're processing subscription related events. If an exception was caught by WC, we'll now log it on the scheduled action and in the failed scheduled action logs. 

| Scheduled action log | WC log |
|--------|--------|
| <img width="337" alt="Screenshot 2023-12-21 at 3 07 40 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/13219bd2-630c-4472-8c2a-bdfcc0336d0c"> | <img width="2268" alt="Screenshot 2023-12-21 at 3 10 34 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/98ffb632-f36a-43c0-8ee1-cedefb9853f6"> |

Making that change alone wouldn't solve the `WCS_Related_Order_Store_Cached_CPT::add_relation` error I mentioned earlier. 

To fix that, I've changed `wcs_create_order_from_subscription()` so that if it fails to load the order, it will throw an exception, roll back the database, return a `WP_Error`. If you follow that up the chain, that will then lead `process_renewal()` to try another attempt to create the order. If that fails too, then it will throw an final error. 

## How to test this PR

1. Turn on WP post tables if you're using HPOS.
2. Add the following code to your site to trigger the `invalid order` exception.
1. Purchase a subscription.
2. Go to the Tools > Scheduled actions and run the subscription payment action for that subscripotion. 
3. On trunk you'll notice the scheduled action fails with the `WCS_Related_Order_Store_Cached_CPT::add_relation()` error. 
4. On this branch the scheduled action will still fail, however the scheduled action will now have the exceptions that were caught and it will also log the full exception stacktrace in the failed-scheduled-actions logs.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
