### PR TITLE
Prevent potential infinite loops and duplicate subscription notes when processing subscription status transitions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.0.0 - 2024-xx-xx =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.
 * Fix - Resolved an issue that would cause subscriptions to be directly cancelled by the WooCommerce process of automatically cancelling unpaid orders in-line with the hold stock setting.
+* Fix - Prevent duplicate status transition notes on subscriptions and potential infinite loops when processing subscription status transitions.
 
 = 6.9.0 - 2024-03-28 =
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -576,6 +576,9 @@ class WC_Subscription extends WC_Order {
 		// Use local copy of status transition value.
 		$status_transition = $this->status_transition;
 
+		// Reset status transition variable.
+		$this->status_transition = false;
+
 		// If we're not currently in the midst of a status transition, bail early.
 		if ( ! $status_transition ) {
 			return;
@@ -617,9 +620,6 @@ class WC_Subscription extends WC_Order {
 			);
 			$this->add_order_note( __( 'Error during subscription status transition.', 'woocommerce-subscriptions' ) . ' ' . $e->getMessage() );
 		}
-
-		// This has run, so reset status transition variable
-		$this->status_transition = false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4608

## Description

Because of the way the `WC_Subscription` status transition is written, if you save the subscription during any one of the hooks fired during the status transition, you will get duplicate order note entries. 

<p align="center">
<img width="299" alt="Screenshot 2024-04-08 at 11 43 39 am" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/ffa81d88-e731-4adb-9aa2-37667c991938">
</p>

This PR fixes that by bringing `WC_Subscription::status_transition()` in line with `WC_Order::status_transition()` which sets the status transition value to false as one of the first things it does. This will prevent subsequent object saves to try save the status transition a second time. 

## How to test this PR

1. In **WooCommerce > Settings > Emails** make sure the **Cancelled Subscription** email is enabled.
2. Go to the Admin Subscription list table. 
3. Cancel any active subscription you have. 
4. View the Subscription's order notes and notice there are 2 notes recording that status change.
5. On this branch there should be only one note. 

If you're unable to replicate using those steps above, perhaps try using this code snippet. I suspect it has something to do with the actions hooked in during the status transition. 


```php
add_action( 'woocommerce_subscription_status_updated', 'dup_order_notes_test' );

function dup_order_notes_test( $subscription ) {
	// Remove the action otherwise it would be a infinite loop. 
	remove_action( 'woocommerce_subscription_status_updated', 'dup_order_notes_test' );
	$subscription->update_meta_data( '_dummy_meta', true );
	$subscription->save();
}
```
With this code active I get 3 status transition notes. 

Note in the code snippet that I had to unhook the function, this PR also fixes that infinite loop potential. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
