### PR TITLE
Improve logging of failed subscription scheduled actions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.1.0 - 2024-xx-xx =
 * Update - Update the shipping method styling to apply borders to the highlighted shipping option in the Checkout block.
+* Update - Include a full stack trace in failed scheduled action logs to improve troubleshooting issues.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -308,7 +308,7 @@ class WCS_Failed_Scheduled_Action_Manager {
 	/**
 	 * Generates a message from an error array.
 	 *
-	 * The $error variable is obtained from get_last_error() and so has some standard keys.
+	 * The $error variable is obtained from get_last_error() and has standard keys message, file and line.
 	 *
 	 * @param array $error The error data to generate a message from.
 	 * @return string The message including the file and line number if available.s

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -332,10 +332,12 @@ class WCS_Failed_Scheduled_Action_Manager {
 	}
 
 	/**
-	 * Undocumented function
+	 * Generates a message from an error array.
 	 *
-	 * @param [type] $error
-	 * @return void
+	 * The $error variable is obtained from get_last_error() and so has some standard keys.
+	 *
+	 * @param array $error The error data to generate a message from.
+	 * @return string The message including the file and line number if available.s
 	 */
 	protected function get_message_from_error( $error ) {
 		$message = $error['message'];


### PR DESCRIPTION
## Description

In WC 8.6, WC core change the logger to have new features that enable you to store additional context about an error and for that to be viewable in the log file itself. 

This PR updates our `WCS_Failed_Scheduled_Action_Manager` to make use of those features. As part of this update I've also updated what is logged to better assist with narrowing down the cause of these issues. 

## How to test this PR

### Setup
1. Go to your database `wp_actionscheduler_actions` table
2. Find a pending scheduled `woocommerce_scheduled_subscription_payment` action
3. Manually edit the action and set the date to be in the past (eg just change the year to 2023). 
   - This will make it easier to test and will use Action Scheduler's queue rather than having to run the actions manually. 
1. Add the following code snippet to assist with testing various scenarios. 

```php
add_action( 'woocommerce_scheduled_subscription_payment', 'test_trigger_failure' );
add_action( 'woocommerce_scheduled_subscription_payment', 'trigger_wc_exceptions', 1 );

function test_trigger_failure() {
	$error_type = 'timeout';
	//$error_type = 'fatal';
	//$error_type = 'error';
	//$error_type = 'exception';

	switch ( $error_type ) {
		case 'timeout':
			// An hard exit will trigger the action to eventually timeout.
			exit;
			break;
		case 'error':
			undefined_function();
			break;
		case 'fatal':
			// Fatal error
			// Note: Fatal errors are caught and thrown as exceptions so you'd need to disable the AS error handler in the `process_action` method to see the fatal error.
			trigger_error( 'This is a fatal error', E_USER_ERROR );
			break;
		case 'exception':
			// Exception
			throw new Exception( 'This is an exception' );
			break;
	}
}

function trigger_wc_exceptions() {
	//return; // Uncomment to disable this function.

	// Change the number of exceptions to trigger. Default is 2.
	foreach ( range( 1, 2 ) as $exception_number ) {
		wc_caught_exception( new Exception( 'Oopsy ' . $exception_number ) );
	}
}
```

### Timeouts

1. With the code above running, set your scheduled action to `pending` and refresh any admin page.
2. Action Scheduler should start processing the action and it should appear as `in-progress` in the database. 
3. Wait 5 minutes ⏲️ 
4. View the `failed-scheduled-actions` log in **WooComemrce > Status > Logs**
5. You should see an error like this: 

<p align="Center">
<img width="1149" alt="Screenshot 2024-04-12 at 3 12 22 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/38105a25-8cbb-4323-a970-6ff48294d344">
</p>

### Errors

1. Optional. Delete the `failed-scheduled-actions` file if you want to keep things tidy. 
1. Uncomment the `$error_type = 'error'` line. 
1. Set your testing scheduled action to `pending` and refresh any admin page.
2. Action Scheduler should start processing the action and it should appear as `in-progress` in the database. 
4. View the `failed-scheduled-actions` log in **WooComemrce > Status > Logs**
5. You should see an error like this: 

<p align="Center">
<img width="2379" alt="Screenshot 2024-04-12 at 3 38 58 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/40ced2a9-ffcc-4d06-b8b6-0437e4afa256">
</br>
<sup>Full stack traces are now included for errors like this.</sup> 
</p>

6. View the scheduled action in the **Tools > Scheduled** action screen and you'll see the exceptions that were caught by WC will also be logged there. 

<img width="333" alt="Screenshot 2024-04-12 at 3 43 47 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/6f23b222-7077-4244-881f-bfbb81f09cb0">

### Uncaught Exceptions

1. Optional. Delete the `failed-scheduled-actions` file if you want to keep things tidy. 
1. Uncomment the `$error_type = 'exception'` line. 
1. Set your testing scheduled action to `pending` and refresh any admin page.
2. Action Scheduler should start processing the action and it should appear as `in-progress` in the database. 
4. View the `failed-scheduled-actions` log in **WooComemrce > Status > Logs**
5. You should see an error like this: 

<p align="Center">
<img width="2386" alt="Screenshot 2024-04-12 at 3 47 51 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/5ce1dbac-ef80-4cff-93ab-ca5f4e58775e">
</p>

### Fatal errors

> [!note] 
> Action Scheduler overrides the default error handler when processing actions (see this code in: [`ActionScheduler_Abstract_QueueRunner::process_action()`](https://github.com/woocommerce/action-scheduler/blob/3.7.4/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php#L51-L66)). This error handler catches all errors and converts them into exceptions. This means I was never able to test the `action_scheduler_unexpected_shutdown` approach, because it never shut down - every error (including the undefined function error) is caught and treated as an exception. Our `WCS_Failed_Scheduled_Action_Manager` has code which handles unexpected shutdowns so we want to confirm that still works just incase there's a type of error that bypasses AS's error handler.

1. Comment out Action Scheduler's error handler in [`ActionScheduler_Abstract_QueueRunner::process_action()`](https://github.com/woocommerce/action-scheduler/blob/3.7.4/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php#L51-L66)).
1. Optional. Delete the `failed-scheduled-actions` file if you want to keep things tidy. 
1. Uncomment the `$error_type = 'fatal'` line. 
1. Set your testing scheduled action to `pending` and refresh any admin page.
2. Action Scheduler should start processing the action and it should appear as `in-progress` in the database. 
4. View the `failed-scheduled-actions` log in **WooComemrce > Status > Logs**
5. You should see an error like this: 

<p align="Center">
<img width="2385" alt="Screenshot 2024-04-12 at 4 00 07 pm" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/56434dee-7709-45bf-aa96-d8b3ace67389">
</br>
<sup>We don't get a full stack here unfortunately because the shutdown handlers just passes us the last error from `get_last_error()` and it only includes line and file information. </sup> 
</p>

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
