### PR TITLE
Fix PHP 8.2 deprecated dynamic property errors in \WCS_PayPal_Reference_Transaction_API

### DIFF
--- a/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api-request.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api-request.php
@@ -695,11 +695,11 @@ class WCS_PayPal_Reference_Transaction_API_Request {
 	 * Format prices.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.12
-	 * @param float|int $price
+	 * @param float|int|null $price
 	 * @param int $decimals Optional. The number of decimal points.
 	 * @return string
 	 */
 	private function price_format( $price, $decimals = 2 ) {
-		return number_format( $price, $decimals, '.', '' );
+		return number_format( (float) $price, $decimals, '.', '' );
 	}
 }

--- a/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api.php
@@ -36,6 +36,18 @@ class WCS_PayPal_Reference_Transaction_API extends WCS_SV_API_Base {
 	/** @var array the request parameters */
 	private $parameters = array();
 
+	/** @var string */
+	public $gateway_id;
+
+	/** @var string */
+	public $api_username;
+
+	/** @var string */
+	public $api_password;
+
+	/** @var string */
+	public $api_signature;
+
 	/**
 	 * Constructor - setup request object and set endpoint
 	 *


### PR DESCRIPTION

PHP 8.2 required properties be defined before assigning them. The `\WCS_PayPal_Reference_Transaction_API` class has 4 properties assigned in __constructs which do not exist and return deprecated warnings.

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Support using PHP 8.2 with the `\WCS_PayPal_Reference_Transaction_API` class without filling the logs with deprecated warnings or throwing exceptions during testing.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set `error_reporting = E_ALL` in php.ini and tail the logs.
2. Use `convertDeprecationsToExceptions="true"` in <phpunit> config during unit testing.
3. Call any code which constructs the `\WCS_PayPal_Reference_Transaction_API` class. 

## Product impact
<!-- What products will this PR ship in? -->

- [X] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref

