### PR TITLE
Make sure to fetch the order discount excluding tax if prices include tax

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 6.8.0 - 2024-xx-xx =
-* Fix - Resolved an issue that would cause discounts when reapplied to subscription orders on the checkout to incorrectly account for inclusive tax.
+* Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.
 
 = 6.7.0 - 2024-01-11 =
 * Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.8.0 - 2024-xx-xx =
+* Fix - Resolved an issue that would cause discounts when reapplied to subscription orders on the checkout to incorrectly account for inclusive tax.
+
 = 6.7.0 - 2024-01-11 =
 * Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.
 * Update - Log all exceptions caught by WooCommerce while processing a subscription scheduled action.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1360,7 +1360,7 @@ class WCS_Cart_Renewal {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.4.3
 	 */
 	public function setup_discounts( $order ) {
-		$order_discount = $order->get_total_discount();
+		$order_discount = $order->get_total_discount( ! $order->get_prices_include_tax() );
 		$coupon_items   = $order->get_items( 'coupon' );
 
 		if ( empty( $order_discount ) && empty( $coupon_items ) ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4227

## Description

When you attempt to pay for a failed parent order where prices are inclusive of tax and there's a discount that applied, the total that appears on the checkout would be incorrect. 

After some digging I discovered it's because we're pulling the order discount amount excluding tax so a $10 discount, for example, would be returned as $9.62. The customer would then only be discounted $9.62 not the full $10.

This PR fixes it.

## How to test this PR

1. Create a recurring discount of $10 in **Marketing → Discounts**.
1. Create a $50 subscription product of any recurring frequency.
3. In WooCommerce → General settings make sure tax calculations are enabled.
4. In WooCommerce → Settings → Taxes make sure prices are inclusive of tax.
5. Disable shipping or add a free shipping method.
6. Add a 4% tax rate that applies. 
7. Add the product to your cart.
8. Apply the coupon.
9. Note that the total is $40 with $1.54 tax. 
10. Fail the payment using a Stripe test card like: `4000000000000002`
11. Go to the My Account > Orders page and attempt to pay for the order. 
12. On `trunk` you'll notice that a discount of $9.62.
13. On this branch it should be correctly $10 with a total of $40. 

| `trunk` | This branch |
|--------|--------|
| <img width="647" alt="Screenshot 2024-01-11 at 5 56 31 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/89e2da6c-948b-47b5-b342-2b0300d1e27b"> | <img width="625" alt="Screenshot 2024-01-11 at 5 57 24 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/874c50c2-a309-4dca-89d1-8a4a0b147b32"> | 

> [!NOTE]
> I've tested this with prices exclusive of tax and with % discounts and they also work with this change also works for those scenarios too.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
