### PR TITLE
Support block themes for add to cart button

### DIFF
--- a/templates/single-product/add-to-cart/subscription.php
+++ b/templates/single-product/add-to-cart/subscription.php
@@ -48,7 +48,7 @@ if ( $product->is_in_stock() ) : ?>
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
-		<button type="submit" class="single_add_to_cart_button button alt" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" class="single_add_to_cart_button button alt wp-element-button" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 


### PR DESCRIPTION
Adds a CSS class needed for block themes to appropriately style buttons. 

Fixes #

## Description

Without the `wp-element-button` class applied, the add to cart buttons within the **Add to Cart with Options** block doesn't adopt any of the expected styles. Adding this class, when using add to cart blocks, resolves the styling issue. I tested this with the Twenty Twenty-Four theme.

## How to test this PR

- Use Twenty Twenty-Four
- Adjust your stylebook to set button styles / colors / etc
- Create the single-product template using blocks, ensuring that **Add to Cart with Options** is used
- Observe that the buttons are unstyled
- Apply this fix, and see they now adopt the theme styling

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
