### PR TITLE
Clear subscription cache after writing dates to the database

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.9.0 - xxxx-xx-xx =
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.
 * Fix - Resolved an issue that could cause an empty error notice to appear on the My Account > Payment methods page when a customer attempted to delete a token used by subscriptions.
+* Fix - Make sure we always clear the subscription object from cache after updating dates.
 
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -796,6 +796,11 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 			$dates_saved[ $date_prop ] = wcs_get_datetime_from( $subscription->get_time( $date_type ) );
 		}
 
+		// If dates were saved, clear the caches.
+		if ( ! empty( $dates_saved ) ) {
+			$this->clear_caches( $subscription );
+		}
+
 		return $dates_saved;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4620

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR addresses a caching issue identified while adding Subscriptions compatibility to our Pre-Orders extension. What was found was that updating the date of a subscription did not refresh the cache, resulting in outdated dates being displayed, particularly in customer emails.

This issue was caused by our datastore class not clearing the cache inside `save_dates()` or `write_dates_to_database()`. Our other add, update and delete metadata functions already clear the cache thanks to piggy-backing off of WooCommerce Core code. For reference, you can see the cache being cleared inside the following functions:
- `persist_save()`
- `persist_updates()`
- `update()`
- `after_meta_change()`, which is called by:
   - `update_meta()`
   - `delete_meta()`
   - `add_meta()`

I couldn't replicate the error when subscriptions are stored in the WP Posts table, therefore this PR only changes the HPOS datastore class.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Enable HPOS and purchase a subscription product to create a fresh subscription
2. Check out `trunk` of subscriptions-core
3. Using something like WP Console, run the following snippet of code:
```
// Update the subscriptions start date
$subscription = wcs_get_subscription( 123 );
$subscription->update_dates( [ 'start_date' => '2020-01-01 00:00:00' ] );

// Get a fresh copy of the subscription
$subscription = wcs_get_subscription( 123 );
echo $subscription->get_date( 'start' );
```
4. While on `trunk`, notice the outdated start date is returned (due to the subscription object being fetched from cache)
5. Checkout `issue/4620`, update the snippet to a different start date again
6. Run the snippet and confirm a fresh copy of the subscription is being returned and the correct start date is being echoed.
7. Disable HPOS and confirm the caching issue is not present.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
