### PR TITLE
Only update token meta after updating token default if the meta key is found

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Make sure we always clear the subscription object from cache after updating dates.
 * Fix - Use block theme styles for the 'Add to Cart' button on subscription product pages.
 * Fix - Customer notes not being saved on the Edit Subscription page for stores with HPOS enabled.
+* Fix - Avoid setting empty meta keys on subscriptions when changing the customer's default payment method.
 
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.

--- a/includes/class-wcs-payment-tokens.php
+++ b/includes/class-wcs-payment-tokens.php
@@ -30,14 +30,12 @@ class WCS_Payment_Tokens extends WC_Payment_Tokens {
 	public static function update_subscription_token( $subscription, $new_token, $old_token ) {
 		$token_payment_gateway = $old_token->get_gateway_id();
 		$payment_meta_table    = self::get_subscription_payment_meta( $subscription, $token_payment_gateway );
-		$updated               = false;
 
 		// Attempt to find the token meta key from the subscription payment meta and the old token.
 		if ( is_array( $payment_meta_table ) ) {
 			foreach ( $payment_meta_table as $meta ) {
 				foreach ( $meta as $meta_key => $meta_data ) {
 					if ( $old_token->get_token() === $meta_data['value'] ) {
-						$updated = true;
 						$subscription->update_meta_data( $meta_key, $new_token->get_token() );
 						$subscription->save();
 						break 2;
@@ -57,12 +55,12 @@ class WCS_Payment_Tokens extends WC_Payment_Tokens {
 		/**
 		 * Enable third-party plugins to run their own updates and filter whether the token was updated or not.
 		 *
-		 * @param bool Whether the token was updated. Default is true if the token meta key was found and updated.
+		 * @param bool Whether the token was updated. Default is true.
 		 * @param WC_Subscription  $subscription
 		 * @param WC_Payment_Token $new_token
 		 * @param WC_Payment_Token $old_token
 		 */
-		$updated = apply_filters( 'woocommerce_subscriptions_update_subscription_token', $updated, $subscription, $new_token, $old_token );
+		$updated = apply_filters( 'woocommerce_subscriptions_update_subscription_token', true, $subscription, $new_token, $old_token );
 
 		if ( $updated ) {
 			do_action( 'woocommerce_subscription_token_changed', $subscription, $new_token, $old_token );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4631

## Description

If you update your default payment method on the **My Account → Payment methods** screen and the Payment method doesn't integrate with the `woocommerce_subscription_payment_meta` filter (eg **WooPayments**), then additional meta will be added to the subscription without a key. 

<p align="center"> 
<img width="618" alt="Screenshot 2024-03-13 at 4 08 57 pm" src="https://github.com/woocommerce/woocommerce-subscriptions/assets/8490476/434679e6-9ba3-45da-895f-6fd67b72292d">
</br>
<sup>Notice the final row of the has an empty meta key</sup>
</p>

This was caused by the foreach loop I've changed in this PR. If the loop didn't find a meta key used for tokens, it would just set it to an empty key because that's the default. 

This PR fixes that. 

## How to test this PR

1. Install WooPayments
2. Install Woo Subscriptions
3. Create 2 subscription products with different billing frequencies (weekly and monthly).
4. Purchase the products together using a standard card `4242424242424242`.
1. Make another purchase using a different card eg `4000056655665556`. 
2. Go to **My Account → Payment methods** 
1. Change the `4000056655665556` payment method to your default. 

<p align="center">
<img width="400" alt="Screenshot 2024-03-13 at 4 15 33 pm" src="https://github.com/woocommerce/woocommerce-subscriptions/assets/8490476/4e51c570-3f64-4fc4-81aa-800304eaaf65">
</p>

8. In the notice that appears on the next page, click **"Yes"**.
   - On `trunk`, check the order meta table for your subscription and you should notice there is an empty meta key with the token ID stored.
   - On this branch, make another subscription purchase using a new card, repeat steps 6-8 no empty additional meta key should be stored.

Zip of this branch for convenience: [woocommerce-subscriptions-core.zip](https://github.com/Automattic/woocommerce-subscriptions-core/files/14716479/woocommerce-subscriptions-core.zip) 

| `trunk` | This branch |
|--------|--------|
|<img width="638" alt="Screenshot 2024-03-22 at 1 18 19 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/fd76048f-a50f-4aea-a2ca-151ccd88f4e7">| <img width="643" alt="Screenshot 2024-03-22 at 1 16 13 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/a44f158c-779d-4264-88e3-9b30b8ec1a43">| 



## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)