### PR TITLE
Block the ui after the user clicks a subscriotion status update action

### DIFF
--- a/assets/js/frontend/view-subscription.js
+++ b/assets/js/frontend/view-subscription.js
@@ -149,10 +149,21 @@ jQuery( function ( $ ) {
 		return $paymentMethod.data( 'is_manual' ) === 'no';
 	}
 
+	function blockActionsOnTrigger() {
+		$( '.subscription_details' ).block( {
+			message: null,
+			overlayCSS: {
+				background: '#fff',
+				opacity: 0.6,
+			},
+		} );
+	}
+
 	$toggle.on( 'click', onToggle );
 	maybeApplyColor();
 	displayToggle();
 
 	$early_renewal_modal_submit.on( 'click', blockEarlyRenewalModal );
 	$( document ).on( 'wcs_show_modal', shouldShowEarlyRenewalModal );
+	$( document ).on( 'click', '.wcs_block_ui_on_click', blockActionsOnTrigger );
 } );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.8.0 - xxxx-xx-xx =
+* Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.
+
 = 6.7.1 - 2024-01-17 =
 * Fix - Resolved an error that would occur with WC 8.5.0 when editing a subscription customer from the admin dashboard.
 

--- a/includes/wcs-user-functions.php
+++ b/includes/wcs-user-functions.php
@@ -307,15 +307,17 @@ function wcs_get_all_user_actions_for_subscription( $subscription, $user_id ) {
 
 		if ( $subscription->can_be_updated_to( 'active' ) && ! $subscription->needs_payment() ) {
 			$actions['reactivate'] = array(
-				'url'  => wcs_get_users_change_status_link( $subscription->get_id(), 'active', $current_status ),
-				'name' => __( 'Reactivate', 'woocommerce-subscriptions' ),
+				'url'      => wcs_get_users_change_status_link( $subscription->get_id(), 'active', $current_status ),
+				'name'     => __( 'Reactivate', 'woocommerce-subscriptions' ),
+				'block_ui' => true,
 			);
 		}
 
 		if ( wcs_can_user_resubscribe_to( $subscription, $user_id ) && false == $subscription->can_be_updated_to( 'active' ) ) {
 			$actions['resubscribe'] = array(
-				'url'  => wcs_get_users_resubscribe_link( $subscription ),
-				'name' => __( 'Resubscribe', 'woocommerce-subscriptions' ),
+				'url'      => wcs_get_users_resubscribe_link( $subscription ),
+				'name'     => __( 'Resubscribe', 'woocommerce-subscriptions' ),
+				'block_ui' => true,
 			);
 		}
 
@@ -323,8 +325,9 @@ function wcs_get_all_user_actions_for_subscription( $subscription, $user_id ) {
 		$next_payment = $subscription->get_time( 'next_payment' );
 		if ( $subscription->can_be_updated_to( 'cancelled' ) && ( ! $subscription->is_one_payment() && ( $subscription->has_status( 'on-hold' ) && empty( $next_payment ) ) || $next_payment > 0 ) ) {
 			$actions['cancel'] = array(
-				'url'  => wcs_get_users_change_status_link( $subscription->get_id(), 'cancelled', $current_status ),
-				'name' => _x( 'Cancel', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'url'      => wcs_get_users_change_status_link( $subscription->get_id(), 'cancelled', $current_status ),
+				'name'     => _x( 'Cancel', 'an action on a subscription', 'woocommerce-subscriptions' ),
+				'block_ui' => true,
 			);
 		}
 	}

--- a/templates/myaccount/subscription-details.php
+++ b/templates/myaccount/subscription-details.php
@@ -81,7 +81,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<td><?php esc_html_e( 'Actions', 'woocommerce-subscriptions' ); ?></td>
 				<td>
 					<?php foreach ( $actions as $key => $action ) : ?>
-						<a href="<?php echo esc_url( $action['url'] ); ?>" class="button <?php echo sanitize_html_class( $key ) ?>"><?php echo esc_html( $action['name'] ); ?></a>
+						<?php $classes = [ 'button', sanitize_html_class( $key ) ]; ?>
+						<?php $classes[] = isset( $action['block_ui'] ) && $action['block_ui'] ? 'wcs_block_ui_on_click' : '' ?>
+						<a
+							href="<?php echo esc_url( $action['url'] ); ?>"
+							class="<?php echo trim( implode( ' ', $classes ) ); ?>"
+						>
+							<?php echo esc_html( $action['name'] ); ?>
+						</a>
 					<?php endforeach; ?>
 				</td>
 			</tr>


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4613

## Description

This PR blocks the view subscriptions UI when the customer clicks one of the status changing URLs. 

https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/1c1d10be-bf74-4215-a136-be8cde736616

## How to test this PR

1. Checkout out this branch. 
2. Go to the **My Account > View subscription** page. 
3. Click the cancel, activate, suspend buttons and confirm you can no longer spam the button. 
4. Click the other actions (change address, change payment etc) you'll notice the UI isn't blocked. 
5. If you have the early renewal modal enabled. It won't block the ui. If you don't have the modal enabled, it will block the ui. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
