### PR TITLE
Use more scalable methods to filter the Orders list table by the parent order relationship on HPOS enabled sites

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Make sure we always clear the subscription object from cache after updating dates.
 * Fix - Use block theme styles for the 'Add to Cart' button on subscription product pages.
 * Fix - Customer notes not being saved on the Edit Subscription page for stores with HPOS enabled.
+* Fix - Use a more scalable way to filter the orders admin list table by parent orders on HPOS stores.
 
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -1351,7 +1351,7 @@ class WC_Subscriptions_Order {
 			// Limit query to parent orders.
 			$query_clauses['join']  = ( empty( $query_clauses['join'] ) ? '' : $query_clauses['join'] . ' ' );
 			$query_clauses['join'] .= "INNER JOIN {$order_query->get_table_name( 'orders' )} as subscriptions ON subscriptions.parent_order_id = wp_wc_orders.id AND subscriptions.type = 'shop_subscription'";
-		} elseif ( false === $include_parent_orders  ) {
+		} elseif ( false === $include_parent_orders ) {
 			// Exclude parent orders.
 			$query_clauses['where']  = ( empty( $query_clauses['where'] ) ? '1=1 ' : $query_clauses['where'] . ' ' );
 			$query_clauses['where'] .= "AND wp_wc_orders.id NOT IN (SELECT parent_order_id FROM {$order_query->get_table_name( 'orders' )} WHERE type = 'shop_subscription')";

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -819,7 +819,11 @@ class WC_Subscriptions_Order {
 			);
 
 		} elseif ( 'parent' === $selected_shop_order_subtype ) {
-			$order_query_args['subscription_parent'] = true;
+			if ( wcs_is_custom_order_tables_usage_enabled() ) {
+				$order_query_args['subscription_parent'] = true;
+			} else {
+				$order_query_args['post__in'] = wcs_get_subscription_orders();
+			}
 		} else {
 
 			switch ( $selected_shop_order_subtype ) {
@@ -849,7 +853,11 @@ class WC_Subscriptions_Order {
 
 		// Also exclude parent orders from non-subscription query
 		if ( 'regular' === $selected_shop_order_subtype ) {
-			$order_query_args['subscription_parent'] = false;
+			if ( wcs_is_custom_order_tables_usage_enabled() ) {
+				$order_query_args['subscription_parent'] = false;
+			} else {
+				$order_query_args['post__not_in'] = wcs_get_subscription_orders();
+			}
 		}
 
 		return $order_query_args;

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -1354,7 +1354,7 @@ class WC_Subscriptions_Order {
 		} elseif ( false === $include_parent_orders ) {
 			// Exclude parent orders.
 			$query_clauses['where']  = ( empty( $query_clauses['where'] ) ? '1=1 ' : $query_clauses['where'] . ' ' );
-			$query_clauses['where'] .= "AND wp_wc_orders.id NOT IN (SELECT parent_order_id FROM {$order_query->get_table_name( 'orders' )} WHERE type = 'shop_subscription')";
+			$query_clauses['where'] .= "AND {$order_query->get_table_name( 'orders' )}.id NOT IN (SELECT parent_order_id FROM {$order_query->get_table_name( 'orders' )} WHERE type = 'shop_subscription')";
 		}
 
 		return $query_clauses;

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -1350,7 +1350,7 @@ class WC_Subscriptions_Order {
 		if ( true === $include_parent_orders ) {
 			// Limit query to parent orders.
 			$query_clauses['join']  = ( empty( $query_clauses['join'] ) ? '' : $query_clauses['join'] . ' ' );
-			$query_clauses['join'] .= "INNER JOIN {$order_query->get_table_name( 'orders' )} as subscriptions ON subscriptions.parent_order_id = wp_wc_orders.id AND subscriptions.type = 'shop_subscription'";
+			$query_clauses['join'] .= "INNER JOIN {$order_query->get_table_name( 'orders' )} as subscriptions ON subscriptions.parent_order_id = {$order_query->get_table_name( 'orders' )}.id AND subscriptions.type = 'shop_subscription'";
 		} elseif ( false === $include_parent_orders ) {
 			// Exclude parent orders.
 			$query_clauses['where']  = ( empty( $query_clauses['where'] ) ? '1=1 ' : $query_clauses['where'] . ' ' );

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -75,6 +75,8 @@ class WC_Subscriptions_Order {
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', array( __CLASS__, 'add_subscription_order_query_args' ), 10, 2 );
 
 		add_filter( 'woocommerce_order_query_args', array( __CLASS__, 'map_order_query_args_for_subscriptions' ) );
+
+		add_filter( 'woocommerce_orders_table_query_clauses', [ __CLASS__, 'filter_orders_query_by_parent_orders' ], 10, 2 );
 	}
 
 	/*
@@ -817,9 +819,7 @@ class WC_Subscriptions_Order {
 			);
 
 		} elseif ( 'parent' === $selected_shop_order_subtype ) {
-
-			$order_query_args['post__in'] = wcs_get_subscription_orders();
-
+			$order_query_args['subscription_parent'] = true;
 		} else {
 
 			switch ( $selected_shop_order_subtype ) {
@@ -849,7 +849,7 @@ class WC_Subscriptions_Order {
 
 		// Also exclude parent orders from non-subscription query
 		if ( 'regular' === $selected_shop_order_subtype ) {
-			$order_query_args['post__not_in'] = wcs_get_subscription_orders();
+			$order_query_args['subscription_parent'] = false;
 		}
 
 		return $order_query_args;
@@ -1321,6 +1321,35 @@ class WC_Subscriptions_Order {
 		}
 
 		return $query_vars;
+	}
+
+	/**
+	 * Modifies the query clauses of a wc_get_orders() query to include/exclude parent orders based on the 'subscription_parent' argument.
+	 *
+	 * @param array            $query_clauses The query clauses.
+	 * @param OrdersTableQuery $order_query   The order query object.
+	 *
+	 * @return $query_clauses The modified query clauses to include/exclude parent orders.
+	 */
+	public static function filter_orders_query_by_parent_orders( $query_clauses, $order_query ) {
+		$include_parent_orders = $order_query->get( 'subscription_parent' );
+
+		// Bail if there's no argument to include/exclude parent orders.
+		if ( is_null( $include_parent_orders ) ) {
+			return $query_clauses;
+		}
+
+		if ( true === $include_parent_orders ) {
+			// Limit query to parent orders.
+			$query_clauses['join']  = ( empty( $query_clauses['join'] ) ? '' : $query_clauses['join'] . ' ' );
+			$query_clauses['join'] .= "INNER JOIN {$order_query->get_table_name( 'orders' )} as subscriptions ON subscriptions.parent_order_id = wp_wc_orders.id AND subscriptions.type = 'shop_subscription'";
+		} elseif ( false === $include_parent_orders  ) {
+			// Exclude parent orders.
+			$query_clauses['where']  = ( empty( $query_clauses['where'] ) ? '1=1 ' : $query_clauses['where'] . ' ' );
+			$query_clauses['where'] .= "AND wp_wc_orders.id NOT IN (SELECT parent_order_id FROM {$order_query->get_table_name( 'orders' )} WHERE type = 'shop_subscription')";
+		}
+
+		return $query_clauses;
 	}
 
 	/* Deprecated Functions */


### PR DESCRIPTION
Fixes #https://github.com/woocommerce/woocommerce-subscriptions/issues/4629

## Description

On the Admin orders list table we allow users to filter the list table by subscription order types. eg renewal, parent, switch or non-subscription. 

Up until now, to filter this list table by the parent orders we have used the `post__in` or `post__not_in` args. 

On large sites this does not scale because the query will eventually contain a long list of order IDs that will run into a query character limit. 

eg

```
...
[customer_note] => 
[search_filter] => all
[post__in] => Array
    (
        [4886] => 4886
        [4937] => 4937
        [4940] => 4940
        [4943] => 4943
        [4945] => 4945
        [5218] => 5218
        [5350] => 5350
        [5491] => 5491
        [5501] => 5501
        [5507] => 5507
        [5516] => 5516
        [5526] => 5526
        [5771] => 5771
        [5775] => 5775
        [5796] => 5796
        [5798] => 5798
        [5892] => 5892
        [5895] => 5895
        [5899] => 5899
....
```

On my local site that only has ~1200 orders and ~300 parent orders, this way of filtering results in a posts in query with over 1200 characters. If you had over 100k orders and considering order numbers get longer the more you have, you can quickly see how this would result in a very large and inefficient query and in some cases a query that eventually fails.  

This PR fixes this for HPOS sites (WP posts aren't eligible see note below) by using a join or subquery. 

> [!note]
> On WP post stores this doesn't work because we're filtering the request query args directly via the `request` filter and there's no opportunity to filter the resulting database query clauses/args like we can on HPOS sites. 

## How to test this PR

1. On `trunk` go to **WooCommerce → Orders**
2. Using the order type filter, select **"Subscription Parent"** orders. 

<p align="center">
<img width="700" alt="Screenshot 2024-03-25 at 4 37 46 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/1d372e9d-ae81-495a-b452-1aa8cf2ac9c4">
</p>

3. Make a note of the number of results. 
4. Using the same order type filter, search for **"Non subscription"**
5. Make a note of the number of results. 
6. Checkout this branch, confirm the results are the same for both order types. 
7. Repeat for both HPOS and WP Post tables. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
