### PR TITLE
When populating the checkout with renewal order checkout values, limit it to only fetch address fields

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.0.0 - 2024-xx-xx =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.
 * Fix - Resolved an issue that would cause subscriptions to be directly cancelled by the WooCommerce process of automatically cancelling unpaid orders in-line with the hold stock setting.
+* Fix - Resolved errors that could occur when paying for renewal orders via the checkout when the store has custom checkout fields.
 
 = 6.9.0 - 2024-03-28 =
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -494,33 +494,49 @@ class WCS_Cart_Renewal {
 	 * Returns address details from the renewal order if the checkout is for a renewal.
 	 *
 	 * @param string $value Default checkout field value.
-	 * @param string $key The checkout form field name/key
+	 * @param string $key   The checkout form field name/key.
+	 *
 	 * @return string $value Checkout field value.
 	 */
 	public function checkout_get_value( $value, $key ) {
 
-		// Only hook in after WC()->checkout() has been initialised
-		if ( $this->cart_contains() && did_action( 'woocommerce_checkout_init' ) > 0 ) {
+		// Only hook in after WC()->checkout() has been initialised.
+		if ( ! $this->cart_contains() || did_action( 'woocommerce_checkout_init' ) <= 0 ) {
+			return $value;
+		}
 
-			// Guard against the fake WC_Checkout singleton, see https://github.com/woocommerce/woocommerce-subscriptions/issues/427#issuecomment-260763250
-			remove_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10 );
+		// Get the most specific order object, which will be the renewal order for renewals, initial order for initial payments, or a subscription for switches/resubscribes.
+		$order = $this->get_order();
 
-			if ( is_callable( array( WC()->checkout(), 'get_checkout_fields' ) ) ) { // WC 3.0+
-				$address_fields = array_merge( WC()->checkout()->get_checkout_fields( 'billing' ), WC()->checkout()->get_checkout_fields( 'shipping' ) );
-			} else {
-				$address_fields = array_merge( WC()->checkout()->checkout_fields['billing'], WC()->checkout()->checkout_fields['shipping'] );
-			}
+		if ( ! $order ) {
+			return $value;
+		}
 
-			add_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10, 2 );
+		// Guard against the fake WC_Checkout singleton, see https://github.com/woocommerce/woocommerce-subscriptions/issues/427#issuecomment-260763250
+		remove_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10 );
 
-			if ( array_key_exists( $key, $address_fields ) && false !== ( $item = $this->cart_contains() ) ) {
+		$address_fields = array_merge(
+			WC()->countries->get_address_fields(
+				$order->get_billing_country(),
+				'billing_'
+			),
+			WC()->countries->get_address_fields(
+				$order->get_shipping_country(),
+				'shipping_'
+			),
+		);
 
-				// Get the most specific order object, which will be the renewal order for renewals, initial order for initial payments, or a subscription for switches/resubscribes
-				$order = $this->get_order( $item );
+		add_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10, 2 );
 
-				if ( ( $order_value = wcs_get_objects_property( $order, $key ) ) ) {
-					$value = $order_value;
-				}
+		// Generate the address getter method for the key.
+		$getter = "get_{$key}";
+
+		if ( array_key_exists( $key, $address_fields ) && is_callable( [ $order, $getter ] ) ) {
+			$order_value = call_user_func( [ $order, $getter ] );
+
+			// Given this is fetching the value for a checkout field, we need to ensure the value is a scalar.
+			if ( is_scalar( $order_value ) ) {
+				$value = $order_value;
 			}
 		}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -512,9 +512,6 @@ class WCS_Cart_Renewal {
 			return $value;
 		}
 
-		// Guard against the fake WC_Checkout singleton, see https://github.com/woocommerce/woocommerce-subscriptions/issues/427#issuecomment-260763250
-		remove_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10 );
-
 		$address_fields = array_merge(
 			WC()->countries->get_address_fields(
 				$order->get_billing_country(),
@@ -525,8 +522,6 @@ class WCS_Cart_Renewal {
 				'shipping_'
 			)
 		);
-
-		add_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10, 2 );
 
 		// Generate the address getter method for the key.
 		$getter = "get_{$key}";

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -523,7 +523,7 @@ class WCS_Cart_Renewal {
 			WC()->countries->get_address_fields(
 				$order->get_shipping_country(),
 				'shipping_'
-			),
+			)
 		);
 
 		add_filter( 'woocommerce_checkout_get_value', array( &$this, 'checkout_get_value' ), 10, 2 );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4627

## Description

When a customer pays for a failed/pending renewal order, we pre-populate the checkout fields with address values from the order.

The function responsible for doing that is WCS_Cart_Renewal::checkout_get_value(). 

This function, prior to this PR, used `wcs_get_objects_property()` to pull these values for the checkout. That function is wide open in terms of what it could fetch and return. ie it attempts to call getters and then meta data and so any order property or meta is returnable in this case.

This level of openness can lead to issues when stores use custom checkout fields. Eg in the issue description, the customer has a `user` field which leads `wcs_get_objects_property()` to pull the `WP_User` object from the order and attempts to put that into the checkout field. 

This PR fixes this by limiting this function to only fetch address values. From the function description itself, I don't believe this broad nature was intended. 

## How to test this PR

1. Add the following code snippet to your site to mimic a custom checkout field being added by a plugin like **Checkout Field Editor**.
2. Purchase a subscription. 
3. Create a pending renewal order for the subscription. 
4. Attempt to pay for the renewal order. 
   5. On this `trunk` notice the PHP error notice indicating that an `WP_User` object cannot be converted etc.
   6. On this branch there should be no issue. 

**Testing intended functionality.**

1. Change the default checkout page to a shortcode checkout. 
    - The Block checkout has some strange caching or something. Sometimes the block checkout would honour the values and other times it wouldn't 🤷‍♂️. It seemed to bypass this function all together. 
1. Edit the renewal order you created at step 3 above. 
3. Change the billing and shipping address in a way that you'll recognise. You want it to be a completely different address. 
4. Attempt to pay for the order again. Confirm that the address fields on the checkout correctly reflect the changes you made. 

```php
add_filter( 'woocommerce_checkout_fields', function ( $fields ) {
	$fields['billing']['user'] = [
		'label'    => 'Custom user',
		'required' => false,
	];
	return $fields;
} );
```


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
