### PR TITLE
Use `wc_wp_theme_get_element_class_name()` instead of hardcoding the `wp-element-button` class name

### DIFF
--- a/templates/single-product/add-to-cart/subscription.php
+++ b/templates/single-product/add-to-cart/subscription.php
@@ -2,7 +2,6 @@
 /**
  * Subscription Product Add to Cart
  *
- * @author  Prospress
  * @package WooCommerce-Subscriptions/Templates
  * @version 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
  */
@@ -39,11 +38,13 @@ if ( $product->is_in_stock() ) : ?>
 		<?php
 		do_action( 'woocommerce_before_add_to_cart_quantity' );
 
-		woocommerce_quantity_input( array(
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
-			'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // WPCS: CSRF ok, input var ok.
-		) );
+		woocommerce_quantity_input(
+			[
+				'min_value'   => apply_filters( 'woocommerce_quantity_input_min', $product->get_min_purchase_quantity(), $product ),
+				'max_value'   => apply_filters( 'woocommerce_quantity_input_max', $product->get_max_purchase_quantity(), $product ),
+				'input_value' => isset( $_POST['quantity'] ) ? wc_stock_amount( wp_unslash( $_POST['quantity'] ) ) : $product->get_min_purchase_quantity(), // phpcs:ignore WordPress.Security.NonceVerification.Missing -- input var ok.
+			]
+		);
 
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>

--- a/templates/single-product/add-to-cart/subscription.php
+++ b/templates/single-product/add-to-cart/subscription.php
@@ -48,7 +48,7 @@ if ( $product->is_in_stock() ) : ?>
 		do_action( 'woocommerce_after_add_to_cart_quantity' );
 		?>
 
-		<button type="submit" class="single_add_to_cart_button button alt wp-element-button" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
+		<button type="submit" class="single_add_to_cart_button button alt<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>"><?php echo esc_html( $product->single_add_to_cart_text() ); ?></button>
 
 		<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 


### PR DESCRIPTION
Fixes #569 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/574 we merged a small change to fix the styling of our "Sign up now" on subscription product pages for stores using a block theme (i.e. 2024 default theme).

This PR tweaks the code slightly to use `wc_wp_theme_get_element_class_name()` instead of hardcoding the `wp-element-button` class name.

The `wc_wp_theme_get_element_class_name()` function was added to WooCommerce Core in v7.0.1 which is below our minimum supported version so no need to check this function exists.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> Since we already fixed the button styling issue in a previous PR, there won't be any noticeable issues to confirm are fixed in this PR. Instead we'll just be checking our sign up buttons contain the correct class names.

1. Activate the 2024 default theme
2. Visit a simple subscription and confirm the page is styled correctly.
3. Inspect the Sign up button and confirm it contains the `'wp-element-button'` class name:
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/c521070f-9173-4bea-83a8-44c4362498e2)

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
