### PR TITLE
Filter whether to recreate the inital payment order’s cart.

### DIFF
--- a/includes/class-wcs-cart-initial-payment.php
+++ b/includes/class-wcs-cart-initial-payment.php
@@ -52,6 +52,23 @@ class WCS_Cart_Initial_Payment extends WCS_Cart_Renewal {
 			return;
 		}
 
+		/**
+		 * Filter whether to recreate the initial payment order.
+		 *
+		 * Allows developers to prevent the initial payment order from being recreated and
+		 * manage the pending to processing/completed workflow without duplicating the order.
+		 *
+		 * @param bool $recreate_order Whether to recreate the initial payment order. Default true.
+		 * @param WC_Order $order The order object.
+		 * @param string $order_key The order key.
+		 * @param int $order_id The order ID.
+		 */
+		$recreate_order = apply_filters( 'wcs_recreate_initial_payment_order', true, $order, $order_key, $order_id );
+
+		if ( ! $recreate_order ) {
+			return;
+		}
+
 		if ( ! is_user_logged_in() ) {
 			// Allow the customer to login first and then redirect them back.
 			$redirect = add_query_arg(

--- a/includes/class-wcs-cart-initial-payment.php
+++ b/includes/class-wcs-cart-initial-payment.php
@@ -53,19 +53,20 @@ class WCS_Cart_Initial_Payment extends WCS_Cart_Renewal {
 		}
 
 		/**
-		 * Filter whether to recreate the initial payment order.
+		 * Filter whether to set up the cart during the pay-for-order payment flow.
 		 *
-		 * Allows developers to prevent the initial payment order from being recreated and
-		 * manage the pending to processing/completed workflow without duplicating the order.
+		 * Allows developers to bypass cart setup for the pay-for-order payment flow.
+		 * This is intended for situations in which re-creating the cart will result in
+		 * the loss of order data.
 		 *
-		 * @param bool $recreate_order Whether to recreate the initial payment order. Default true.
-		 * @param WC_Order $order The order object.
-		 * @param string $order_key The order key.
-		 * @param int $order_id The order ID.
+		 * @param bool     $recreate_cart Whether to recreate the initial payment order. Default true.
+		 * @param WC_Order $order         The order object.
+		 * @param string   $order_key     The order key.
+		 * @param int      $order_id      The order ID.
 		 */
-		$recreate_order = apply_filters( 'wcs_recreate_initial_payment_order', true, $order, $order_key, $order_id );
+		$recreate_cart = apply_filters( "wcs_setup_cart_for_{$this->cart_item_key}", true, $order, $order_key, $order_id );
 
-		if ( ! $recreate_order ) {
+		if ( ! $recreate_cart ) {
 			return;
 		}
 

--- a/includes/class-wcs-cart-initial-payment.php
+++ b/includes/class-wcs-cart-initial-payment.php
@@ -59,6 +59,8 @@ class WCS_Cart_Initial_Payment extends WCS_Cart_Renewal {
 		 * This is intended for situations in which re-creating the cart will result in
 		 * the loss of order data.
 		 *
+		 * @since 6.2.0
+		 *
 		 * @param bool     $recreate_cart Whether to recreate the initial payment order. Default true.
 		 * @param WC_Order $order         The order object.
 		 * @param string   $order_key     The order key.


### PR DESCRIPTION
Fixes #591

## Description

This adds a filter to `WCS_Cart_Initial_Payment::maybe_setup_cart()` to allow other extensions to filter whether the initial cart is recreated during the checkout flow.

I've done this for the pre-orders project to introduce support for subscription products. Feel free to request an alternative approach if this filter isn't required.

Risks: The main risk I see is extensions naively implementing the filter and conflicting with Subs/Subs-Core expectations. For example `add_filter( 'wcs_recreate_initial_payment_order', '__return_false' )` 

At present i haven't got anything to protect against that as once someone is writing PHP it's reasonable to expect them to know what they are doing. If the Subs dev approach is different, let me know.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm unsure how to test this without using the pre-orders subs compatibility branch to demonstrate the issue. 

1. Checkout woocommerce-pre-orders#497
2. Activate WooPayments as a payment method
3. Activate Subs
4. Create a Far Future pre-order:
   * Type: Simple Subscription (other details as you wish)
   * Pre-orders: enabled
   * Pre-order matures a month or more from now
   * Pre-order paid upon release
5. Open a private/incognito browser window and purchase the product.
   * Ensure you use a real email address or mail capture tool such as mailhog
   * During checkout you will be presented with the "pay later" gateway
   * WooPayments will not be available
6. Back in the admin, go to: WooCommerce > Pre-orders > Actions (tab) > Complete (section)
7. From the dropdown, select your demo product
8. Fill out the message field
9. Submit the form
10. Check the email of the test user
11. Click the email ending "your pre-order from Date is now available"
12. Click the link to pay for the pre-order
13. On Subs-Core trunk:
  a. The payment page will be hijacked by Subs and the order recreated
  b. Rather than being able to pay for the order, the only gateway available will be pay later
14. On this branch: payment will proceed via the pay-for-order screen



## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
