### PR TITLE
Try: Add product editor hooks for testing variation extensibility

### DIFF
--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -1419,4 +1419,17 @@ jQuery( function ( $ ) {
 	$( '.woo_subscriptions_empty_state__button_container a' ).on( 'click', function ( e ) {
 		$( this ).addClass( 'is-busy' );
 	} );
+
+	if ( window.wp.hooks && wp.data ) {
+		window.wp.hooks.addFilter( 'woocommerce_save_product_data', 'woocommerce-subscriptions', ( data, productId ) => {
+			const product = wp.data.select( 'core' ).getEditedEntityRecord( 'postType', 'product', productId );
+			if ( data.type === 'variable' && product.is_subscribable ) {
+				return {
+					...data,
+					type: 'variable-subscription'
+				}
+			}
+			return data;
+		} );
+	}
 } );

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -65,6 +65,9 @@ class WC_Subscriptions_Admin {
 		// Add subscription pricing fields on edit product page
 		add_action( 'woocommerce_product_options_general_product_data', __CLASS__ . '::subscription_pricing_fields' );
 
+		// Add subscription fields to product editor
+		add_action( 'woocommerce_block_template_area_product-form_after_add_block_product-pricing-section', __CLASS__ . '::add_product_editor_fields' );
+
 		// Add listener to clear our own transients when WooCommerce -> Clear Transients is
 		// triggered from the admin panel
 		add_action( 'woocommerce_page_wc-status', __CLASS__ . '::clear_subscriptions_transients' );
@@ -153,6 +156,35 @@ class WC_Subscriptions_Admin {
 
 		// Prevent variations from being deleted if switching from a variable product type to a variable product type.
 		add_filter( 'woocommerce_delete_variations_on_product_type_change', array( __CLASS__, 'maybe_keep_variations' ), 10, 4 );
+	}
+
+	public static function add_product_editor_fields( $pricing_section ) {
+		if ( ! $pricing_section->get_root_template()->get_id() === 'simple-product' ) {
+			return;
+		}
+
+		$pricing_section->add_block(
+			[
+				'id'         => 'subscriptions-enabled',
+				'blockName'  => 'woocommerce/product-checkbox-field',
+				'order'      => 20,
+				'attributes' => [
+					'title'    => __(
+						'Subscriptions',
+						'woocommerce-subscriptions'
+					),
+					'label'    => __(
+						'Subscribable',
+						'woocommerce-subscriptions'
+					),
+					'property' => 'is_subscribable',
+					'tooltip'  => __(
+						'When checked, this product will act as a subscription.',
+						'woocommerce-subscriptions'
+					),
+				],
+			]
+		);
 	}
 
 	/**
@@ -852,6 +884,7 @@ class WC_Subscriptions_Admin {
 				'users',
 				'woocommerce_page_wc-settings',
 				'woocommerce_page_wc-orders',
+				'woocommerce_page_wc-admin',
 				wcs_get_page_screen_id( 'shop_subscription' ),
 			],
 			true


### PR DESCRIPTION
## Description

This is a POC for making subscriptions compatible with the new product editor flow.  It should be tested in conjuction with https://github.com/woocommerce/woocommerce/pull/44162 demonstrate the use of the product editor hooks.

<img width="536" alt="Screenshot 2024-01-29 at 3 26 14 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/10561050/e0e0a772-a8f8-444b-a1c0-045038f281e2">
<img width="521" alt="Screenshot 2024-01-29 at 3 24 54 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/10561050/ff3f808e-7602-4afd-b9fa-191929e2c2d6">


## How to test this PR

Follow the testing instructions in https://github.com/woocommerce/woocommerce/pull/44162.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
