### PR TITLE
Fix subscription product sales ending before WC products

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Tweak - Show notice about product being removed from the cart when a subscription is for disabled mixed checkout setting.
 * Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.
 * Fix - Typo in confirmation alert when users remove an item from a subscription.
+* Fix - Ensure the scheduled sale price for subscription products ends at the end of the "to" day set in product settings.
 
 = 7.0.0 - 2024-04-11 =
 * Fix - Update the failing payment method on a subscription when customers successfully pay for a failed renewal order via the block checkout.

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -514,7 +514,7 @@ class WC_Subscriptions_Admin {
 
 		$site_offset = wc_timezone_offset();
 
-		// Save the timestamps in UTC time, the way WC does it.
+		// Fetch the timestamps in UTC time to check if the product is currently on sale.
 		$date_from = ! empty( $_POST['_sale_price_dates_from'] ) ? wcs_date_to_time( gmdate( 'Y-m-d 00:00:00', wcs_strtotime_dark_knight( wc_clean( wp_unslash( $_POST['_sale_price_dates_from'] ) ) ) ) ) - $site_offset : '';
 		$date_to   = ! empty( $_POST['_sale_price_dates_to'] ) ? wcs_date_to_time( gmdate( 'Y-m-d 23:59:59', wcs_strtotime_dark_knight( wc_clean( wp_unslash( $_POST['_sale_price_dates_to'] ) ) ) ) ) - $site_offset : '';
 
@@ -523,9 +523,6 @@ class WC_Subscriptions_Admin {
 		if ( ! empty( $date_to ) && empty( $date_from ) ) {
 			$date_from = $now;
 		}
-
-		update_post_meta( $post_id, '_sale_price_dates_from', $date_from );
-		update_post_meta( $post_id, '_sale_price_dates_to', $date_to );
 
 		// Update price if on sale
 		if ( '' !== $sale_price && ( ( empty( $date_to ) && empty( $date_from ) ) || ( $date_from < $now && ( empty( $date_to ) || $date_to > $now ) ) ) ) {

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -509,11 +509,11 @@ class WC_Subscriptions_Admin {
 		update_post_meta( $post_id, '_regular_price', $subscription_price );
 		update_post_meta( $post_id, '_sale_price', $sale_price );
 
-		$site_offset = get_option( 'gmt_offset' ) * 3600;
+		$site_offset = wc_timezone_offset();
 
 		// Save the timestamps in UTC time, the way WC does it.
-		$date_from = ( ! empty( $_POST['_sale_price_dates_from'] ) ) ? wcs_date_to_time( $_POST['_sale_price_dates_from'] ) - $site_offset : '';
-		$date_to   = ( ! empty( $_POST['_sale_price_dates_to'] ) ) ? wcs_date_to_time( $_POST['_sale_price_dates_to'] ) - $site_offset : '';
+		$date_from = ! empty( $_POST['_sale_price_dates_from'] ) ? wcs_date_to_time( gmdate( 'Y-m-d 00:00:00', wcs_strtotime_dark_knight( wc_clean( wp_unslash( $_POST['_sale_price_dates_from'] ) ) ) ) ) - $site_offset : '';
+		$date_to   = ! empty( $_POST['_sale_price_dates_to'] ) ? wcs_date_to_time( gmdate( 'Y-m-d 23:59:59', wcs_strtotime_dark_knight( wc_clean( wp_unslash( $_POST['_sale_price_dates_to'] ) ) ) ) ) - $site_offset : '';
 
 		$now = gmdate( 'U' );
 


### PR DESCRIPTION
Fixes 4646-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

When the same scheduled sale days are set on a subscription product and a regular product, the sale price for the subscription product expires earlier than the regular product.

After some investigation, I found that WooCommerce sets the "sale from" to be the beginning of the given day, and the "sale to" to be the end of the given day i.e, their code:

```php
$date_on_sale_from = date( 'Y-m-d 00:00:00', strtotime( $date_on_sale_from ) );
$date_on_sale_to = date( 'Y-m-d 23:59:59', strtotime( $date_on_sale_to ) );
```

In Subscriptions we didn't apply this rule and so sales were ending earlier for subscription products than regular products despite having the same dates.

This PR fixes this issue by making sure the scheduled sale "to" date ends at `Y-m-d 23:59:59`.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a subscription product and simple WC product with the sale schedule (found in the general tab)![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/04d5042e-d91a-4791-ae03-0f638e0d520f)
2. Put the following snippet into something like WP Console compare the scheduled sale dates for both products:
```php
$product_id = 123123;
$subscription_product_id = 456456;

echo "---- Simple Product ----" . PHP_EOL;
$from = get_post_meta( $product_id, '_sale_price_dates_from', true );
$to   = get_post_meta( $product_id, '_sale_price_dates_to', true );
echo '_sale_price_dates_from = ' . gmdate( 'Y-m-d H:i:s', $from ) . ' ( ' . $from . ' )' . PHP_EOL;
echo '_sale_price_dates_to   = ' . gmdate( 'Y-m-d H:i:s', $to ) . ' ( ' . $to . ' )' . PHP_EOL;
echo PHP_EOL . PHP_EOL;
echo "---- Subscription Product ----" . PHP_EOL;
$from = get_post_meta( $subscription_product_id, '_sale_price_dates_from', true );
$to   = get_post_meta( $subscription_product_id, '_sale_price_dates_to', true );
echo '_sale_price_dates_from = ' . gmdate( 'Y-m-d H:i:s', $from ) . ' ( ' . $from . ' )' . PHP_EOL;
echo '_sale_price_dates_to   = ' . gmdate( 'Y-m-d H:i:s', $to ) . ' ( ' . $to . ' )' . PHP_EOL;
```
4. Confirm they're the same.
5. Now update your sites timezone, go back to each product and save the sale dates again.
6. Run the above snippet again and confirm both dates are the same.
7. Inside wp-config, set your servers timezone using `date_default_timezone_set( 'Australia/Brisbane' );`
8. Go back to each Edit Product page and save the sale to and from dates.
9. Run the above snippet again and confirm the sale dates stored on the product and subscription are the same.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
