### PR TITLE
Saving customer note from Edit Subscription page not working when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 6.9.0 - xxxx-xx-xx =
 * Fix - Resolved an issue that could cause an empty error notice to appear on the My Account > Payment methods page when a customer attempted to delete a token used by subscriptions.
+* Fix - Use block theme styles for the 'Add to Cart' button on subscription product pages.
+* Fix - Customer notes not being saved on the Edit Subscription page for stores with HPOS enabled.
 
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.

--- a/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
+++ b/includes/admin/meta-boxes/class-wcs-meta-box-subscription-data.php
@@ -408,6 +408,11 @@ class WCS_Meta_Box_Subscription_Data extends WC_Meta_Box_Order_Data {
 			}
 		}
 
+		// Customer note.
+		if ( isset( $_POST['excerpt'] ) ) {
+			$props['customer_note'] = sanitize_textarea_field( wp_unslash( $_POST['excerpt'] ) );
+		}
+
 		$subscription->set_props( $props );
 		$subscription->save();
 


### PR DESCRIPTION
Fixes 4618-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Updating the customer note on the Edit Subscription page doesn't work on stores using HPOS as their datastore:

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/9b238fe8-28ec-429f-8842-619c17cfd168)

In our `WCS_Meta_Box_Subscription_Data::output()` function we load in this customer note field with the following code:

```
<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer\'s notes about the order', 'woocommerce-subscriptions' ); ?>"><?php echo wp_kses_post( $subscription->get_customer_note() ); ?></textarea>
```

On save, in a WP Post environment, the `$_POST['excerpt']` data is handled by WordPress core's own save posts process, but in an HPOS environment, we need to manually save this data which is done by this PR.

> [!NOTE]  
> In WooCommerce Core, they've updated this textarea to have name `'customer_note'` instead of `excerpt`. I've opted to leave ours as `'excerpt'` for backwards compatibility and I couldn't think of a reason to update it. Keen to hear what others think.
>
> The only reason I would consider changing it is to be consistent with WooCommerce/Orders.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. On `trunk`, enable HPOS
2. Purchase a subscription product
3. Visit the WP Admin > Edit Subscription page
4. Under the shipping details, click the pencil and edit the customer note field.
5. Hit **Update** and on page refresh, notice how the customer note changes aren't sticking
6. Check out this branch and update the customer note to confirm it's working
7. Disable HPOS and confirm saving the subscription as a WP Post continues to work.


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
