### PR TITLE
Fixes bulk actions buttons (suspend, cancel) on Subscriptions list table not working while filtering the table

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Ensure the scheduled sale price for subscription products ends at the end of the "to" day set in product settings.
 * Fix - Subscription table is empty in mobile view when HPOS is enabled.
 * Fix - WooCommerce page header is hidden when HPOS is enabled.
+* Fix - Resolved an issue that prevented bulk actions from running on the Subscriptions list table when the table was filtered by date, payment method, product or customer.
 * Dev - Calling wcs_create_subscription() will no longer attempt to fetch a fresh instance of the subscription at the end. This is to prevent loading the subscription from the database potentially unnecessarily.
 
 = 7.0.0 - 2024-04-11 =

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1367,7 +1367,7 @@ class WCS_Admin_Post_Types {
 		}
 
 		$action_url   = add_query_arg( $action_url_args );
-		$action_url   = remove_query_arg( [ 'changed', 'ids' ], $action_url );
+		$action_url   = remove_query_arg( [ 'changed', 'ids', 'filter_action' ], $action_url );
 		$all_statuses = array(
 			'active'    => __( 'Reactivate', 'woocommerce-subscriptions' ),
 			'on-hold'   => __( 'Suspend', 'woocommerce-subscriptions' ),


### PR DESCRIPTION
Fixes #553

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

When the subscriptions list table is being filtered by date, product, payment method or customer, the bulk action buttons under each list item (suspend, cancel etc) do not work:
![image](https://github.com/Automattic/woocommerce-subscriptions-core/assets/2275145/2b38e527-b37d-4b09-8446-db23cee47a4a)

This issue is caused by the `WP_List_Table::current_action()` function, which is called in WooCommerce's [`handle_bulk_actions()`](https://github.com/woocommerce/woocommerce/blob/f2cf6b56aa762cb36eb9496b878c5c295376f16d/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php#L1231-L1235), returning `false` when the `filter_action` query arg exists.

This means whenever the table is filtered, `handle_bulk_actions()` is not ran.
To fix this I've just removed the `filter_action` from the action URLs.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the WooCommerce > Subscriptions and filter the table by customer "admin"
2. While on `trunk` try to use the bulk action buttons to cancel a subscription
3. Notice the page refreshes but the subscription is not cancelled :x: 
4. Check out this branch and run the same test.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
