### PR TITLE
Override the place order button text on the block checkout with subscription-context overrides

### DIFF
--- a/assets/src/js/filters/index.js
+++ b/assets/src/js/filters/index.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -119,6 +120,15 @@ export const registerFilters = () => {
 			}
 
 			return pricePlaceholder;
+		},
+		placeOrderButtonLabel: ( label ) => {
+			const subscriptionsData = getSetting( 'subscriptions_data' );
+
+			if ( subscriptionsData?.place_order_override ) {
+				return subscriptionsData?.place_order_override;
+			}
+
+			return label;
 		},
 	} );
 };

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Make sure we always clear the subscription object from cache after updating dates.
 * Fix - Use block theme styles for the 'Add to Cart' button on subscription product pages.
 * Fix - Customer notes not being saved on the Edit Subscription page for stores with HPOS enabled.
+* Fix - Resolved an issue that prevented subscription custom place order button labels from working on the block checkout.
 
 = 6.8.0 - 2024-02-08 =
 * Fix - Block the UI after a customer clicks actions on the My Account > Subscriptions page to prevent multiple requests from being sent.

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -49,8 +49,8 @@ class WC_Subscriptions_Core_Plugin {
 	/**
 	 * An array of cart handler objects.
 	 *
-	 * The key is the cart type ('renewal', 'resubscribe', 'initial', 'switch') and the value is the cart handler instances (WCS_Cart_Renewal, WCS_Cart_Resubscribe and WCS_Cart_Initial_Payment etc).
-	 * Use WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance() to get a cart handler instance.
+	 * Use @see WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( '{class}' ) to fetch a cart handler instance.
+	 * eg WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( 'WCS_Cart_Renewal' ).
 	 *
 	 * @var WCS_Cart_Renewal[]
 	 */

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -131,9 +131,9 @@ class WC_Subscriptions_Core_Plugin {
 		WCS_PayPal_Standard_Change_Payment_Method::init();
 		WC_Subscriptions_Tracker::init();
 		WCS_Upgrade_Logger::init();
-		$this->cart_handlers['renewal'] = new WCS_Cart_Renewal();
+		$this->cart_handlers['renewal']     = new WCS_Cart_Renewal();
 		$this->cart_handlers['resubscribe'] = new WCS_Cart_Resubscribe();
-		$this->cart_handlers['initial'] = new WCS_Cart_Initial_Payment();
+		$this->cart_handlers['initial']     = new WCS_Cart_Initial_Payment();
 		WCS_Download_Handler::init();
 		WCS_Limiter::init();
 		WCS_Admin_System_Status::init();

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -47,6 +47,13 @@ class WC_Subscriptions_Core_Plugin {
 	protected static $instance = null;
 
 	/**
+	 *
+	 *
+	 * @var array
+	 */
+	protected $cart_handlers = [];
+
+	/**
 	 * Initialise class and attach callbacks.
 	 */
 	public function __construct( $autoloader = null ) {
@@ -121,9 +128,9 @@ class WC_Subscriptions_Core_Plugin {
 		WCS_PayPal_Standard_Change_Payment_Method::init();
 		WC_Subscriptions_Tracker::init();
 		WCS_Upgrade_Logger::init();
-		new WCS_Cart_Renewal();
-		new WCS_Cart_Resubscribe();
-		new WCS_Cart_Initial_Payment();
+		$this->cart_handlers['renewal'] = new WCS_Cart_Renewal();
+		$this->cart_handlers['resubscribe'] = new WCS_Cart_Resubscribe();
+		$this->cart_handlers['initial'] = new WCS_Cart_Initial_Payment();
 		WCS_Download_Handler::init();
 		WCS_Limiter::init();
 		WCS_Admin_System_Status::init();
@@ -317,6 +324,20 @@ class WC_Subscriptions_Core_Plugin {
 	 */
 	public function get_gateways_handler_class() {
 		return 'WC_Subscriptions_Core_Payment_Gateways';
+	}
+
+	/**
+	 * Gets the cart handler instance.
+	 *
+	 * @param string $type The cart type. Can be 'renewal', 'resubscribe' or 'initial'.
+	 * @return WCS_Cart_Renewal|null
+	 */
+	public function get_cart_handler_instance( $type ) {
+		if ( ! isset( $this->cart_handlers[ $type ] ) ) {
+			return null;
+		}
+
+		return $this->cart_handlers[ $type ];
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -47,9 +47,12 @@ class WC_Subscriptions_Core_Plugin {
 	protected static $instance = null;
 
 	/**
+	 * An array of cart handler objects.
 	 *
+	 * The key is the cart type ('renewal', 'resubscribe', 'initial', 'switch') and the value is the cart handler instances (WCS_Cart_Renewal, WCS_Cart_Resubscribe and WCS_Cart_Initial_Payment etc).
+	 * Use WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance() to get a cart handler instance.
 	 *
-	 * @var array
+	 * @var WCS_Cart_Renewal[]
 	 */
 	protected $cart_handlers = [];
 

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -131,9 +131,9 @@ class WC_Subscriptions_Core_Plugin {
 		WCS_PayPal_Standard_Change_Payment_Method::init();
 		WC_Subscriptions_Tracker::init();
 		WCS_Upgrade_Logger::init();
-		$this->cart_handlers['renewal']     = new WCS_Cart_Renewal();
-		$this->cart_handlers['resubscribe'] = new WCS_Cart_Resubscribe();
-		$this->cart_handlers['initial']     = new WCS_Cart_Initial_Payment();
+		$this->add_cart_handler( new WCS_Cart_Renewal() );
+		$this->add_cart_handler( new WCS_Cart_Resubscribe() );
+		$this->add_cart_handler( new WCS_Cart_Initial_Payment() );
 		WCS_Download_Handler::init();
 		WCS_Limiter::init();
 		WCS_Admin_System_Status::init();
@@ -332,15 +332,27 @@ class WC_Subscriptions_Core_Plugin {
 	/**
 	 * Gets the cart handler instance.
 	 *
-	 * @param string $type The cart type. Can be 'renewal', 'resubscribe' or 'initial'.
-	 * @return WCS_Cart_Renewal|null
+	 * @param string $class The class name of the cart handler. eg 'WCS_Cart_Renewal'.
+	 * @return WCS_Cart_Renewal|null The cart handler instance or null if not found.
 	 */
-	public function get_cart_handler_instance( $type ) {
-		if ( ! isset( $this->cart_handlers[ $type ] ) ) {
+	public function get_cart_handler( $class ) {
+		if ( ! isset( $this->cart_handlers[ $class ] ) ) {
 			return null;
 		}
 
-		return $this->cart_handlers[ $type ];
+		return $this->cart_handlers[ $class ];
+	}
+
+	/**
+	 * Adds a cart handler instance.
+	 *
+	 * This is used to add cart handlers for different cart types. For example, renewal, resubscribe, initial, switch etc.
+	 * To access a cart handler instance, use WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( $class ).
+	 *
+	 * @param WCS_Cart_Renewal $cart_handler An instance of a cart handler.
+	 */
+	protected function add_cart_handler( $cart_handler ) {
+		$this->cart_handlers[ get_class( $cart_handler ) ] = $cart_handler;
 	}
 
 	/**

--- a/includes/class-wcs-blocks-integration.php
+++ b/includes/class-wcs-blocks-integration.php
@@ -82,6 +82,7 @@ class WCS_Blocks_Integration implements IntegrationInterface {
 	public function get_script_data() {
 		return array(
 			'woocommerce-subscriptions-blocks' => 'active',
+			'place_order_override'             => $this->get_place_order_button_text_override(),
 		);
 	}
 
@@ -96,5 +97,35 @@ class WCS_Blocks_Integration implements IntegrationInterface {
 			return filemtime( $file );
 		}
 		return \WC_Subscriptions_Core_Plugin::instance()->get_library_version();
+	}
+
+	/**
+	 * Fetches the place order button text if it has been overridden by one of Woo Subscription's methods.
+	 *
+	 * @return string|null The overridden place order button text or null if it hasn't been overridden.
+	 */
+	protected function get_place_order_button_text_override() {
+		$default = $order_button_text = null;
+
+		// Check if any of our button text override functions (hooked onto 'woocommerce_order_button_text') change the default text.
+		$callbacks = [
+			[ 'WC_Subscriptions_Checkout', 'order_button_text' ],
+			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'renewal' ), 'order_button_text' ],
+			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'switch' ), 'order_button_text' ]
+		];
+
+		foreach ( $callbacks as $callback ) {
+			if ( ! is_callable( $callback ) ) {
+				continue;
+			}
+
+			$order_button_text = call_user_func( $callback, $default );
+
+			if ( $order_button_text !== $default ) {
+				break;
+			}
+		}
+
+		return $order_button_text;
 	}
 }

--- a/includes/class-wcs-blocks-integration.php
+++ b/includes/class-wcs-blocks-integration.php
@@ -113,6 +113,7 @@ class WCS_Blocks_Integration implements IntegrationInterface {
 			[ 'WC_Subscriptions_Checkout', 'order_button_text' ],
 			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( 'WCS_Cart_Renewal' ), 'order_button_text' ],
 			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( 'WCS_Cart_Switch' ), 'order_button_text' ],
+			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( 'WCS_Cart_Resubscribe' ), 'order_button_text' ],
 		];
 
 		foreach ( $callbacks as $callback ) {

--- a/includes/class-wcs-blocks-integration.php
+++ b/includes/class-wcs-blocks-integration.php
@@ -112,7 +112,7 @@ class WCS_Blocks_Integration implements IntegrationInterface {
 		$callbacks = [
 			[ 'WC_Subscriptions_Checkout', 'order_button_text' ],
 			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'renewal' ), 'order_button_text' ],
-			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'switch' ), 'order_button_text' ]
+			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'switch' ), 'order_button_text' ],
 		];
 
 		foreach ( $callbacks as $callback ) {

--- a/includes/class-wcs-blocks-integration.php
+++ b/includes/class-wcs-blocks-integration.php
@@ -111,8 +111,8 @@ class WCS_Blocks_Integration implements IntegrationInterface {
 		// Check if any of our button text override functions (hooked onto 'woocommerce_order_button_text') change the default text.
 		$callbacks = [
 			[ 'WC_Subscriptions_Checkout', 'order_button_text' ],
-			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'renewal' ), 'order_button_text' ],
-			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler_instance( 'switch' ), 'order_button_text' ],
+			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( 'WCS_Cart_Renewal' ), 'order_button_text' ],
+			[ \WC_Subscriptions_Core_Plugin::instance()->get_cart_handler( 'WCS_Cart_Switch' ), 'order_button_text' ],
 		];
 
 		foreach ( $callbacks as $callback ) {

--- a/includes/class-wcs-blocks-integration.php
+++ b/includes/class-wcs-blocks-integration.php
@@ -105,7 +105,8 @@ class WCS_Blocks_Integration implements IntegrationInterface {
 	 * @return string|null The overridden place order button text or null if it hasn't been overridden.
 	 */
 	protected function get_place_order_button_text_override() {
-		$default = $order_button_text = null;
+		$default           = null;
+		$order_button_text = $default;
 
 		// Check if any of our button text override functions (hooked onto 'woocommerce_order_button_text') change the default text.
 		$callbacks = [


### PR DESCRIPTION
Fixes #https://github.com/woocommerce/woocommerce-subscriptions/issues/4628

## Description

When you renew, switch or purchase a new subscription the place order button text on the checkout it changed to give the customer more context. 

| Sign up <sup>*</sup> | Switch | Renew |
|--------|--------|--------|
| <img width="462" alt="Screenshot 2024-03-26 at 5 01 10 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/5f7a6fe9-7433-4d28-bb6a-a0748932bce5">|<img width="462" alt="Screenshot 2024-03-26 at 4 57 06 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/cf40eb3a-2855-4f17-9876-7c853ea43b7b">| <img width="462" alt="Screenshot 2024-03-26 at 4 58 10 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/551bff85-c6ed-4d75-8b2e-371c578530a8">| 

<p align="center">
<img width="400" alt="Screenshot 2024-03-26 at 5 05 16 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/74634757-a6b4-4d57-87b9-0f734293e9dc">
</br>
<sup>* The default <strong>"Sign up now"</strong> is changeable by Subscription admin settings. </sup>
</p>

These overrides don't currently apply to the block checkout. This PR fixes that. 

> [!important]
> **To test the switch case you will need to use the `issue/4628` branch of the Woo Subscriptions repo. Ref: https://github.com/woocommerce/woocommerce-subscriptions/pull/4637**

## How to test this PR

0. Run `npm run build` as this PR has changes to built JS files. 
1. Go to **WooCommerce → Settings → Subscriptions**
2. Scroll down to the **Button Text** section and change the default place order button text. 
3. Add a standard (non-subscription) product to your cart. 
4. Go to the block checkout and note that the place order button is still the default **"Place Order"**. 
5. Add a subscription product to you cart. 
7. View the block checkout.
    - On trunk it will still say **"Place Order"**. 
    - On this branch the place order button text will be replaced with the text you entered in step 2. 
6. Purchase a variable subscription product and from the My Account Subscription page click the button to switch (upgrade/downgrade). 
7. View the block checkout.
    - On trunk it will still say **"Place Order"**. 
    - On this branch the place order button text will be replaced with **"Switch subscription"**
6. Create a failed/pending renewal order and attempt to pay for it by adding it to the cart.
7. View the block checkout.
    - On trunk it will still say **"Place Order"**. 
    - On this branch the place order button text will be replaced with **"Renew subscription"**

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
