### PR TITLE
Ensure the woocommerce_subscriptions_paid_for_failed_renewal_order hook is fired when paying for failed renewal orders via the block checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.0.0 - 2024-xx-xx =
+* Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.
+
 = 6.9.0 - 2024-03-28 =
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.
 * Fix - Resolved an issue that could cause an empty error notice to appear on the My Account > Payment methods page when a customer attempted to delete a token used by subscriptions.

--- a/includes/class-wc-subscriptions-renewal-order.php
+++ b/includes/class-wc-subscriptions-renewal-order.php
@@ -127,7 +127,7 @@ class WC_Subscriptions_Renewal_Order {
 			if ( $order_completed && ! $subscription->has_status( wcs_get_subscription_ended_statuses() ) && ! $subscription->has_status( 'active' ) ) {
 
 				// Included here because calling payment_complete sets the retry status to 'cancelled'
-				$is_failed_renewal_order = 'failed' === $orders_old_status || wc_string_to_bool( $order->get_meta( '_was_failed_renewal_order', true ) );
+				$is_failed_renewal_order = 'failed' === $orders_old_status || wc_string_to_bool( $order->get_meta( WC_Subscription::RENEWAL_FAILED_META_KEY, true ) );
 				$is_failed_renewal_order = apply_filters( 'woocommerce_subscriptions_is_failed_renewal_order', $is_failed_renewal_order, $order_id, $orders_old_status );
 
 				if ( $order_needed_payment ) {
@@ -138,11 +138,6 @@ class WC_Subscriptions_Renewal_Order {
 				if ( $is_failed_renewal_order ) {
 					do_action( 'woocommerce_subscriptions_paid_for_failed_renewal_order', wc_get_order( $order_id ), $subscription );
 				}
-			} elseif ( 'pending' === $orders_new_status && 'failed' === $orders_old_status && wcs_is_checkout_blocks_api_request() ) {
-				// The WooCommerce block checkout will update the order status from "failed" to "pending" right before attempting to process the payment.
-				// We need to flag this event so we can still trigger paid-for-failed-renewal-order actions once the order is paid.
-				$order->update_meta_data( '_was_failed_renewal_order', 'true' );
-				$order->save();
 			} elseif ( 'failed' == $orders_new_status ) {
 				$subscription->payment_failed();
 			}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4638

## Description

When you successfully pay for a failed renewal order, we trigger the `woocommerce_subscriptions_paid_for_failed_renewal_order` hook. This is used by gateways to update the token on the subscription, to use the new token.

However, when you pay for an order via the block checkout, WooCommerce Core updates the status to pending ([code ref](https://github.com/woocommerce/woocommerce/blob/8.7.0/plugins/woocommerce/src/StoreApi/Utilities/CheckoutTrait.php#L64)). This brakes our logic which expects the status transition to be failed → processing/completed.

This PR attempts to fix this by making sure we flag when a failed renewal order is paid via block checkout and is updated to pending. Then when the order status transition is pending → processing/completed we can confirm that as scenario where the customer has paid for a failed renewal order. 

## How to test this PR

1. Purchase a subscription using Stripe.
2. Update the subscription's payment method to 4000000000000341
3. Process a renewal. It should fail.
4. Pay for the failed renewal order via the Block checkout. 
   - On `trunk` Note that the `woocommerce_subscriptions_paid_for_failed_renewal_order` hook isn't fired because the order is pending, not failed.
   - On this branch that hook is fired because of the additional meta flag. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
