### PR TITLE
Add `highlightChecked` prop to the `ShippingRatesControlPackage` in WC Blocks integration

### DIFF
--- a/assets/src/js/recurring-packages/index.js
+++ b/assets/src/js/recurring-packages/index.js
@@ -17,7 +17,8 @@ import { useMemo } from '@wordpress/element';
  * @param {boolean} props.showItems             If shipping rates should show items inside them.
  * @param {Element} props.noResultsMessage      Message shown when no rate are found.
  * @param {Function} props.renderOption          Function that decides how rates are going to render.
- * @param {Object}props.components
+ * @param {Object} props.components
+ * @param {string} props.context               This will be woocommerce/cart or woocommerce/checkout.
  */
 export const SubscriptionsRecurringPackages = ( {
 	extensions,
@@ -27,6 +28,7 @@ export const SubscriptionsRecurringPackages = ( {
 	noResultsMessage,
 	renderOption,
 	components,
+	context,
 } ) => {
 	const { subscriptions = [] } = extensions;
 	const { ShippingRatesControlPackage } = components;
@@ -58,7 +60,7 @@ export const SubscriptionsRecurringPackages = ( {
 			showItems={ shouldShowItems }
 			noResultsMessage={ noResultsMessage }
 			renderOption={ renderOption }
-			highlightChecked={ true }
+			highlightChecked={ 'woocommerce/checkout' === context }
 		/>
 	) );
 };

--- a/assets/src/js/recurring-packages/index.js
+++ b/assets/src/js/recurring-packages/index.js
@@ -58,6 +58,7 @@ export const SubscriptionsRecurringPackages = ( {
 			showItems={ shouldShowItems }
 			noResultsMessage={ noResultsMessage }
 			renderOption={ renderOption }
+			highlightChecked={ true }
 		/>
 	) );
 };

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.1.0 - 2024-xx-xx =
+* Update - Update the shipping method styling to apply borders to the highlighted shipping option in the Checkout block.
+
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.
 * Fix - Resolved an issue that would cause subscriptions to be directly cancelled by the WooCommerce process of automatically cancelling unpaid orders in-line with the hold stock setting.


### PR DESCRIPTION
This PR is part of https://github.com/woocommerce/woocommerce/pull/46150 and should be merged in time for WC 8.9. Ideally WC Subscriptions will ship this patch before WC 8.9 is released.

## Description

This PR adds new props to the `ShippingRatesControlPackage` used to display the recurring shipping packages. The purpose of them are to allow the selected method to be highlighted in the Checkout block.

`context` is whether the component is rendered in the Cart or Checkout block and `highlightChecked` determines if the checked option should be highlighted.

This change needs to be made here as well as in WC Core because we default to _not_ highlighting the selected item to preserve backward compatibility with any other consumers of the component. 

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

0. Be using https://github.com/woocommerce/woocommerce/pull/46150 or latest WC Core trunk if that is merged already.
1. Create 3 subscription items with different lengths, (weekly, yearly, monthly)
2. Add them to your cart and go to the Cart block.
3. Ensure the shipping options in the sidebar show correctly, i.e. without borders around each rate.

<img width="300" alt="image" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/5656702/114f92c1-e584-4b1a-b409-442f59986b5e">

4. Go to the Checkout block. Ensure you can see the additional packages, and that they _do_ have borders around each rate

<img width="517" alt="image" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/5656702/8c8a0aab-c4df-4f7f-890b-9d666f54eda4">

5. Switch back to WC Core trunk and run the tests again, the borders won't show but please ensure the shipping selectors for recurring packages still work and can change the method.


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
