### PR TITLE
Update the subscription edit product "Expire after" language so it's more clear

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Prevents a PHP fatal error that occurs when the cart contains a renewal order item that no longer exists.
 * Fix - When HPOS is enabled and data compatibility mode is turned on, make sure subscription date changes made to postmeta are synced to orders_meta table.
 * Fix - Resolved an issue that would cause undefined $current_page, $max_num_pages, and $paginate variable errors when viewing a page with the subscriptions-shortcode.
+* Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.
 
 = 6.5.0 - 2023-11-09 =
 * Add - When a customer toggles automatic renewals on or off via their My Account page, add a note to the subscription to record that event.

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -341,7 +341,7 @@ class WC_Subscriptions_Admin {
 				'label'       => __( 'Stop renewing after', 'woocommerce-subscriptions' ),
 				'options'     => wcs_get_subscription_ranges( $chosen_period ),
 				'desc_tip'    => true,
-				'description' => __( 'Automatically expire the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'woocommerce-subscriptions' ),
+				'description' => __( 'Automatically stop renewing the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'woocommerce-subscriptions' ),
 			)
 		);
 

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -338,7 +338,7 @@ class WC_Subscriptions_Admin {
 			array(
 				'id'          => '_subscription_length',
 				'class'       => 'wc_input_subscription_length select short wc-enhanced-select',
-				'label'       => __( 'Expire after', 'woocommerce-subscriptions' ),
+				'label'       => __( 'Stop renewing after', 'woocommerce-subscriptions' ),
 				'options'     => wcs_get_subscription_ranges( $chosen_period ),
 				'desc_tip'    => true,
 				'description' => __( 'Automatically expire the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'woocommerce-subscriptions' ),
@@ -479,7 +479,7 @@ class WC_Subscriptions_Admin {
 				<option value="variable_subscription_sign_up_fee"><?php esc_html_e( 'Subscription sign-up fee', 'woocommerce-subscriptions' ); ?></option>
 				<option value="variable_subscription_period_interval"><?php esc_html_e( 'Subscription billing interval', 'woocommerce-subscriptions' ); ?></option>
 				<option value="variable_subscription_period"><?php esc_html_e( 'Subscription period', 'woocommerce-subscriptions' ); ?></option>
-				<option value="variable_subscription_length"><?php esc_html_e( 'Expire after', 'woocommerce-subscriptions' ); ?></option>
+				<option value="variable_subscription_length"><?php esc_html_e( 'Stop renewing after', 'woocommerce-subscriptions' ); ?></option>
 				<option value="variable_subscription_trial_length"><?php esc_html_e( 'Free trial length', 'woocommerce-subscriptions' ); ?></option>
 				<option value="variable_subscription_trial_period"><?php esc_html_e( 'Free trial period', 'woocommerce-subscriptions' ); ?></option>
 			</optgroup>

--- a/includes/wcs-time-functions.php
+++ b/includes/wcs-time-functions.php
@@ -85,7 +85,7 @@ function wcs_get_non_cached_subscription_ranges() {
 	foreach ( array( 'day', 'week', 'month', 'year' ) as $period ) {
 
 		$subscription_lengths = array(
-			_x( 'Never expire', 'Subscription length', 'woocommerce-subscriptions' ),
+			_x( 'Do not stop until cancelled', 'Subscription length', 'woocommerce-subscriptions' ),
 		);
 
 		switch ( $period ) {

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -63,7 +63,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</p>
 	<p class="form-row form-row-last show_if_variable-subscription _subscription_length_field" style="display: none">
 		<label for="variable_subscription_length[<?php echo esc_attr( $loop ); ?>]">
-			<?php esc_html_e( 'Expire after', 'woocommerce-subscriptions' ); ?>
+			<?php esc_html_e( 'Stop renewing after', 'woocommerce-subscriptions' ); ?>
 			<?php echo wcs_help_tip( _x( 'Automatically expire the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'Subscription Length dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ) ); ?>
 		</label>
 		<select name="variable_subscription_length[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_length wc-enhanced-select">

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -64,7 +64,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p class="form-row form-row-last show_if_variable-subscription _subscription_length_field" style="display: none">
 		<label for="variable_subscription_length[<?php echo esc_attr( $loop ); ?>]">
 			<?php esc_html_e( 'Stop renewing after', 'woocommerce-subscriptions' ); ?>
-			<?php echo wcs_help_tip( _x( 'Automatically expire the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'Subscription Length dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ) ); ?>
+			<?php echo wcs_help_tip( _x( 'Automatically stop renewing the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'Subscription Length dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ) ); ?>
 		</label>
 		<select name="variable_subscription_length[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_length wc-enhanced-select">
 		<?php foreach ( wcs_get_subscription_ranges( $billing_period ) as $key => $value ) : ?>

--- a/tests/unit/test-wcs-time-functions.php
+++ b/tests/unit/test-wcs-time-functions.php
@@ -127,7 +127,7 @@ class WCS_Time_Functions_Tests extends WP_UnitTestCase {
 	public function test_wcs_get_subscription_ranges() {
 
 		$expected_output_years = array(
-			0 => 'Never expire',
+			0 => 'Do not stop until cancelled',
 			1 => '1 year',
 			2 => '2 years',
 			3 => '3 years',
@@ -137,7 +137,7 @@ class WCS_Time_Functions_Tests extends WP_UnitTestCase {
 		$this->assertEquals( $expected_output_years, wcs_get_subscription_ranges( 'year' ) );
 
 		$expected_output_months = array(
-			0  => 'Never expire',
+			0  => 'Do not stop until cancelled',
 			1  => '1 month',
 			2  => '2 months',
 			3  => '3 months',
@@ -166,7 +166,7 @@ class WCS_Time_Functions_Tests extends WP_UnitTestCase {
 		$this->assertEquals( $expected_output_months, wcs_get_subscription_ranges( 'month' ) );
 
 		$expected_output_weeks = array(
-			0  => 'Never expire',
+			0  => 'Do not stop until cancelled',
 			1  => '1 week',
 			2  => '2 weeks',
 			3  => '3 weeks',
@@ -223,7 +223,7 @@ class WCS_Time_Functions_Tests extends WP_UnitTestCase {
 		$this->assertEquals( $expected_output_weeks, wcs_get_subscription_ranges( 'week' ) );
 
 		$expected_output_days = array(
-			0  => 'Never expire',
+			0  => 'Do not stop until cancelled',
 			1  => '1 day',
 			2  => '2 days',
 			3  => '3 days',


### PR DESCRIPTION
## Description

Slack: p1695716745140699-slack-C055WHLA98D

Merchants can sometimes get confused when creating a subscription product what the Subscription length/expiration is. They can interpret "Expire" to mean the subscription's renewal billing term not the full length or when the subscription will be cancelled. 

This PR changes the language used to describe the subscription length/expiration fields on the edit product page to make this more clear.

**`Expire after`** → **`Stop renewing after`**
**`Never expire`** → **`Do not stop until cancelled`**

<p align="center">
<img width="700" alt="Screenshot 2024-01-11 at 11 01 20 am" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/0935f20e-27b2-4da1-a18e-883baa9dbe57">
</br>
<sup>The new Subscription product expire/length field</sup>
</p>

## How to test this PR

1. Clone this repo into your plugin directory. 
2. Checkout this branch (`change-expire-after-language`).
3. Go to **Product → Add new** from your WP dashboard.
4. Select **Simple Subscription** from the product dropdown. 
5. Notice the new label, default dropdown option and tip description.
6. Change the product type to Variable Subscription
7. In the Attributes tab create a variation.
   - Check the "Used for variations" checkbox. 
9. In the variations tab create variations. 
10. Verify the subscription length fields are also updated for the variations. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)