### PR TITLE
New helper function: wcs_set_recurring_item_total()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 7.1.2 - 2024-xx-xx =
 * Update - Show "FREE" instead of 0 when there is no shipping cost in the recurring totals section of the Cart and Checkout blocks (requires WooCommerce 9.0+).
-* Add - New function wcs_set_recurring_item_total() to set line item totals that have been copied from an initial order to their proper recurring totals (i.e. remove sign-up fees).
+* Dev - New function wcs_set_recurring_item_total() to set line item totals that have been copied from an initial order to their proper recurring totals (i.e. remove sign-up fees).
 
 = 7.1.1 - 2024-05-09 =
 * Fix - Resolved an issue that caused "WC_DateTime could not be converted to int" warnings to occur on non-hpos sites while editing a subscription.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.1.2 - 2024-xx-xx =
 * Update - Show "FREE" instead of 0 when there is no shipping cost in the recurring totals section of the Cart and Checkout blocks (requires WooCommerce 9.0+).
+* Add - New function wcs_set_recurring_item_total() to set line item totals that have been copied from an initial order to their proper recurring totals (i.e. remove sign-up fees).
 
 = 7.1.1 - 2024-05-09 =
 * Fix - Resolved an issue that caused "WC_DateTime could not be converted to int" warnings to occur on non-hpos sites while editing a subscription.

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -1003,3 +1003,55 @@ function wcs_order_contains_early_renewal( $order ) {
 function wcs_get_subscription_item_grouping_key( $item, $renewal_time = '' ) {
 	return apply_filters( 'woocommerce_subscriptions_item_grouping_key', wcs_get_subscription_grouping_key( $item->get_product(), $renewal_time ), $item );
 }
+
+/**
+ * Sets the order item total to its recurring product price.
+ *
+ * This function takes an order item and checks if its totals have been modified to account for free trials or sign-up fees (i.e. parent orders).
+ * If the totals have been adjusted, the function sets the item's total back to their recurring total.
+ *
+ * Note: If the line item has a custom total that doesn't match the expected price, don't override it.
+ *
+ * @param WC_Order_Item $item Subscription line item.
+ */
+function wcs_set_recurring_item_total( &$item ) {
+	$product = $item->get_product();
+
+	if ( ! $product ) {
+		return;
+	}
+
+	$sign_up_fee  = WC_Subscriptions_Product::get_sign_up_fee( $product );
+	$sign_up_fee  = is_numeric( $sign_up_fee ) ? (float) $sign_up_fee : 0;
+	$trial_length = WC_Subscriptions_Product::get_trial_length( $product );
+
+	$recurring_price = (float) $product->get_price();
+	$initial_price   = $trial_length > 0 ? $sign_up_fee : $recurring_price + $sign_up_fee;
+	$initial_total   = wc_get_price_excluding_tax(
+		$product,
+		[
+			'qty'   => $item->get_quantity(),
+			'price' => $initial_price,
+		]
+	);
+
+	// Check if a custom item total was set on the order. If so, don't override it.
+	if ( (float) $item->get_subtotal() !== $initial_total ) {
+		return;
+	}
+
+	$recurring_total = wc_get_price_excluding_tax(
+		$product,
+		[
+			'qty'   => $item->get_quantity(),
+			'price' => $recurring_price,
+		]
+	);
+
+	$item->set_props(
+		[
+			'subtotal' => $recurring_total,
+			'total'    => $recurring_total,
+		]
+	);
+}

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -1017,7 +1017,7 @@ function wcs_get_subscription_item_grouping_key( $item, $renewal_time = '' ) {
 function wcs_set_recurring_item_total( &$item ) {
 	$product = $item->get_product();
 
-	if ( ! $product ) {
+	if ( ! $product || ! WC_Subscriptions_Product::is_subscription( $product ) ) {
 		return;
 	}
 

--- a/tests/unit/test-wcs-order-functions.php
+++ b/tests/unit/test-wcs-order-functions.php
@@ -400,5 +400,26 @@ class WCS_Order_Functions_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 50, $line_item->get_total() );
 		$this->assertEquals( 50, $line_item->get_subtotal() );
+
+		/**
+		 * Subscription item with quantity.
+		 */
+		$sign_up_fee_trial_product = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'                     => 40,
+				'subscription_sign_up_fee'  => 60,
+				'subscription_trial_length' => 10,
+			]
+		);
+
+		$line_item->set_product( $sign_up_fee_trial_product );
+		$line_item->set_quantity( 2 );
+		$line_item->set_total( 120 ); // Initial total is just the sign-up fee.
+		$line_item->set_subtotal( 120 );
+
+		wcs_set_recurring_item_total( $line_item );
+
+		$this->assertEquals( 80, $line_item->get_total() );
+		$this->assertEquals( 80, $line_item->get_subtotal() );
 	}
 }

--- a/tests/unit/test-wcs-order-functions.php
+++ b/tests/unit/test-wcs-order-functions.php
@@ -304,6 +304,86 @@ class WCS_Order_Functions_Test extends WP_UnitTestCase {
 			$this->assertIsArray( $subscriptions );
 			$this->assertEmpty( $subscriptions );
 		}
+	}
 
+	public function test_wcs_set_recurring_item_total() {
+		/**
+		 * Regular subscription item.
+		 */
+		$product = WCS_Helper_Product::create_simple_subscription_product( [ 'price' => 10 ] );
+
+		$line_item = new WC_Order_Item_Product();
+		$line_item->set_product( $product );
+		$line_item->set_quantity( 1 );
+		$line_item->set_total( 10 );
+		$line_item->set_subtotal( 10 );
+
+		wcs_set_recurring_item_total( $line_item );
+
+		$this->assertEquals( 10, $line_item->get_total() );
+		$this->assertEquals( 10, $line_item->get_subtotal() );
+
+		/**
+		 * Subscription item with trial.
+		 */
+		$trial_product = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'                     => 20,
+				'subscription_trial_length' => 10,
+			]
+		);
+
+		$line_item = new WC_Order_Item_Product();
+		$line_item->set_product( $trial_product );
+		$line_item->set_quantity( 1 );
+		$line_item->set_total( 0 ); // Trial product's are free initially.
+		$line_item->set_subtotal( 0 );
+
+		wcs_set_recurring_item_total( $line_item );
+
+		$this->assertEquals( 20, $line_item->get_total() );
+		$this->assertEquals( 20, $line_item->get_subtotal() );
+
+		/**
+		 * Subscription item with sign-up fee.
+		 */
+		$sign_up_fee_product = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'                    => 30,
+				'subscription_sign_up_fee' => 50,
+			]
+		);
+
+		$line_item = new WC_Order_Item_Product();
+		$line_item->set_product( $sign_up_fee_product );
+		$line_item->set_quantity( 1 );
+		$line_item->set_total( 80 ); // Initial total is the sum of the product price and sign-up fee.
+		$line_item->set_subtotal( 80 );
+
+		wcs_set_recurring_item_total( $line_item );
+
+		$this->assertEquals( 30, $line_item->get_total() );
+		$this->assertEquals( 30, $line_item->get_subtotal() );
+
+		/**
+		 * Subscription item with sign-up fee and trial.
+		 */
+		$sign_up_fee_trial_product = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'                     => 40,
+				'subscription_sign_up_fee'  => 60,
+				'subscription_trial_length' => 10,
+			]
+		);
+
+		$line_item->set_product( $sign_up_fee_trial_product );
+		$line_item->set_quantity( 1 );
+		$line_item->set_total( 60 ); // Initial total is just the sign-up fee.
+		$line_item->set_subtotal( 60 );
+
+		wcs_set_recurring_item_total( $line_item );
+
+		$this->assertEquals( 40, $line_item->get_total() );
+		$this->assertEquals( 40, $line_item->get_subtotal() );
 	}
 }

--- a/tests/unit/test-wcs-order-functions.php
+++ b/tests/unit/test-wcs-order-functions.php
@@ -385,5 +385,20 @@ class WCS_Order_Functions_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 40, $line_item->get_total() );
 		$this->assertEquals( 40, $line_item->get_subtotal() );
+
+		/**
+		 * Simple product
+		 */
+		$simple_product = WC_Helper_Product::create_simple_product();
+
+		$line_item->set_product( $simple_product );
+		$line_item->set_quantity( 1 );
+		$line_item->set_total( 50 ); // Default price is $10.00. We set it to $50 here to confirm it's not changed.
+		$line_item->set_subtotal( 50 );
+
+		wcs_set_recurring_item_total( $line_item );
+
+		$this->assertEquals( 50, $line_item->get_total() );
+		$this->assertEquals( 50, $line_item->get_subtotal() );
 	}
 }


### PR DESCRIPTION
Needed for testing: 4656-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR turns a private function found in our V3 Subscriptions Controller class into a public helper function: `wcs_set_recurring_item_total()`.

This function is used by both V2 and V3 Subscriptions API Controller classes when implementing the `POST orders/123/subscriptions` endpoint and is used to make sure the order items copied from the parent order over to the subscription have the correct recurring totals (i.e. the totals do not include sign-up fees or are $0 due to the product including a trial period)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
