### PR TITLE
Use strtotime to avoid errors passing wc_datetime objects

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.1.1 - 2024-xx-xx =
+* Fix - Resolved an issue that caused "WC_DateTime could not be converted to int" warnings to occur on non-hpos sites while editing a subscription.
+
 = 7.1.0 - 2024-05-09 =
 * Fix - Add check to prevent fatal error in rsort and array_sum.
 * Fix - Use `add_to_cart_ajax_redirect` instead of the deprecated `redirect_ajax_add_to_cart` function as callback.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -1120,7 +1120,7 @@ class WCS_Admin_Post_Types {
 			7  => __( 'Subscription saved.', 'woocommerce-subscriptions' ),
 			8  => __( 'Subscription submitted.', 'woocommerce-subscriptions' ),
 			// translators: php date string
-			9  => sprintf( __( 'Subscription scheduled for: %1$s.', 'woocommerce-subscriptions' ), '<strong>' . date_i18n( _x( 'M j, Y @ G:i', 'used in "Subscription scheduled for <date>"', 'woocommerce-subscriptions' ), wcs_date_to_time( $theorder->get_date_created() ?? $post->post_date ) ) . '</strong>' ),
+			9  => sprintf( __( 'Subscription scheduled for: %1$s.', 'woocommerce-subscriptions' ), '<strong>' . date_i18n( _x( 'M j, Y @ G:i', 'used in "Subscription scheduled for <date>"', 'woocommerce-subscriptions' ), strtotime( $theorder->get_date_created() ?? $post->post_date ) ) . '</strong>' ),
 			10 => __( 'Subscription draft updated.', 'woocommerce-subscriptions' ),
 		);
 


### PR DESCRIPTION
## Description

Fixes the following warnings on the edit subscription page with HPOS disabled: 

```
PHP Notice:  Object of class WC_DateTime could not be converted to int in /wcdev/app/public/wp-content/plugins/woocommerce-subscriptions-core/includes/wcs-time-functions.php on line 664
```

## How to test this PR

1. Disable HPOS
2. Go to WooCommerce > Subscriptions
3. Edit one of your subscriptions.
4. Check your php error logs and verify you received the error mentioned above.
5. On this branch there should be no error.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
