### PR TITLE
Fixes attempt to read property "post_date" on null errors

### DIFF
--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1098,7 +1098,15 @@ class WCS_Admin_Post_Types {
 	public function post_updated_messages( $messages ) {
 		global $post, $theorder;
 
-		$created_date = ! empty( $theorder ) && $theorder instanceof WC_Subscription ? $theorder->get_date_created() : $post->post_date;
+		if ( ! isset( $theorder ) || ! $theorder instanceof WC_Subscription ) {
+			if ( ! isset( $post ) || 'shop_subscription' !== $post->post_type ) {
+				return $messages;
+			} elseif ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) ) {
+				\Automattic\WooCommerce\Utilities\OrderUtil::init_theorder_object( $post );
+			} else {
+				return $messages;
+			}
+		}
 
 		$messages['shop_subscription'] = array(
 			0  => '', // Unused. Messages start at index 1.
@@ -1112,7 +1120,7 @@ class WCS_Admin_Post_Types {
 			7  => __( 'Subscription saved.', 'woocommerce-subscriptions' ),
 			8  => __( 'Subscription submitted.', 'woocommerce-subscriptions' ),
 			// translators: php date string
-			9  => sprintf( __( 'Subscription scheduled for: %1$s.', 'woocommerce-subscriptions' ), '<strong>' . date_i18n( _x( 'M j, Y @ G:i', 'used in "Subscription scheduled for <date>"', 'woocommerce-subscriptions' ), wcs_date_to_time( $created_date ) ) . '</strong>' ),
+			9  => sprintf( __( 'Subscription scheduled for: %1$s.', 'woocommerce-subscriptions' ), '<strong>' . date_i18n( _x( 'M j, Y @ G:i', 'used in "Subscription scheduled for <date>"', 'woocommerce-subscriptions' ), wcs_date_to_time( $theorder->get_date_created() ?? $post->post_date ) ) . '</strong>' ),
 			10 => __( 'Subscription draft updated.', 'woocommerce-subscriptions' ),
 		);
 


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

I recently merged https://github.com/Automattic/woocommerce-subscriptions-core/pull/615 which fixed an issue with "Subscription updated." messages missing on stores with HPOS enabled.

While smoke testing the release I noticed the following notices:

```
PHP Warning:  Attempt to read property "post_date" on null in /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/admin/class-wcs-admin-post-types.php on line 1101
```

This PR fixes these issues.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. I found the issue while manually running the "process renewal" from the Edit subscription page

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
