### PR TITLE
Added break statements in switch (#533)

### DIFF
--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2516,6 +2516,7 @@ class WC_Subscription extends WC_Order {
 						// translators: %s: date type (e.g. "end").
 						$messages[] = sprintf( __( 'The %s date must occur after the cancellation date.', 'woocommerce-subscriptions' ), $date_type );
 					}
+					break;
 
 				case 'cancelled':
 					if ( array_key_exists( 'last_order_date_created', $timestamps ) && $timestamp < $timestamps['last_order_date_created'] ) {
@@ -2527,17 +2528,22 @@ class WC_Subscription extends WC_Order {
 						// translators: %s: date type (e.g. "end").
 						$messages[] = sprintf( __( 'The %s date must occur after the next payment date.', 'woocommerce-subscriptions' ), $date_type );
 					}
+					break;
+
 				case 'next_payment':
 					// Guarantees that end is strictly after trial_end, because if next_payment and end can't be at same time
 					if ( array_key_exists( 'trial_end', $timestamps ) && $timestamp < $timestamps['trial_end'] ) {
 						// translators: %s: date type (e.g. "end").
 						$messages[] = sprintf( __( 'The %s date must occur after the trial end date.', 'woocommerce-subscriptions' ), $date_type );
 					}
+					break;
+
 				case 'trial_end':
 					if ( ! in_array( $date_type, array( 'end', 'cancelled' ) ) && $timestamp <= $timestamps['start'] ) {
 						// translators: %s: date type (e.g. "next_payment").
 						$messages[] = sprintf( __( 'The %s date must occur after the start date.', 'woocommerce-subscriptions' ), $date_type );
 					}
+					break;
 			}
 
 			$dates[ $date_type ] = gmdate( 'Y-m-d H:i:s', $timestamp );


### PR DESCRIPTION
Fixes #533 

## Description

Missing `break` statements inside the `switch` ... `case` block in `WC_Subscription::validate_date_updates()` are causing an unexpected behavior when validating dates while changing subscription status.

According to PHP documentation, 

> when a case statement is found whose expression (...) matches the value of the switch expression (...) PHP continues to execute the statements until the end of the switch block.

So for example, when the case matches 'end' then all the following lines inside the block will be executed as if the expression would match 'cancelled', 'next_payment' and 'trial_end'.

- How can this code break?
This shouldn't break because it doesn't add any new code, it only enhances existing code, ensuring expected behavior.

<img width="1010" alt="subscription-bug-533" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/2756703/c0f43595-3077-48ca-ab14-31e231f3cbfd">

In this screenshot we can see how the debugger stops in the wrong case.

## How to test this PR

1. Generate a subscription.
2. After the subscription period, generate renewal.
3. Move the subscription status to "On hold".
4. Make a PUT request to /wc/v3/subscriptions/{ID} with {"status":"cancelled"}
5. Before the fix, the request will throw an error: `The next_payment date must occur after the start date.`
    After the fix, the request should change the subscription status to `cancelled` without errors.

## Product impact

- [x] Affects WooCommerce Subscriptions  #533 
