### PR TITLE
Fix "Call to undefined function wc_notice_count()" error while editing customer in admin

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.7.1 - 2024-xx-xx =
+* Fix - Resolved an error that would occur with WC 8.5.0 when editing a subscription customer from the admin dashboard.
+
 = 6.7.0 - 2024-01-11 =
 * Update - Changed the edit subscription product "Expire after" (Subscription length) so it more clearly describes when a subscription will automatically stop renewing.
 * Update - Log all exceptions caught by WooCommerce while processing a subscription scheduled action.

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -143,7 +143,7 @@ class WC_Subscriptions_Addresses {
 	 */
 	public static function maybe_update_subscription_addresses( $user_id, $address_type ) {
 
-		if ( ! wcs_user_has_subscription( $user_id ) || wc_notice_count( 'error' ) > 0 || empty( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( $_POST['_wcsnonce'], 'wcs_edit_address' ) ) {
+		if ( ! wcs_user_has_subscription( $user_id ) || empty( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( $_POST['_wcsnonce'], 'wcs_edit_address' ) || wc_notice_count( 'error' ) > 0  ) {
 			return;
 		}
 

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -143,7 +143,7 @@ class WC_Subscriptions_Addresses {
 	 */
 	public static function maybe_update_subscription_addresses( $user_id, $address_type ) {
 
-		if ( ! wcs_user_has_subscription( $user_id ) || ! isset( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['_wcsnonce'] ), 'wcs_edit_address' ) || wc_notice_count( 'error' ) > 0 ) {
+		if ( ! wcs_user_has_subscription( $user_id ) || ! isset( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wcsnonce'] ) ), 'wcs_edit_address' ) || wc_notice_count( 'error' ) > 0 ) {
 			return;
 		}
 

--- a/includes/class-wc-subscriptions-addresses.php
+++ b/includes/class-wc-subscriptions-addresses.php
@@ -143,7 +143,7 @@ class WC_Subscriptions_Addresses {
 	 */
 	public static function maybe_update_subscription_addresses( $user_id, $address_type ) {
 
-		if ( ! wcs_user_has_subscription( $user_id ) || empty( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( $_POST['_wcsnonce'], 'wcs_edit_address' ) || wc_notice_count( 'error' ) > 0  ) {
+		if ( ! wcs_user_has_subscription( $user_id ) || ! isset( $_POST['_wcsnonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['_wcsnonce'] ), 'wcs_edit_address' ) || wc_notice_count( 'error' ) > 0 ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #https://github.com/woocommerce/woocommerce-subscriptions/issues/4605

## Description

This PR fixes an error that occurs on the latest WC version 8.5.1 when editing a customer in the admin dashboard. 

```
PHP Fatal error:  Uncaught Error: Call to undefined function wc_notice_count() in app/public/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/class-wc-subscriptions-addresses.php:146
Stack trace:
#0 app/public/wp-includes/class-wp-hook.php(324): WC_Subscriptions_Addresses::maybe_update_subscription_addresses(10, 'billing')
#1 app/public/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#2 app/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 app/public/wp-content/plugins/woocommerce/includes/admin/class-wc-admin-profile.php(243): do_action('woocommerce_cus...', 10, 'billing')
#4 app/public/wp-includes/class-wp-hook.php(324): WC_Admin_Profile->save_customer_meta_fields(10)
#5 app/public/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#6 app/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#7 app/public/wp-admin/user-edit.php(157): do_action('edit_user_profi...', 10)
#8 {main}
```

## How to test this PR

1. Install the latest WC versions (8.5.1).
2. Go to the Users screen in your WP Dashboard. 
3. Edit a user that has at least 1 subscription. 
4. No changes to the user are needed. Just scroll to the bottom of the screen and hit the "Update Profile" button. 
   - On `trunk` you will see the error I mentioned above. 
   - On this branch there should be no error. 


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
