### PR TITLE
Fix subscription table is empty in mobile view when HPOS is enabled.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Tweak - Show notice about product being removed from the cart when a subscription is for disabled mixed checkout setting.
 * Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.
 * Fix - Subscription table is empty in mobile view when HPOS is enabled.
+* Fix - WooCommerce page header is hidden when HPOS is enabled.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Include a full stack trace in failed scheduled action logs to improve troubleshooting issues.
 * Tweak - Show notice about product being removed from the cart when a subscription is for disabled mixed checkout setting.
 * Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.
+* Fix - Subscription table is empty in mobile view when HPOS is enabled.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1170,7 +1170,7 @@ class WCS_Admin_Post_Types {
 	 */
 	public function list_table_primary_column( $default, $screen_id ) {
 
-		if ( 'edit-shop_subscription' == $screen_id ) {
+		if ( in_array( $screen_id, [ wcs_get_page_screen_id( 'shop_subscription' ), 'edit-shop_subscription' ], true ) ) {
 			$default = 'order_title';
 		}
 

--- a/includes/admin/class-wcs-wc-admin-manager.php
+++ b/includes/admin/class-wcs-wc-admin-manager.php
@@ -40,6 +40,16 @@ class WCS_WC_Admin_Manager {
 			)
 		);
 
+		// WooCommerce > Subscriptions (HPOS)
+		wc_admin_connect_page(
+			array(
+				'id'        => 'woocommerce-custom-orders-subscriptions',
+				'screen_id' => wcs_get_page_screen_id( 'shop_subscription' ),
+				'title'     => __( 'Subscriptions', 'woocommerce-subscriptions' ),
+				'path'      => 'admin.php?page=wc-orders--shop_subscription',
+			)
+		);
+
 		// WooCommerce > Subscriptions > Add New.
 		wc_admin_connect_page(
 			array(


### PR DESCRIPTION
Fixes #584 

This PR fixes to issues related to HPOS-
- With HPOS enabled, the subscription table is empty in mobile view.
- With HPOS enabled, the WooCommerce page header is missing from the Subscriptions page.

## How to test this PR

1. Enable HPOS from **WooCommerce > Settings > Advanced > Features** page.
2. Create at least one subscription.
3. Go to **WooCommerce > Subscriptions**.
4. Notice that the subscription is present in the table.
5. In `trunk` branch, inspect at a mobile breakpoint (max-width: 782 px). Notice that the table is empty.
6. Also, the WooCommerce page header is missing on the Subscriptions page.

<img src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/33387139/3f62affb-d754-47ca-8ebe-026ef7391220" width="50%" height="50%" />

7. In this branch, inspect at a mobile breakpoint (max-width: 782 px). Notice that the subscriptions are rendered correctly in the table. 
8. In this branch, the WooCommerce page header is present on the Subscriptions page for both desktop and mobile views.

<img src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/33387139/9c3674d3-5f10-4cf8-bc69-6dc2e19019e4" width="50%" height="50%" />



