### PR TITLE
Fix subscription product sync options for yearly products not being editable

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -383,10 +383,6 @@ a.close-subscriptions-search {
 	margin-right: 2px;
 }
 
-#variable_product_options .select2 {
-	margin: 2px 2px 0 0;
-}
-
 #variable_product_options
 	.select2-container 
 	.select2-selection--single {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -77,8 +77,16 @@ a.close-subscriptions-search {
 	display: block;
 	width: 50%;
 }
-.subscription_sync_annual > .select2-container {
+/* Variation Subscription Product Sync Settings */
+.variable_subscription_sync .subscription_sync_annual > .select2-container {
 	max-width: 49.5%;
+}
+/* Simple Subscription Product Sync Settings */
+#general_product_data .subscription_sync_annual .select2-container {
+	max-width: 45%;
+}
+#general_product_data .subscription_sync_annual .select2-container:not(:last-child) {
+	margin-right: 3.8%;
 }
 @media only screen and ( max-width: 1280px ) {
 	.woocommerce_options_panel ._subscription_price_fields .wrap,

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -79,7 +79,10 @@ a.close-subscriptions-search {
 }
 /* Variation Subscription Product Sync Settings */
 .variable_subscription_sync .subscription_sync_annual > .select2-container {
-	max-width: 49.5%;
+	max-width: 48%;
+}
+.variable_subscription_sync .subscription_sync_annual > .select2-container:last-child {
+	float: right;
 }
 /* Simple Subscription Product Sync Settings */
 #general_product_data .subscription_sync_annual .select2-container {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -389,7 +389,8 @@ a.close-subscriptions-search {
 #variable_product_options
 	.variable_subscription_pricing_2_3
 	.wc_input_subscription_period_interval + .select2 {
-	width: 33% !important;
+	width: calc( 100% / 3 ) !important;
+	float: left;
 }
 #variable_product_options
 	.variable_subscription_pricing_2_3
@@ -398,6 +399,7 @@ a.close-subscriptions-search {
 	.variable_subscription_pricing_2_3
 	.wc_input_subscription_period_interval + .select2 {
 		padding-bottom: 2px;
+		margin-top: 2px;
 }
 
 #variable_product_options

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -84,6 +84,7 @@ a.close-subscriptions-search {
 .variable_subscription_sync .subscription_sync_annual > .select2-container:last-child {
 	float: right;
 }
+#woocommerce-product-data .variable_subscription_pricing ._subscription_length_field .wc_input_subscription_length + .select2,
 #woocommerce-product-data .variable_subscription_sync .subscription_sync_week_month .wc_input_subscription_payment_sync + .select2 {
 	width: 100% !important;
 }
@@ -332,7 +333,7 @@ a.close-subscriptions-search {
 	margin-top: 0;
 }
 .wc_input_subscription_trial_period + .select2 {
-	width: 48% !important;
+	width: 50% !important;
 	margin-top: 0;
 }
 
@@ -432,13 +433,14 @@ a.close-subscriptions-search {
 }
 #variable_product_options
 	.variable_subscription_pricing_2_3
-	.wc_input_subscription_trial_period,
+	.wc_input_subscription_trial_period + .select2,
 #variable_product_options
 	.variable_subscription_pricing_2_3
 	.wc_input_subscription_trial_length {
-	max-width: 50%;
+	width: 50%;
 }
-.variable_subscription_pricing_2_3 .wc_input_subscription_trial_period {
+.variable_subscription_pricing_2_3 .wc_input_subscription_trial_period + .select2 {
+	margin-top: 2px;
 	float: right;
 }
 .variable_subscription_pricing_2_3 .variable_subscription_length,

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -77,6 +77,9 @@ a.close-subscriptions-search {
 	display: block;
 	width: 50%;
 }
+.subscription_sync_annual > .select2-container {
+	max-width: 49.5%;
+}
 @media only screen and ( max-width: 1280px ) {
 	.woocommerce_options_panel ._subscription_price_fields .wrap,
 	.woocommerce_options_panel ._subscription_trial_length_field .wrap,

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -84,6 +84,9 @@ a.close-subscriptions-search {
 .variable_subscription_sync .subscription_sync_annual > .select2-container:last-child {
 	float: right;
 }
+#woocommerce-product-data .variable_subscription_sync .subscription_sync_week_month .wc_input_subscription_payment_sync + .select2 {
+	width: 100% !important;
+}
 /* Simple Subscription Product Sync Settings */
 ._subscription_trial_length_field .select2-container:last-child,
 #general_product_data .subscription_sync_annual .select2-container:last-child {
@@ -106,8 +109,8 @@ a.close-subscriptions-search {
 }
 .woocommerce_options_panel ._subscription_price_fields .wrap input,
 .woocommerce_options_panel ._subscription_price_fields .wrap select {
-	width: 30.75%;
-	margin-right: 3.8%;
+	width: 30%;
+	margin-right: 5%;
 }
 .woocommerce_options_panel
 	._subscription_payment_sync_date_day_field
@@ -317,15 +320,15 @@ a.close-subscriptions-search {
 	width: auto !important;
 }
 
-.wc_input_subscription_length +.select2,
-.wc_input_subscription_payment_sync +.select2,
+#woocommerce-product-data .wc_input_subscription_length +.select2,
+#woocommerce-product-data .wc_input_subscription_payment_sync +.select2,
 #_subscription_limit +.select2 {
 	width: 50% !important;
 	margin-bottom: 4px;
 }
 
 .wc_input_subscription_period + .select2 {
-	width: 30.75% !important;
+	width: 30% !important;
 	margin-top: 0;
 }
 .wc_input_subscription_trial_period + .select2 {
@@ -333,9 +336,9 @@ a.close-subscriptions-search {
 	margin-top: 0;
 }
 
-.wc_input_subscription_period_interval + .select2 {
-	margin-right: 3.8%;
-	width: 30.75% !important;
+#general_product_data .wc_input_subscription_period_interval + .select2 {
+	margin-right: 5%;
+	width: 30% !important;
 }
 
 .variable_subscription_sync p._subscription_payment_sync_field {
@@ -381,10 +384,19 @@ a.close-subscriptions-search {
 	.wc_input_subscription_price,
 #variable_product_options
 	.variable_subscription_pricing_2_3
-	.wc_input_subscription_period_interval {
-	max-width: 33%;
-	float: left;
-	margin-right: 2px;
+	.wc_input_subscription_period + .select2,
+#variable_product_options
+	.variable_subscription_pricing_2_3
+	.wc_input_subscription_period_interval + .select2 {
+	width: 33% !important;
+}
+#variable_product_options
+	.variable_subscription_pricing_2_3
+	.wc_input_subscription_period + .select2,
+#variable_product_options
+	.variable_subscription_pricing_2_3
+	.wc_input_subscription_period_interval + .select2 {
+		padding-bottom: 2px;
 }
 
 #variable_product_options

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -85,12 +85,16 @@ a.close-subscriptions-search {
 	float: right;
 }
 /* Simple Subscription Product Sync Settings */
-#general_product_data .subscription_sync_annual .select2-container {
-	max-width: 45%;
+._subscription_trial_length_field .select2-container:last-child,
+#general_product_data .subscription_sync_annual .select2-container:last-child {
+	width: 45% !important;
+	margin-left: 5%;
 }
-#general_product_data .subscription_sync_annual .select2-container:not(:last-child) {
-	margin-right: 3.8%;
+._subscription_trial_length_field .select2-container:not( :last-child ),
+#general_product_data .subscription_sync_annual .select2-container:not( :last-child ) {
+	width: 50% !important;
 }
+
 @media only screen and ( max-width: 1280px ) {
 	.woocommerce_options_panel ._subscription_price_fields .wrap,
 	.woocommerce_options_panel ._subscription_trial_length_field .wrap,
@@ -105,8 +109,6 @@ a.close-subscriptions-search {
 	width: 30.75%;
 	margin-right: 3.8%;
 }
-.woocommerce_options_panel ._subscription_trial_length_field .wrap input,
-.woocommerce_options_panel ._subscription_trial_length_field .wrap select,
 .woocommerce_options_panel
 	._subscription_payment_sync_date_day_field
 	.wrap
@@ -315,17 +317,19 @@ a.close-subscriptions-search {
 	width: auto !important;
 }
 
-.wc_input_subscription_payment_sync +.select2,
 .wc_input_subscription_length +.select2,
+.wc_input_subscription_payment_sync +.select2,
 #_subscription_limit +.select2 {
-	min-width: 180px;
-	width: 80% !important;
+	width: 50% !important;
 	margin-bottom: 4px;
 }
 
-.wc_input_subscription_period + .select2,
-.wc_input_subscription_trial_period + .select2 {
+.wc_input_subscription_period + .select2 {
 	width: 30.75% !important;
+	margin-top: 0;
+}
+.wc_input_subscription_trial_period + .select2 {
+	width: 48% !important;
 	margin-top: 0;
 }
 
@@ -384,20 +388,20 @@ a.close-subscriptions-search {
 }
 
 #variable_product_options
-	.select2-container 
+	.select2-container
 	.select2-selection--single {
 	min-height: 40px;
 }
 
-#variable_product_options 
-	.select2-container 
-	.select2-selection--single 
+#variable_product_options
+	.select2-container
+	.select2-selection--single
 	.select2-selection__rendered {
 	line-height: 36px;
 }
-#variable_product_options 
-	.select2-container 
-	.select2-selection--single 
+#variable_product_options
+	.select2-container
+	.select2-selection--single
 	.select2-selection__arrow {
 	height: 36px;
 }

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -708,14 +708,18 @@ jQuery( function ( $ ) {
 				);
 
 				if ( 0 < $( this ).val() ) {
-					$syncDayOfMonthInput
-						.val( 1 )
-						.attr( {
-							step: '1',
-							min: '1',
-							max: $.daysInMonth( $( this ).val() ),
-						} )
-						.prop( 'disabled', false );
+					// Clear existing options.
+					$syncDayOfMonthInput.empty();
+
+					// Add options for each day in the month.
+					for ( var day = 1; day <= $.daysInMonth( $( this ).val() ); day++ ) {
+						$syncDayOfMonthInput.append( $( '<option>', {
+							value: day,
+							text: day
+						} ) );
+					}
+
+					$syncDayOfMonthInput.prop( 'disabled', false );
 				} else {
 					$syncDayOfMonthInput.val( 0 ).trigger( 'change' );
 				}

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -722,6 +722,7 @@ jQuery( function ( $ ) {
 					$syncDayOfMonthInput.prop( 'disabled', false );
 				} else {
 					$syncDayOfMonthInput.val( 0 ).trigger( 'change' );
+					$syncDayOfMonthInput.prop( 'disabled', true );
 				}
 			}
 		);

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Make sure we always clear the subscription object from cache after updating dates.
 * Fix - Use block theme styles for the 'Add to Cart' button on subscription product pages.
 * Fix - Customer notes not being saved on the Edit Subscription page for stores with HPOS enabled.
+* Fix - Ensure products that have a yearly billing period can choose a date that the subscription is synchronized to.
 
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -313,9 +313,11 @@ class WC_Subscriptions_Synchroniser {
 
 					<?php $days_in_month = $payment_month ? gmdate( 't', wc_string_to_timestamp( "2001-{$payment_month}-01" ) ) : 0; ?>
 					<select id="<?php echo esc_attr( self::$post_meta_key_day ); ?>" name="<?php echo esc_attr( self::$post_meta_key_day ); ?>" class="wc_input_subscription_payment_sync wc-enhanced-select" <?php disabled( 0, $payment_month, true ); ?> />
-						<?php foreach ( range( 1, $days_in_month ) as $day ) {
+					<?php
+						foreach ( range( 1, $days_in_month ) as $day ) {
 							echo '<option value="' . esc_attr( $day ) . '"' . selected( $day, $payment_day, false ) . '>' . esc_html( $day ) . '</option>';
-						} ?>
+						}
+					?>
 					</select>
 				</span>
 				<?php echo wcs_help_tip( self::$sync_description_year ); ?>

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -312,7 +312,11 @@ class WC_Subscriptions_Synchroniser {
 					</select>
 
 					<?php $days_in_month = $payment_month ? gmdate( 't', wc_string_to_timestamp( "2001-{$payment_month}-01" ) ) : 0; ?>
-					<input type="number" id="<?php echo esc_attr( self::$post_meta_key_day ); ?>" name="<?php echo esc_attr( self::$post_meta_key_day ); ?>" class="wc_input_subscription_payment_sync wc-enhanced-select" value="<?php echo esc_attr( $payment_day ); ?>" placeholder="<?php echo esc_attr_x( 'Day', 'input field placeholder for day field for annual subscriptions', 'woocommerce-subscriptions' ); ?>" step="1" min="<?php echo esc_attr( min( 1, $days_in_month ) ); ?>" max="<?php echo esc_attr( $days_in_month ); ?>" <?php disabled( 0, $payment_month, true ); ?> />
+					<select id="<?php echo esc_attr( self::$post_meta_key_day ); ?>" name="<?php echo esc_attr( self::$post_meta_key_day ); ?>" class="wc_input_subscription_payment_sync wc-enhanced-select" <?php disabled( 0, $payment_month, true ); ?> />
+						<?php foreach ( range( 1, $days_in_month ) as $day ) {
+							echo '<option value="' . esc_attr( $day ) . '"' . selected( $day, $payment_day, false ) . '>' . esc_html( $day ) . '</option>';
+						} ?>
+					</select>
 				</span>
 				<?php echo wcs_help_tip( self::$sync_description_year ); ?>
 			</p><?php

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -314,9 +314,9 @@ class WC_Subscriptions_Synchroniser {
 					<?php $days_in_month = $payment_month ? gmdate( 't', wc_string_to_timestamp( "2001-{$payment_month}-01" ) ) : 0; ?>
 					<select id="<?php echo esc_attr( self::$post_meta_key_day ); ?>" name="<?php echo esc_attr( self::$post_meta_key_day ); ?>" class="wc_input_subscription_payment_sync wc-enhanced-select" <?php disabled( 0, $payment_month, true ); ?> />
 					<?php
-						foreach ( range( 1, $days_in_month ) as $day ) {
-							echo '<option value="' . esc_attr( $day ) . '"' . selected( $day, $payment_day, false ) . '>' . esc_html( $day ) . '</option>';
-						}
+					foreach ( range( 1, $days_in_month ) as $day ) {
+						echo '<option value="' . esc_attr( $day ) . '"' . selected( $day, $payment_day, false ) . '>' . esc_html( $day ) . '</option>';
+					}
 					?>
 					</select>
 				</span>

--- a/templates/admin/html-variation-synchronisation.php
+++ b/templates/admin/html-variation-synchronisation.php
@@ -34,12 +34,16 @@ global $wp_locale;
 				<?php echo wcs_help_tip( WC_Subscriptions_Synchroniser::$sync_description_year ); ?>
 			</label>
 			<select name="variable_subscription_payment_sync_date_month[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_payment_sync wc_input_subscription_payment_sync_month wc-enhanced-select">
-			<?php foreach ( WC_Subscriptions_Synchroniser::get_year_sync_options() as $key => $value ) : ?>
-				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $payment_month ); ?>><?php echo esc_html( $value ); ?></option>
-			<?php endforeach; ?>
+				<?php foreach ( WC_Subscriptions_Synchroniser::get_year_sync_options() as $key => $value ) : ?>
+					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $payment_month ); ?>><?php echo esc_html( $value ); ?></option>
+				<?php endforeach; ?>
 			</select>
 			<?php $daysInMonth = $payment_month ? gmdate( 't', wc_string_to_timestamp( "2001-{$payment_month}-01" ) ) : 0; ?>
-			<input type="number" class="wc_input_subscription_payment_sync wc_input_subscription_payment_sync_day" name="variable_subscription_payment_sync_date_day[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $payment_day ); ?>" placeholder="<?php echo esc_attr_x( 'Day', 'input field placeholder for day field for annual subscriptions', 'woocommerce-subscriptions' ); ?>" step="1" min="<?php echo esc_attr( min( 1, $daysInMonth ) ); ?>" max="<?php echo esc_attr( $daysInMonth ); ?>" <?php disabled( 0, $payment_month, true ); ?> />
+			<select name="variable_subscription_payment_sync_date_day[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_payment_sync wc_input_subscription_payment_sync_day wc-enhanced-select form-row form-row-first" placeholder="<?php echo esc_attr_x( 'Day', 'input field placeholder for day field for annual subscriptions', 'woocommerce-subscriptions' ); ?>" <?php disabled( 0, $payment_month, true ); ?> />
+				<?php foreach ( range( 1, $days_in_month ) as $day ) {
+					echo '<option value="' . esc_attr( $day ) . '"' . selected( $day, $payment_day, false ) . '>' . esc_html( $day ) . '</option>';
+				} ?>
+			</select>
 		</div>
 	</div>
 </div>

--- a/templates/admin/html-variation-synchronisation.php
+++ b/templates/admin/html-variation-synchronisation.php
@@ -38,7 +38,7 @@ global $wp_locale;
 					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $payment_month ); ?>><?php echo esc_html( $value ); ?></option>
 				<?php endforeach; ?>
 			</select>
-			<?php $daysInMonth = $payment_month ? gmdate( 't', wc_string_to_timestamp( "2001-{$payment_month}-01" ) ) : 0; ?>
+			<?php $days_in_month = $payment_month ? gmdate( 't', wc_string_to_timestamp( "2001-{$payment_month}-01" ) ) : 0; ?>
 			<select name="variable_subscription_payment_sync_date_day[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_payment_sync wc_input_subscription_payment_sync_day wc-enhanced-select form-row form-row-first" placeholder="<?php echo esc_attr_x( 'Day', 'input field placeholder for day field for annual subscriptions', 'woocommerce-subscriptions' ); ?>" <?php disabled( 0, $payment_month, true ); ?> />
 				<?php foreach ( range( 1, $days_in_month ) as $day ) {
 					echo '<option value="' . esc_attr( $day ) . '"' . selected( $day, $payment_day, false ) . '>' . esc_html( $day ) . '</option>';


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4588

## Description

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/508, the number input elements that enable store admin to select the day of the month for which yearly subscription products are synced to was changed from a `<input type="number" ... >` to a select2 (by giving it the `wc-enhanced-select` class. This essentially broke these elements because attempting to turn input elements into a select2 powered element didn't work - ie they had no options.

<p align="center">
<img width="420" alt="Screenshot 2024-03-09 at 10 43 12 am" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/676587dc-8a93-4171-9269-a08662e9d28a">
</p>

This PR fixes this by turning these elements into true select2 elements via `<select>` and `<option>` elements.

<p align="center">

<img width="420" alt="Screenshot 2024-03-09 at 3 35 06 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/5b8ce8d5-0582-420d-a7f6-e2bfa7de06e9">
</p>


## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Simple Subscription.

1. Go to **Products → Add new**
2. Choose **Simple subscription** from the product type dropdown.
3. Enter a price and choose "yearly" as the subscription period.
4. In the "Synchronise renewals" section choose a month
5. Try to set a day. 
6. On `trunk` you'll notice the dropdown is empty. 
7. On this branch it should have all the days of the chosen month. eg
  - 28 for February
  - 30 for September
  - 31 for January


| Before | After |
|--------|--------|
| <img width="971" alt="Screenshot 2024-03-14 at 3 48 28 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/298b275c-bcf9-4110-bf7c-97604880b885"> | <img width="967" alt="Screenshot 2024-03-14 at 3 54 13 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/3d098b5e-a78a-40b3-b33b-c95e63c37d18"> | 

8. Confirm that saving the synchronisation product is correctly sets the product as a synced product to that date. 
9. Confirm that unselecting a month option unsets the synchronisation property from the product. 
10. Confirm that weekly, monthly products are unaffected by this change.

#### Variable Subscription

1. Go to **Products → Add new**
2. Choose **Variable subscription** from the product type dropdown.
3. Create variations 
4. Enter a price and choose "yearly" as the subscription period.
5. In the "Synchronise renewals" section choose a month (eg January)
6. Try to set a day. 
7. On `trunk` you'll notice the date selector is a number input. 
8. On this branch it should be select2 with all the days of the chosen month as options. eg
  - 28 for February
  - 30 for September
  - 31 for January

| Before | After |
|--------|--------|
| <img width="853" alt="Screenshot 2024-03-14 at 4 14 05 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/60c66af9-f65b-496f-a056-ebe440618085"> | <img width="852" alt="Screenshot 2024-03-14 at 4 15 13 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/7f93dc8d-2802-409f-a2f6-302775f332d8">| 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
