### PR TITLE
Fix filtered order links in subscription reports not working correctly when HPOS is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Include a full stack trace in failed scheduled action logs to improve troubleshooting issues.
 * Tweak - Show notice about product being removed from the cart when a subscription is for disabled mixed checkout setting.
 * Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.
+* Fix - Filtered order links in subscription reports returns all the orders when HPOS is enabled.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1402,7 +1402,7 @@ class WC_Subscriptions_Admin {
 	public static function filter_orders_and_subscriptions_from_order_table( $clauses ) {
 		global $wpdb;
 
-		if ( ! ( isset( $_GET['page'] ) && 'wc-orders' === $_GET['page'] ) || ! isset( $_GET['_report'] ) ) {
+		if ( ! ( isset( $_GET['page'] ) && in_array( $_GET['page'], [ 'wc-orders', 'wc-orders--shop_subscription' ] ) ) || ! isset( $_GET['_report'] ) ) {
 			return $clauses;
 		}
 


### PR DESCRIPTION
Fixes WCS-4650

With HPOS enabled, the links highlighted in the screenshot below do not work as intended, resulting in a list of all orders instead of showing the filtered order for the reports being viewed.

![reports](https://github.com/Automattic/woocommerce-subscriptions-core/assets/33387139/803909d2-4d3d-49c6-9ea7-82c53fe6be24)


### Description
- The existing `posts_where` filter works on the `posts` table only. As this is not triggered for the HPOS order table, the orders are not filtered by expected ids when coming from the reports page.
- I have used the `woocommerce_orders_table_query_clauses` filter which is available to modify the query clauses of the HPOS order tables.

## How to test this PR

1. Enable HPOS from **WooCommerce > Settings > Advanced > Features** page.
2. Enable compatibility mode if not enabled already to view the subscription report when HPOS is enabled.
3. Go to **WooCommerce > Reporst > Subscriptions**
4. Click the link `subscription renewals`.
5. In `trunk` it should take you to the order table page and display all the orders.
6. In this branch, it should take you to the order table page and display the renewal orders only. 