### PR TITLE
Fix empty error notices on the My Account > Payment Methods page when the store uses block based notices

### DIFF
--- a/assets/js/frontend/payment-methods.js
+++ b/assets/js/frontend/payment-methods.js
@@ -5,15 +5,18 @@ jQuery( function ( $ ) {
 	$( '.wcs_deletion_error' ).on( 'click', function ( e ) {
 		e.preventDefault();
 
+		var notice_content_container = $( '#wcs_delete_token_warning' ).find( 'li' );
+
+		// For block based WC notices we need to find the notice content container.
+		if ( $( '#wcs_delete_token_warning' ).find( '.wc-block-components-notice-banner' ).length > 0 ) {
+			notice_content_container = $( '#wcs_delete_token_warning' ).find( '.wc-block-components-notice-banner__content' );
+		}
+
 		// Use the href to determine which notice needs to be displayed.
 		if ( '#choose_default' === $( this ).attr( 'href' ) ) {
-			$( '#wcs_delete_token_warning' )
-				.find( 'li' )
-				.html( wcs_payment_methods.choose_default_error );
+			notice_content_container.html( wcs_payment_methods.choose_default_error );
 		} else {
-			$( '#wcs_delete_token_warning' )
-				.find( 'li' )
-				.html( wcs_payment_methods.add_method_error );
+			notice_content_container.html( wcs_payment_methods.add_method_error );
 		}
 
 		// Display the notice.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 6.9.0 - xxxx-xx-xx =
+* Fix - Resolved an issue that could cause an empty error notice to appear on the My Account > Payment methods page when a customer attempted to delete a token used by subscriptions.
+
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.
 * Fix - WC 8.6.0 compatibility: Resolved wc_get_log_file_path() deprecation warnings.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4616

## Description

If you attempted to delete a token that was used by an active subscription, there was no default set and you used a block based checkout, you'd be faced with this empty error message.

<p align="center">
<img width="700" alt="Screenshot 2024-02-14 at 1 02 46 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/3b9c6f64-ad35-4c7e-aa54-f332b90fffcc">
</p>

The issue here was caused by the way we display this notice. We print an empty notice to the screen and hide it ([`WCS_My_Account_Payment_Methods::print_deleting_notices()`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/issue/4616-fix-subscription-token-notice-error/includes/class-wcs-my-account-payment-methods.php#L278-L283)). If the user clicks on one of the delete token buttons that we've altered to instead result in an error, we populate the empty notice with the correct error message and then show the notice. 

The problem was that block based stores use a slightly different notice HTML and so populating the notice with the content didn't work. 

This PR updates the JS code to make sure it can support block based notices format and old WC notices. 

## How to test this PR

### WC 8.4+ 

1. Make sure you're running WC 8.5 and above.
1. Purchase a subscription using a saved token or add a new one. 
2. Go to the My Account > Payment methods screen 
3. Attempt to delete the token. 
   - `trunk` You should see the blank notice above. 
   - On this branch the notice should be populated with the correct content. 

| `trunk` | This branch |
|--------|--------|
| <img width="567" alt="Screenshot 2024-02-14 at 2 05 16 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/8ddcf92b-902d-4ef7-9230-4c53ae348068"> | <img width="762" alt="Screenshot 2024-02-14 at 2 08 06 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/c4d2397e-1b0c-4abe-bf82-a372a70f4d1e"> |  

### WC 8.4 

1. Install WC 8.4 from here: https://github.com/woocommerce/woocommerce/releases/tag/8.4.0
2. Repeat steps above. 
3. On `trunk` and this branch, the notice works fine. 

<img width="755" alt="Screenshot 2024-02-14 at 2 05 33 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/018f2bbb-b680-469a-9288-678929604935">

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
