### PR TITLE
Introduce filter to prevent activation of subscriptions following payment.

### DIFF
--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -481,6 +481,23 @@ class WC_Subscriptions_Order {
 		$unpaid_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'on-hold', 'failed' ), $order );
 		$order_completed = in_array( $new_order_status, $paid_statuses, true ) && in_array( $old_order_status, $unpaid_statuses, true );
 
+		/**
+		 * Filter whether the subscription order is considered completed.
+		 *
+		 * Allow third party extensions to modify whether the order is considered
+		 * completed and the subscription should activate. This allows for different
+		 * treatment of orders and subscriptions during the completion flow.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool              $order_completed  Whether the order is considered completed.
+		 * @param string            $new_order_status The new order status.
+		 * @param string            $old_order_status The old order status.
+		 * @param WC_Subscription[] $subscriptions    The subscriptions in the order.
+		 * @param WC_Order          $order            The order object.
+		 */
+		$order_completed = apply_filters( 'wcs_is_subscription_order_completed', $order_completed, $new_order_status, $old_order_status, $subscriptions, $order );
+
 		foreach ( $subscriptions as $subscription ) {
 			// A special case where payment completes after user cancels subscription
 			if ( $order_completed && $subscription->has_status( 'cancelled' ) ) {

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -488,7 +488,7 @@ class WC_Subscriptions_Order {
 		 * completed and the subscription should activate. This allows for different
 		 * treatment of orders and subscriptions during the completion flow.
 		 *
-		 * @since x.x.x
+		 * @since 6.9.0
 		 *
 		 * @param bool              $order_completed  Whether the order is considered completed.
 		 * @param string            $new_order_status The new order status.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -501,8 +501,24 @@ class WC_Subscriptions_Order {
 				$subscription->update_dates( array( 'cancelled' => $cancelled_date ) );
 			}
 
+			$activate_subscription = $order_completed && ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) && ! $subscription->has_status( 'active' );
+
+			/**
+			 * Filters whether to activate a subscription when an order is paid for.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param bool            $activate_subscription Whether to activate the subscription. Defaults to true if new status is a
+			 *                                           paid status and the old status is an unpaid status. False otherwise.
+			 * @param int             $order_id              The order ID.
+			 * @param WC_Subscription $subscription      The subscription.
+			 * @param string          $new_order_status      The new order status.
+			 * @param string          $old_order_status      The old order status.
+			 */
+			$activate_subscription = apply_filters( 'wcs_activate_subscription_on_payment', $activate_subscription, $order_id, $subscription, $new_order_status, $old_order_status );
+
 			// Do we need to activate a subscription?
-			if ( $order_completed && ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) && ! $subscription->has_status( 'active' ) ) {
+			if ( $activate_subscription ) {
 
 				$new_start_date_offset = current_time( 'timestamp', true ) - $subscription->get_time( 'start' );
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -501,24 +501,8 @@ class WC_Subscriptions_Order {
 				$subscription->update_dates( array( 'cancelled' => $cancelled_date ) );
 			}
 
-			$activate_subscription = $order_completed && ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) && ! $subscription->has_status( 'active' );
-
-			/**
-			 * Filters whether to activate a subscription when an order is paid for.
-			 *
-			 * @since x.x.x
-			 *
-			 * @param bool            $activate_subscription Whether to activate the subscription. Defaults to true if new status is a
-			 *                                           paid status and the old status is an unpaid status. False otherwise.
-			 * @param int             $order_id              The order ID.
-			 * @param WC_Subscription $subscription      The subscription.
-			 * @param string          $new_order_status      The new order status.
-			 * @param string          $old_order_status      The old order status.
-			 */
-			$activate_subscription = apply_filters( 'wcs_activate_subscription_on_payment', $activate_subscription, $order_id, $subscription, $new_order_status, $old_order_status );
-
 			// Do we need to activate a subscription?
-			if ( $activate_subscription ) {
+			if ( $order_completed && ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) && ! $subscription->has_status( 'active' ) ) {
 
 				$new_start_date_offset = current_time( 'timestamp', true ) - $subscription->get_time( 'start' );
 


### PR DESCRIPTION
Fixes #578

## Description

_Edited following discussion below with Matt_

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

Introduces a new filter within `WC_Subscriptions_Order::maybe_record_subscription_payment()` to allow third party extensions to prevent subscriptions from being marked as completed and activated following payment. This is to account for statuses that WooCommerce Core needs to consider the main order completed but the subscription remains in progress.

This is to assist with pre-order support of subscription with upfront payments and to prevent renewals before the product has been released.

In pre-orders it was considered to simply remove the filter registered by subscriptions (`remove_action( 'woocommerce_order_status_changed', 'WC_Subscriptions_Order::maybe_record_subscription_payment', 9, 3 );`) but I though that had a greater risk of unintended side-effects for unrelated subscription products. 

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to …
2. Click on …

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
