### PR TITLE
Fix WC 8.6 `wc_get_log_file_path()` deprecation warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.8.0 - xxxx-xx-xx =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.
+* Fix - WC 8.6.0 compatibility: Resolved wc_get_log_file_path() deprecation warnings.
 
 = 6.7.1 - 2024-01-17 =
 * Fix - Resolved an error that would occur with WC 8.5.0 when editing a subscription customer from the admin dashboard.

--- a/includes/class-wcs-cached-data-manager.php
+++ b/includes/class-wcs-cached-data-manager.php
@@ -166,7 +166,7 @@ class WCS_Cached_Data_Manager extends WCS_Cache_Manager {
 	 * truncated to 0 bytes.
 	 */
 	public static function cleanup_logs() {
-		wcs_deprecated_function( __METHOD__, '6.0.0', );
+		wcs_deprecated_function( __METHOD__, '6.0.0' );
 		$file = wc_get_log_file_path( 'wcs-cache' );
 		$max_cache_size = apply_filters( 'wcs_max_log_size', 50 * 1024 * 1024 );
 

--- a/includes/class-wcs-cached-data-manager.php
+++ b/includes/class-wcs-cached-data-manager.php
@@ -198,7 +198,7 @@ class WCS_Cached_Data_Manager extends WCS_Cache_Manager {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.9
 	 */
 	public function initialize_cron_check_size() {
-		wcs_deprecated_function( __METHOD__, '6.0.0', );
+		wcs_deprecated_function( __METHOD__, '6.0.0' );
 
 		$hook = 'wcs_cleanup_big_logs';
 

--- a/includes/class-wcs-cached-data-manager.php
+++ b/includes/class-wcs-cached-data-manager.php
@@ -18,8 +18,6 @@ class WCS_Cached_Data_Manager extends WCS_Cache_Manager {
 
 	public function __construct() {
 		add_action( 'woocommerce_loaded', array( $this, 'load_logger' ) );
-
-		add_action( 'admin_init', array( $this, 'initialize_cron_check_size' ) ); // setup cron task to truncate big logs.
 		add_filter( 'cron_schedules', array( $this, 'add_weekly_cron_schedule' ) ); // create a weekly cron schedule
 	}
 
@@ -168,6 +166,7 @@ class WCS_Cached_Data_Manager extends WCS_Cache_Manager {
 	 * truncated to 0 bytes.
 	 */
 	public static function cleanup_logs() {
+		wcs_deprecated_function( __METHOD__, '6.0.0', );
 		$file = wc_get_log_file_path( 'wcs-cache' );
 		$max_cache_size = apply_filters( 'wcs_max_log_size', 50 * 1024 * 1024 );
 
@@ -199,6 +198,7 @@ class WCS_Cached_Data_Manager extends WCS_Cache_Manager {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.9
 	 */
 	public function initialize_cron_check_size() {
+		wcs_deprecated_function( __METHOD__, '6.0.0', );
 
 		$hook = 'wcs_cleanup_big_logs';
 

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -263,6 +263,11 @@ class WC_Subscriptions_Upgrader {
 			WCS_Upgrade_3_1_0::migrate_subscription_webhooks_using_api_version_3();
 		}
 
+		if ( version_compare( self::$active_version, '6.8.0', '<' ) ) {
+			// Upon upgrading to 6.8.0 delete the 'wcs_cleanup_big_logs' WP Cron job that is no longer used.
+			wp_unschedule_hook( 'wcs_cleanup_big_logs' );
+		}
+
 		self::upgrade_complete();
 	}
 

--- a/includes/upgrades/templates/wcs-upgrade.php
+++ b/includes/upgrades/templates/wcs-upgrade.php
@@ -62,8 +62,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p><?php esc_html_e( 'Your database has been updated successfully!', 'woocommerce-subscriptions' ); ?></p>
 			<p class="step"><a class="button" href="<?php echo esc_url( $about_page_url ); ?>"><?php esc_html_e( 'Continue', 'woocommerce-subscriptions' ); ?></a></p>
 			<p class="log-notice"><?php
+				// Get the log file URL depending on the log handler (file or database).
+				$url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&log_file=%s-%s-log', WCS_Upgrade_Logger::$handle, sanitize_file_name( wp_hash( WCS_Upgrade_Logger::$handle ) ) ) );
+
+				// In WC 8.6 the URL format changed to include the source parameter.
+				if ( ! wcs_is_woocommerce_pre( '8.6.0' ) ) {
+					$url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&source=%s&paged=1', WCS_Upgrade_Logger::$handle ) );
+				}
+
 				// translators: $1: placeholder is number of weeks, 2$: path to the file
-				echo wp_kses( sprintf( __( 'To record the progress of the update a new log file was created. This file will be automatically deleted in %1$d weeks. If you would like to delete it sooner, you can find it here: %2$s', 'woocommerce-subscriptions' ), esc_html( WCS_Upgrade_Logger::$weeks_until_cleanup ), '<code class="log-notice">' . esc_html( wc_get_log_file_path( WCS_Upgrade_Logger::$handle ) ) . '</code>' ), array( 'code' => array( 'class' => true ) ) );
+				echo wp_kses_post( sprintf( __( 'To record the progress of the update a new log file was created. This file will be automatically deleted in %1$d weeks. If you would like to delete it sooner, you can find it in the %2$sWooCommerce logs screen%3$s.', 'woocommerce-subscriptions' ), esc_html( WCS_Upgrade_Logger::$weeks_until_cleanup ), '<a href="' . esc_url( $url ) . '">', '</a>' ) );
 				?>
 			</p>
 		</div>

--- a/templates/admin/html-failed-scheduled-action-notice.php
+++ b/templates/admin/html-failed-scheduled-action-notice.php
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Get the log file URL depending on the log handler (file or database).
 $url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&log_file=%s-%s-log', 'failed-scheduled-actions', sanitize_file_name( wp_hash( 'failed-scheduled-actions' ) ) ) );
 
+// In WC 8.6 the URL format changed to include the source parameter.
+if ( ! wcs_is_woocommerce_pre( '8.6.0' ) ) {
+	$url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&source=%s&paged=1', 'failed-scheduled-actions' ) );
+}
+
 if ( defined( 'WC_LOG_HANDLER' ) && 'WC_Log_Handler_DB' === WC_LOG_HANDLER ) {
 	$url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&source=%s', 'failed-scheduled-actions' ) );
 }

--- a/tests/unit/test-wcs-functions.php
+++ b/tests/unit/test-wcs-functions.php
@@ -10,46 +10,6 @@ function wcs_max_log_size_filter() {
  */
 class WCS_Functions_Test extends WP_UnitTestCase {
 
-	public function test_wcs_cleanup_logs_no_changes() {
-		$file = wc_get_log_file_path( 'wcs-cache' );
-
-		// Nothing should happen here
-		$content = uniqid();
-		file_put_contents( $file, $content );
-		WCS_Cached_Data_Manager::cleanup_logs();
-		$this->assertEquals( $content, file_get_contents( $file ) );
-	}
-
-	public function test_wcs_cleanup_logs() {
-		$file = wc_get_log_file_path( 'wcs-cache' );
-
-		// random lines
-		$lines = array();
-		for ( $i = 0; $i < 10000; ++$i ) {
-			$lines[] = uniqid( true );
-		}
-		$log = implode( "\n", $lines );
-		file_put_contents( $file, $log );
-
-		add_filter( 'wcs_max_log_size', 'wcs_max_log_size_filter' );
-		$GLOBALS['wcs_max_log_size_filter'] = strlen( $log );
-
-		WCS_Cached_Data_Manager::cleanup_logs();
-		$content = file_get_contents( $file );
-		$this->assertNotEquals( $log, $content );
-
-		// Make sure we have "log file automatically truncated" message
-		$this->assertFalse( (bool) preg_match( '/log.+truncated/', $log ) );
-		$this->assertTrue( (bool) preg_match( '/log.+truncated/', $content ) );
-
-		$new_lines = explode( "\n", $content );
-		// make sure that 1000 (default lines to keep) +1 is being saved
-		$this->assertEquals( 1001, count( $new_lines ) );
-
-		// Make sure the last 1000 entries are kept
-		$this->assertEquals( array_slice( $lines, -1000 ), array_slice( $new_lines, 0, 1000 ) );
-	}
-
 	public function test_wcs_is_subscription() {
 		// test cases
 		$subscription_object    = WCS_Helper_Subscription::create_subscription( array( 'status' => 'active' ) );


### PR DESCRIPTION
## Description

This PR fixes failing unit tests, updates the way we point users to the view a certain log file and deprecates cleaning up large log files as WC core now handles that functionality. 

## How to test this PR

### Cron job

1. Install a plugin like WP Crontrol to view cron jobs.
2. Go to **Tools > Cron events**
3. Search for `wcs_cleanup_big_logs` and notice that job is still queued. 

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/5a8c238d-ae61-430f-88f5-605f64318aec)

4. Checkout this branch and that should be updated to have no action attached to it. 
5. Go into your database and search the options table for `woocommerce_subscriptions_active_version`. 
6. Update that option to be `6.7.0` (minus 1 version).
   - This will just trigger the upgrade flow. 
7. Notice that `wcs_cleanup_big_logs` is no longer listed.

### Scheduled action notice

1. Install WooCommerce 8.6 beta from the zips here: https://github.com/woocommerce/woocommerce/tags
2. Simulate a fatal error during a subscription scheduled action by deleting a subscription from the database and running it's payment action manually or update the scheduled action directly and alter the subscription ID arg so it isn't valid.
3. You should see the following notice:

<img width="1228" alt="Screenshot 2024-02-08 at 2 17 24 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/9a872f53-a098-44f2-97be-42180963782a">

4. On `trunk` clicking the **WooCommerce logs screen** link will send you to the logs screen but not to the files directly. 
5. On this branch the logs table will only include `failed-scheduled-actions` files. 

### wcs-upgrade

1. I wasn't able to find a way to get this page to show easily so I verified that my changes in this PR correctly generated valid HTML using WP Console. 

```php
// Get the log file URL depending on the log handler (file or database).
$url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&log_file=%s-%s-log', WCS_Upgrade_Logger::$handle, sanitize_file_name( wp_hash( WCS_Upgrade_Logger::$handle ) ) ) );

// In WC 8.6 the URL format changed to include the source parameter.
if ( ! wcs_is_woocommerce_pre( '8.6.0' ) ) {
	$url = admin_url( sprintf( 'admin.php?page=wc-status&tab=logs&source=%s&paged=1', WCS_Upgrade_Logger::$handle ) );
}

// translators: $1: placeholder is number of weeks, 2$: path to the file
echo wp_kses_post( sprintf( __( 'To record the progress of the update a new log file was created. This file will be automatically deleted in %1$d weeks. If you would like to delete it sooner, you can find it in the %2$sWooCommerce logs screen%3$s.', 'woocommerce-subscriptions' ), esc_html( WCS_Upgrade_Logger::$weeks_until_cleanup ), '<a href="' . esc_url( $url ) . '">', '</a>' ) );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
