### PR TITLE
fix: label improvement on my subscription page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.2.0 - 2024-xx-xx =
+* Fix - label improvement on my subscription page template.
 * Fix - Regenerate subscriptions related order caches (renewal, resubscribe, switch) if it's stored as an invalid value to prevent fatal errors.
 * Update - Show "FREE" instead of 0 when there is no shipping cost in the recurring totals section of the Cart and Checkout blocks (requires WooCommerce 9.0+).
 * Dev - New function wcs_set_recurring_item_total() to set line item totals that have been copied from an initial order to their proper recurring totals (i.e. remove sign-up fees).

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -31,7 +31,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
 		<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
 			<td class="subscription-id order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-id woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'ID', 'woocommerce-subscriptions' ); ?>">
-				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>"><?php echo esc_html( sprintf( _x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ); ?></a>
+				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce' ), $subscription->get_order_number() ) ) ?>">
+					<?php echo esc_html( sprintf( _x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ); ?>
+				</a>
 				<?php do_action( 'woocommerce_my_subscriptions_after_subscription_id', $subscription ); ?>
 			</td>
 			<td class="subscription-status order-status woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-status woocommerce-orders-table__cell-order-status" data-title="<?php esc_attr_e( 'Status', 'woocommerce-subscriptions' ); ?>">

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -4,7 +4,7 @@
  *
  * @author   Prospress
  * @category WooCommerce Subscriptions/Templates
- * @version  1.0.0 - Migrated from WooCommerce Subscriptions v2.6.4
+ * @version  7.2.0 - Migrated from WooCommerce Subscriptions v2.6.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/43627

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Similar changes to https://github.com/woocommerce/woocommerce/pull/48374
Adding an `aria-label` to the subscription link with the subscription number for screen readers.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a customer, place an order with a subscription item
- As a customer, navigate to "My account > Subscriptions"
- The links to the individual subscriptions should include an `aria-label` attribute
<img width="1480" alt="Screenshot 2024-06-11 at 2 05 48 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/2d09692c-7a44-40eb-acfc-fbf6c771794c">


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? no
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
