### PR TITLE
Fix get related order IDs method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.1.2 - xxxx-xx-xx =
+* Fix - Add check to prevent fatal error when retrieving related order IDs.
+
 = 7.1.1 - 2024-05-09 =
 * Fix - Resolved an issue that caused "WC_DateTime could not be converted to int" warnings to occur on non-hpos sites while editing a subscription.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 7.1.2 - xxxx-xx-xx =
-* Fix - Added a check for the format when listing related subscription orders.
+= 7.2.0 - xxxx-xx-xx =
+* Fix - Regenerate subscriptions related order caches (renewal, resubscribe, switch) if it's stored as an invalid value to prevent fatal errors.
 
 = 7.1.1 - 2024-05-09 =
 * Fix - Resolved an issue that caused "WC_DateTime could not be converted to int" warnings to occur on non-hpos sites while editing a subscription.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.1.2 - xxxx-xx-xx =
-* Fix - Add check to prevent fatal error when retrieving related order IDs.
+* Fix - Added a check for the format when listing related subscription orders.
 
 = 7.1.1 - 2024-05-09 =
 * Fix - Resolved an issue that caused "WC_DateTime could not be converted to int" warnings to occur on non-hpos sites while editing a subscription.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2065,7 +2065,10 @@ class WC_Subscription extends WC_Order {
 			$relation_types = ( 'any' === $order_type ) ? array( 'renewal', 'resubscribe', 'switch' ) : array( $order_type );
 
 			foreach ( $relation_types as $relation_type ) {
-				$related_order_ids = array_merge( $related_order_ids, WCS_Related_Order_Store::instance()->get_related_order_ids( $this, $relation_type ) );
+				$related_orders_for_relation_type = WCS_Related_Order_Store::instance()->get_related_order_ids( $this, $relation_type );
+				if ( is_array( $related_orders_for_relation_type ) ) {
+					$related_order_ids = array_merge( $related_order_ids, $related_orders_for_relation_type );
+				}
 			}
 		}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2065,10 +2065,7 @@ class WC_Subscription extends WC_Order {
 			$relation_types = ( 'any' === $order_type ) ? array( 'renewal', 'resubscribe', 'switch' ) : array( $order_type );
 
 			foreach ( $relation_types as $relation_type ) {
-				$related_orders_for_relation_type = WCS_Related_Order_Store::instance()->get_related_order_ids( $this, $relation_type );
-				if ( is_array( $related_orders_for_relation_type ) ) {
-					$related_order_ids = array_merge( $related_order_ids, $related_orders_for_relation_type );
-				}
+				$related_order_ids = array_merge( $related_order_ids, WCS_Related_Order_Store::instance()->get_related_order_ids( $this, $relation_type ) );
 			}
 		}
 

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -210,7 +210,9 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 
 		$meta_data = $this->get_related_order_metadata( $subscription, $relation_type );
 
-		return $meta_data ? maybe_unserialize( $meta_data->meta_value ) : '';
+		$related_orders = $meta_data ? maybe_unserialize( $meta_data->meta_value ) : '';
+
+		return is_array( $related_orders ) ? $related_orders : '';
 	}
 
 	/**


### PR DESCRIPTION
Fixes p1715949726180409-slack

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

We have a merchant that sometimes receives a fatal error when listing subscriptions. This is happening because, for their specific case, the related orders retrieval method is not always returning an array as expected, but a serialized array (still unknown reasons). This PR adds a type check for the returned value to avoid the issue.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is hard to reproduce since, right now, we are still not sure how this is happening for the merchant. Since code review should be enough.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes