### PR TITLE
Fix issue with disabled mixed checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 7.1.0 - 2024-xx-xx =
 * Update - Update the shipping method styling to apply borders to the highlighted shipping option in the Checkout block.
+* Tweak - Show notice about product being removed from the cart when a subscription is for disabled mixed checkout setting.
+* Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/includes/class-wc-subscriptions-cart-validator.php
+++ b/includes/class-wc-subscriptions-cart-validator.php
@@ -47,7 +47,7 @@ class WC_Subscriptions_Cart_Validator {
 
 			// If the product is sold individually or if the cart doesn't already contain this product, empty the cart.
 			if ( ! WC()->cart->is_empty() && ( ( $product && $product->is_sold_individually() ) || ! WC()->cart->find_product_in_cart( $cart_item_id ) ) ) {
-				$message = WC()->cart->get_cart_contents_count() > 1 ? __( 'Products have been removed from your cart. Only one subscription product can be purchased at a time.', 'woocommerce-subscriptions' ) : __( 'A product has been removed from your cart. Only one subscription product can be purchased at a time.', 'woocommerce-subscriptions' );
+				$message = $cart_contains_subscription ? __( 'A subscription has been removed from your cart. Only one subscription product can be purchased at a time.', 'woocommerce-subscriptions' ) : __( 'Products have been removed from your cart. Products and subscriptions can not be purchased at the same time.', 'woocommerce-subscriptions' );
 				WC()->cart->empty_cart();
 				wc_add_notice( $message, 'notice' );
 			}

--- a/includes/class-wc-subscriptions-cart-validator.php
+++ b/includes/class-wc-subscriptions-cart-validator.php
@@ -68,7 +68,7 @@ class WC_Subscriptions_Cart_Validator {
 			wc_add_notice( __( 'A subscription has been removed from your cart. Products and subscriptions can not be purchased at the same time.', 'woocommerce-subscriptions' ), 'notice' );
 
 			// Redirect to cart page to remove subscription & notify shopper
-			add_filter( 'woocommerce_add_to_cart_fragments', array( __CLASS__, 'redirect_ajax_add_to_cart' ) );
+			add_filter( 'woocommerce_add_to_cart_fragments', array( __CLASS__, 'add_to_cart_ajax_redirect' ) );
 		}
 
 		return $valid;
@@ -107,7 +107,7 @@ class WC_Subscriptions_Cart_Validator {
 				wc_add_notice( __( 'Your cart has been emptied of subscription products. Only one subscription product can be purchased at a time.', 'woocommerce-subscriptions' ), 'notice' );
 
 				// Redirect to cart page to remove subscription & notify shopper
-				add_filter( 'woocommerce_add_to_cart_fragments', array( __CLASS__, 'redirect_ajax_add_to_cart' ) );
+				add_filter( 'woocommerce_add_to_cart_fragments', array( __CLASS__, 'add_to_cart_ajax_redirect' ) );
 
 				break;
 			}

--- a/includes/class-wc-subscriptions-cart-validator.php
+++ b/includes/class-wc-subscriptions-cart-validator.php
@@ -46,8 +46,10 @@ class WC_Subscriptions_Cart_Validator {
 			$product        = wc_get_product( $product_id );
 
 			// If the product is sold individually or if the cart doesn't already contain this product, empty the cart.
-			if ( ( $product && $product->is_sold_individually() ) || ! WC()->cart->find_product_in_cart( $cart_item_id ) ) {
+			if ( ! WC()->cart->is_empty() && ( ( $product && $product->is_sold_individually() ) || ! WC()->cart->find_product_in_cart( $cart_item_id ) ) ) {
+				$message = WC()->cart->get_cart_contents_count() > 1 ? __( 'Products have been removed from your cart. Only one subscription product can be purchased at a time.', 'woocommerce-subscriptions' ) : __( 'A product has been removed from your cart. Only one subscription product can be purchased at a time.', 'woocommerce-subscriptions' );
 				WC()->cart->empty_cart();
+				wc_add_notice( $message, 'notice' );
 			}
 		} elseif ( $is_subscription && wcs_cart_contains_renewal() && ! $multiple_subscriptions_possible && ! $manual_renewals_enabled ) {
 


### PR DESCRIPTION
Fixes #130 #560 

## Description
This PR handles two issues related to the mixed checkout.
- When a simple product is added to cart with an existing subscription product and subscription rules avoid to have both types, Add to cart Ajax call gets a 500 response. The error is caused by trying to use non-existing function redirect_ajax_add_to_cart in WC_Subscriptions_Cart_Validator class.

```
PHP Fatal error:  Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, class WC_Subscriptions_Cart_Validator does not have a method "redirect_ajax_add_to_cart" in C:\xampp\htdocs\testsubscriptions\wp-includes\class-wp-hook.php:307
```

In `WC_Subscriptions_Cart_Validator` class we were using `redirect_ajax_add_to_cart` as the callback which does not exist. This function is replaced by `add_to_cart_ajax_redirect`, handled by the [deprecation handler class](https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/includes/deprecated/deprecation-handlers/class-wc-subscriptions-deprecation-handler.php#L153). In https://github.com/Automattic/woocommerce-subscriptions-core/pull/606/commits/118ef402104c54fbef89f2b788294954ee416259, I am now directly using the `add_to_cart_ajax_redirect` as the callback. I could not reproduce this issue but using `add_to_cart_ajax_redirect` directly as the callback makes more sense here. 

- When mixed checkout is disabled, and a subscription is in the cart when another product type is added, the customer is provided with a notice `A subscription has been removed from your cart. Products and subscriptions can not be purchased at the same time`. But when a subscription is added to the cart that already contains another product, no notice is provided.
Addressed this in https://github.com/Automattic/woocommerce-subscriptions-core/pull/606/commits/152cb9d7a5bcd717e8c107c8d181a301a1196b72, [6fdf3be](https://github.com/Automattic/woocommerce-subscriptions-core/pull/606/commits/6fdf3beb6386145c561b46a3a1ee4dace5080597),now showing a notice on the page when the other products are removed from the cart because of adding a subscription.

## How to test this PR
#### Issue #130 

1. Disabled mixed checkout from **WooCommerce > Settings > Subscriptions**.
2. Create a variable subscription. On the product edit page's `Advance section`, limit the subscription to one active subscription at a time.
3. As a shopper, add the variable subscription to the cart.
4. Now add another simple product to the cart.
5. The simple product should be added to the cart without any error.

#### Issue #560 
1. Disabled mixed checkout from **WooCommerce > Settings > Subscriptions**.
2. As a shopper, add a subscription to the cart.
3. Now add another simple product to the cart. You should see the following notice on the page. 

![sub for prod](https://github.com/Automattic/woocommerce-subscriptions-core/assets/33387139/ce099257-c244-4903-866f-4f511e8ca2b5)

5. Clear the cart and add a subscription again.
6. Now add a second subscription to the cart. You should see the following notice on the page.

![subs](https://github.com/Automattic/woocommerce-subscriptions-core/assets/33387139/cd86554e-7313-40c1-8907-618b11dc8db3)

7. Clear the cart and add one or a couple of simple products to the cart.
8. Now add a subscription to the cart. You should see the following notice on the page.

![product message](https://github.com/Automattic/woocommerce-subscriptions-core/assets/33387139/a309de99-8c9d-4731-9cc2-141a9d020098)