### PR TITLE
Fix typo in confirmation alert when users remove an item from a subscription.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Include a full stack trace in failed scheduled action logs to improve troubleshooting issues.
 * Tweak - Show notice about product being removed from the cart when a subscription is for disabled mixed checkout setting.
 * Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.
+* Fix - Typo in confirmation alert when users remove an item from a subscription.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/templates/myaccount/subscription-totals-table.php
+++ b/templates/myaccount/subscription-totals-table.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php if ( $allow_item_removal ) : ?>
 						<td class="remove_item">
 							<?php if ( wcs_can_item_be_removed( $item, $subscription ) ) : ?>
-								<?php $confirm_notice = apply_filters( 'woocommerce_subscriptions_order_item_remove_confirmation_text', __( 'Are you sure you want remove this item from your subscription?', 'woocommerce-subscriptions' ), $item, $_product, $subscription );?>
+								<?php $confirm_notice = apply_filters( 'woocommerce_subscriptions_order_item_remove_confirmation_text', __( 'Are you sure you want to remove this item from your subscription?', 'woocommerce-subscriptions' ), $item, $_product, $subscription );?>
 								<a href="<?php echo esc_url( WCS_Remove_Item::get_remove_url( $subscription->get_id(), $item_id ) );?>" class="remove" onclick="return confirm('<?php printf( esc_html( $confirm_notice ) ); ?>');">&times;</a>
 							<?php endif; ?>
 						</td>

--- a/templates/myaccount/subscription-totals-table.php
+++ b/templates/myaccount/subscription-totals-table.php
@@ -2,7 +2,6 @@
 /**
  * Subscription details table
  *
- * @author  Prospress
  * @package WooCommerce_Subscription/Templates
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
  * @version 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
@@ -25,15 +24,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<tbody>
 		<?php
 		foreach ( $subscription->get_items() as $item_id => $item ) {
-			$_product  = apply_filters( 'woocommerce_subscriptions_order_item_product', $item->get_product(), $item );
+			$_product = apply_filters( 'woocommerce_subscriptions_order_item_product', $item->get_product(), $item );
 			if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 				?>
 				<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $subscription ) ); ?>">
 					<?php if ( $allow_item_removal ) : ?>
 						<td class="remove_item">
 							<?php if ( wcs_can_item_be_removed( $item, $subscription ) ) : ?>
-								<?php $confirm_notice = apply_filters( 'woocommerce_subscriptions_order_item_remove_confirmation_text', __( 'Are you sure you want to remove this item from your subscription?', 'woocommerce-subscriptions' ), $item, $_product, $subscription );?>
-								<a href="<?php echo esc_url( WCS_Remove_Item::get_remove_url( $subscription->get_id(), $item_id ) );?>" class="remove" onclick="return confirm('<?php printf( esc_html( $confirm_notice ) ); ?>');">&times;</a>
+								<?php $confirm_notice = apply_filters( 'woocommerce_subscriptions_order_item_remove_confirmation_text', __( 'Are you sure you want to remove this item from your subscription?', 'woocommerce-subscriptions' ), $item, $_product, $subscription ); ?>
+								<a href="<?php echo esc_url( WCS_Remove_Item::get_remove_url( $subscription->get_id(), $item_id ) ); ?>" class="remove" onclick="return confirm('<?php printf( esc_html( $confirm_notice ) ); ?>');">&times;</a>
 							<?php endif; ?>
 						</td>
 					<?php endif; ?>
@@ -77,7 +76,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php
 			}
 
-			if ( $subscription->has_status( array( 'completed', 'processing' ) ) && ( $purchase_note = get_post_meta( $_product->id, '_purchase_note', true ) ) ) {
+			$purchase_note = get_post_meta( $_product->get_id(), '_purchase_note', true );
+			if ( $subscription->has_status( array( 'completed', 'processing' ) ) && $purchase_note ) {
 				?>
 				<tr class="product-purchase-note">
 					<td colspan="3"><?php echo wp_kses_post( wpautop( do_shortcode( $purchase_note ) ) ); ?></td>
@@ -89,7 +89,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tbody>
 		<tfoot>
 		<?php
-		foreach ( $totals as $key => $total ) : ?>
+		foreach ( $totals as $key => $total ) :
+			?>
 			<tr>
 				<th scope="row" <?php echo ( $allow_item_removal ) ? 'colspan="2"' : ''; ?>><?php echo esc_html( $total['label'] ); ?></th>
 				<td><?php echo wp_kses_post( $total['value'] ); ?></td>


### PR DESCRIPTION
Fixes #438 

### Description
There's a typo in the notice shown to users when they remove an item from their subscription. The notice is missing a `to` between `you` and `want`.

```
Are you sure you want remove this item from your subscription?
```

### Steps to reproduce

1. Purchase a subscription with at least 2 separate line items. 
2. Go to the **My Account > Subscriptions** page.
3. Click the `x` next to one of the items.
4. You should see the notice as below.
```
Are you sure you want to remove this item from your subscription?
```