### PR TITLE
Fix database issues when ordering the admin subscriptions table by the last order date on HPOS sites

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Resolved an issue that would cause subscriptions to be directly cancelled by the WooCommerce process of automatically cancelling unpaid orders in-line with the hold stock setting.
 * Fix - Prevent duplicate status transition notes on subscriptions and potential infinite loops when processing subscription status transitions.
 * Fix - Resolved an issue that could lead to "Undefined array key 'order-received'" errors.
+* Fix - Resolved database errors that would occur when ordering the subscriptions list table by the 'Last order date' on sites with HPOS enabled.
 
 = 6.9.0 - 2024-03-28 =
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1811,7 +1811,7 @@ class WCS_Admin_Post_Types {
 
 		$query_order = strtoupper( $args['order'] );
 
-		$pieces['orderby'] = "COALESCE(lp.last_payment, wp_wc_orders.date_created_gmt, 0) {$query_order}";
+		$pieces['orderby'] = "COALESCE(lp.last_payment, parent_order.date_created_gmt, 0) {$query_order}";
 
 		return $pieces;
 	}
@@ -1878,7 +1878,8 @@ class WCS_Admin_Post_Types {
 		//phpcs:enable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$pieces['join'] .= "LEFT JOIN {$table_name} as lp
-			ON {$order_table}.id = lp.id";
+			ON {$order_table}.id = lp.id
+			LEFT JOIN {$order_table} as parent_order on {$order_table}.parent_order_id = parent_order.id";
 
 		return $pieces;
 	}

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1864,9 +1864,9 @@ class WCS_Admin_Post_Types {
 		$table_name = substr( "{$wpdb->prefix}tmp_{$session}_lastpayment", 0, 64 );
 
 		// Create a temporary table, drop the previous one.
-		$wpdb->query( $wpdb->prepare( 'DROP TEMPORARY TABLE IF EXISTS %s', $table_name ) );
-
 		//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DROP TEMPORARY TABLE IF EXISTS {$table_name}" );
+
 		$wpdb->query(
 			"CREATE TEMPORARY TABLE {$table_name} (id INT PRIMARY KEY, last_payment DATETIME) AS
 			SELECT order_meta.meta_value as id, MAX( orders.date_created_gmt ) as last_payment

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1839,7 +1839,7 @@ class WCS_Admin_Post_Types {
 				WHERE order_meta.meta_key = '_subscription_renewal'
 				GROUP BY order_meta.meta_value) lp
 			ON {$order_table}.id = lp.meta_value
-			LEFT JOIN {$order_table} orders on {$order_table}.parent_order_id = orders.ID";
+			LEFT JOIN {$order_table} as parent_order on {$order_table}.parent_order_id = parent_order.ID";
 
 		return $pieces;
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4576

## Description

There was an issue when ordering the subscriptions list table by the subscriptions last payment date when using HPOS. 

After spending a lot of time trying to narrow down the cause of generic database errors I found that it was mostly caused by using strings as table names eg `'wp_wc_orders'` vs just `wp_wc_orders`. 

This PR fixes that and makes some additional minor changes to table alias etc.

## How to test this PR

1. Make sure HPOS is enabled in **WooCommerce > Settings > Advanced > Features**
2. Go to the **WooCommerce > Subscriptions** list table. 
3. Attempt to sort by the **Last order date** column.
4. On `trunk` you will see no results and the following database error.

<img width="2385" alt="Screenshot 2024-04-09 at 5 46 23 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/cbcfd5e3-525f-4817-a9ca-033f3c341bcb">

```
WordPress database error Unknown error 1146 for query
SELECT wp_wc_orders.id, COALESCE(lp.last_payment, orders.date_created_gmt, 0) as lp 
FROM wp_wc_orders LEFT JOIN wp_tmp_XIXiw5htnUIQc2hd4Y3scRHmvRS1LQUVX5N3bmdYVRF_lastpayment lp
ON wp_wc_orders.id = lp.id
LEFT JOIN wp_wc_orders orders on wp_wc_orders.parent_order_id = orders.id WHERE 1=1 AND (wp_wc_orders.status IN ('wc-pending','wc-active','wc-on-hold','wc-cancelled','wc-switched','wc-expired','wc-pending-cancel')) AND (wp_wc_orders.type = 'shop_subscription') 
GROUP BY wp_wc_orders.id
ORDER BY CAST(lp AS DATETIME) ASC
LIMIT 0, 20
```

5. On this branch there should be results ordered correctly by the subscriptions last payment date. Note that subscriptions with no parent or renewal order will be listed first when ordered in ascending order. 


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)