### PR TITLE
Update the change payment method flow to reduce customers missing the checkbox to update all subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 6.9.0 - xxxx-xx-xx =
+* Add - New modal to replace the checkbox displayed on the change payment method page asking customers to update all subscriptions.
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.
 * Fix - Resolved an issue that could cause an empty error notice to appear on the My Account > Payment methods page when a customer attempted to delete a token used by subscriptions.
 * Fix - Make sure we always clear the subscription object from cache after updating dates.

--- a/templates/checkout/form-change-payment-method.php
+++ b/templates/checkout/form-change-payment-method.php
@@ -3,7 +3,6 @@
  * Pay for order form displayed after a customer has clicked the "Change Payment method" button
  * next to a subscription on their My Account page.
  *
- * @author  Prospress
  * @package WooCommerce/Templates
  * @version 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
  */
@@ -49,11 +48,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			$pay_order_button_text = _x( 'Add payment method', 'text on button on checkout page', 'woocommerce-subscriptions' );
 		}
 
-		$pay_order_button_text     = apply_filters( 'woocommerce_change_payment_button_text', $pay_order_button_text );
-		$customer_subscription_ids = WCS_Customer_Store::instance()->get_users_subscription_ids( $subscription->get_customer_id() );
-		$payment_gateways_handler  = WC_Subscriptions_Core_Plugin::instance()->get_gateways_handler_class();
+		$pay_order_button_text = apply_filters( 'woocommerce_change_payment_button_text', $pay_order_button_text );
+		$available_gateways    = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( $available_gateways = WC()->payment_gateways->get_available_payment_gateways() ) :
+		if ( $available_gateways ) :
 			?>
 			<ul class="payment_methods methods">
 				<?php
@@ -85,25 +83,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endif; ?>
 
 		<?php if ( $available_gateways ) : ?>
-			<?php if ( count( $customer_subscription_ids ) > 1 && $payment_gateways_handler::one_gateway_supports( 'subscription_payment_method_change_admin' ) ) : ?>
-			<span class="update-all-subscriptions-payment-method-wrap">
-				<?php
-				// translators: $1: opening <strong> tag, $2: closing </strong> tag
-				$label = sprintf( esc_html__( 'Update the payment method used for %1$sall%2$s of my current subscriptions', 'woocommerce-subscriptions' ), '<strong>', '</strong>' );
-
-				woocommerce_form_field(
-					'update_all_subscriptions_payment_method',
-					array(
-						'type'    => 'checkbox',
-						'class'   => array( 'form-row-wide' ),
-						'label'   => $label,
-						'default' => apply_filters( 'wcs_update_all_subscriptions_payment_method_checked', false ),
-					)
-				);
-				?>
-			</span>
-			<?php endif; ?>
-
 		<div class="form-row">
 			<?php wp_nonce_field( 'wcs_change_payment_method', '_wcsnonce', true, true ); ?>
 

--- a/templates/checkout/modal-update-payment-method-for-all-subscriptions.php
+++ b/templates/checkout/modal-update-payment-method-for-all-subscriptions.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This template is for the modal that gets displayed after a customer has clicked the "Change payment method" button.
+ * This modael is used to confirm whether the customer wants to update all of their subscriptions to use the new payment method.
+ *
+ * @package WooCommerce/Templates
+ * @version 6.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+?>
+<span class="update-all-subscriptions-payment-method-wrap">
+	<p>
+		<?php
+		echo sprintf(
+			// translators: $1: opening <strong> tag, $2: closing </strong> tag
+			esc_html__( 'You are about to update subscription #%1$d to use a new payment method.%2$sIf you would like to update %3$sall%4$s of your current subscriptions to use this new payment method please check the box below before continuing.', 'woocommerce-subscriptions' ),
+			esc_html( $subscription->get_id() ),
+			'<br>',
+			'<strong>',
+			'</strong>'
+		);
+		?>
+	</p>
+
+	<?php
+	woocommerce_form_field(
+		'update_all_subscriptions_payment_method',
+		array(
+			'type'    => 'checkbox',
+			'class'   => [ 'form-row-wide' ],
+			'label'   => esc_html__( 'Use this new payment method for all of my current subscriptions', 'woocommerce-subscriptions' ),
+			'default' => apply_filters( 'wcs_update_all_subscriptions_payment_method_checked', false ),
+		)
+	);
+	?>
+</span>
+<input type="submit" class="button alt" id="place_order" value="<?php esc_attr_e( 'Update payment method', 'woocommerce-subscriptions' ); ?>" data-value="<?php esc_attr_e( 'Update payment method', 'woocommerce-subscriptions' ); ?>" />


### PR DESCRIPTION
Fixes 4372-gh-woocommerce/woocommerce-subscriptions
Slack p1710775338910969-slack-C7U3Y3VMY

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

According to the linked issue, merchants are regularly contacting support confused as to why their customers are updating their payment details but their other subscriptions were not updating, and as reported in the issue, this is mostly due to the checkbox option being missed by customers:

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/f3c1db4a-a584-4b9c-91b6-d2ef43a64edb)

This isn't a good merchant or customer experience so in the slack thread, I proposed the idea of simply changing this checkbox to be enabled by default, but that may have the opposite effect to those customers that wish to use different cards for different subscriptions and also don't see this checkbox.

In this PR I decided to experiment a little bit and propose moving the checkbox into a separate modal, prompting customers to take action before submitting the change payment method form.

![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/bff3f064-b396-4fc2-85f8-290024a3e54e)

I'm not convinced that the modal approach is the best thing here, mainly because it's introducing another step to the process. The other thing I'm not sure about is the text/content of the modal itself. There's not much we need to put here and it looks rather boring if you ask me, so I'm open to other options to help improve this.

Some other alternatives I considered:
 - Instead of a checkbox, use radio buttons and make it a required field so that customers have to choose. This could be a bit ugly 😅 
 - Have an option in subscription settings to let stores use the old checkbox over the modal approach if they don't like it.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a payment method that supports changing payment methods (i.e. Stripe)
2. Have multiple subscriptions purchased to prompt the update all my subscriptions flow
3. Visit **My Account > Subscriptions > View Subscription**
4. Click on Change payment action
5. Select a different payment method and press "Change payment method"
6. You should notice a new modal prompting whether you want to update all of your subscriptions.
7. Check the box and confirm all of your subscriptions have been updated.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
