### PR TITLE
Fix undefined array-key order-received PHP error on order received page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.0.0 - 2024-xx-xx =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.
 * Fix - Resolved an issue that would cause subscriptions to be directly cancelled by the WooCommerce process of automatically cancelling unpaid orders in-line with the hold stock setting.
+* Fix - Resolved an issue that could lead to "Undefined array key 'order-received'" errors.
 
 = 6.9.0 - 2024-03-28 =
 * Fix - Resolved an issue where discounts, when reapplied to failed or manual subscription order payments, would incorrectly account for inclusive tax.

--- a/includes/gateways/paypal/class-wcs-paypal.php
+++ b/includes/gateways/paypal/class-wcs-paypal.php
@@ -511,11 +511,11 @@ class WCS_PayPal {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.5.3
 	 */
 	public static function maybe_add_payment_lock() {
-		if ( ! wcs_is_order_received_page() ) {
+		global $wp;
+		if ( ! isset( $wp->query_vars['order-received'] ) ) {
 			return;
 		}
 
-		global $wp;
 		$order = wc_get_order( absint( $wp->query_vars['order-received'] ) );
 
 		if ( $order && self::instance()->get_id() === $order->get_payment_method() && $order->needs_payment() && ! self::are_reference_transactions_enabled() && wcs_order_contains_subscription( $order, array( 'parent' ) ) ) {


### PR DESCRIPTION
Fixes #418

## Description

In our legacy PayPal code we have a function that is supposed to set meta when the customer lands on the order received page. 

The logic at the top of the function has a gap and can lead to the following error:

```
PHP Warning:  Undefined array key "order-received" in /public/wp-content/plugins/woocommerce-subscriptions-core/includes/gateways/paypal/class-wcs-paypal.php on line 519 
```

This can occur because our `wcs_is_order_received_page()` just checks if `order-received` is anywhere in the URI. 

`wcs_is_order_received_page()` has a function comment which indicates that checking the URI is by design. It's supposed to be used in cases where we want to check if the request is for the order received without accessing the `$wp->query_vars`. In this case we need to access the `$wp->query_vars` to pull the order ID and so it's not a good candidate for this. 

This PR fixes that. 

## How to test this PR

> [!note]
> I'm not sure how folks are replicating this natively, whenever I go to a legit order received page, it pulls the order ID out of the URL just fine. 

1. Go to the front page of your store and add the `order-recieved` query var. 
   - eg: http://example.local/shop/&order-received=true
2. On `trunk` you should get the error I mentioned above. On this branch there will be no error. 
3. Confirm that the order received page still works as intended.
   - eg Add a breakpoint or logging to the `maybe_add_payment_lock()` function and verify that the `$order` param is still being loaded eg add a `$order->get_id()`.
4. Purchase a new product of any type and confirm via the breakpoint or logging that you added that the order is still loading and that `maybe_add_payment_lock()` would still work as intended. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
