### PR TITLE
fix: label improvement on subscription and order pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.3.0 - 2024-xx-xx =
+* Fix - label improvements on subscription and order page templates.
 * Fix - Fixed an issue with subscriptions containing multiple renewal orders to mark a random item as processing, instead of the last order.
 
 = 7.2.0 - 2024-06-13 =

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <tr>
 	<td>
-		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>">
+		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce' ), $order->get_order_number() ) ) ?>">
 			<?php
 			// translators: placeholder is an order number.
 			echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) );

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -11,7 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <tr>
 	<td>
-		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) ?>">
+		<?php // translators: placeholder is an order number. ?>
+		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ); ?>">
 			<?php
 			// translators: placeholder is an order number.
 			echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) );

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <tr>
 	<td>
-		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce' ), $order->get_order_number() ) ) ?>">
+		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) ?>">
 			<?php
 			// translators: placeholder is an order number.
 			echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) );

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
 		<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
 			<td class="subscription-id order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-id woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'ID', 'woocommerce-subscriptions' ); ?>">
-				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce' ), $subscription->get_order_number() ) ) ?>">
+				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ) ?>">
 					<?php echo esc_html( sprintf( _x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ); ?>
 				</a>
 				<?php do_action( 'woocommerce_my_subscriptions_after_subscription_id', $subscription ); ?>

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -31,6 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
 		<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
 			<td class="subscription-id order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-id woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'ID', 'woocommerce-subscriptions' ); ?>">
+				<?php // translators: placeholder is a subscription number. ?>
 				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ) ?>">
 					<?php echo esc_html( sprintf( _x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ); ?>
 				</a>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -40,6 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			?><tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?>">
 				<td class="order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'Order Number', 'woocommerce-subscriptions' ); ?>">
+					<?php // translators: placeholder is an order number. ?>
 					<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) ?>">
 						<?php echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ); ?>
 					</a>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			?><tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?>">
 				<td class="order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'Order Number', 'woocommerce-subscriptions' ); ?>">
-					<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View order number %s', 'woocommerce' ), $order->get_order_number() ) ) ?>">
+					<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) ?>">
 						<?php echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ); ?>
 					</a>
 				</td>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -4,7 +4,7 @@
  *
  * @author   Prospress
  * @category WooCommerce Subscriptions/Templates
- * @version  1.0.0 - Migrated from WooCommerce Subscriptions v2.6.2
+ * @version  7.3.0 - Migrated from WooCommerce Subscriptions v2.6.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -40,7 +40,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			?><tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $order->get_status() ); ?>">
 				<td class="order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'Order Number', 'woocommerce-subscriptions' ); ?>">
-					<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>">
+					<a href="<?php echo esc_url( $order->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View order number %s', 'woocommerce' ), $order->get_order_number() ) ) ?>">
 						<?php echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ); ?>
 					</a>
 				</td>

--- a/templates/myaccount/related-subscriptions.php
+++ b/templates/myaccount/related-subscriptions.php
@@ -4,7 +4,7 @@
  *
  * @author   Prospress
  * @category WooCommerce Subscriptions/Templates
- * @version  1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
+ * @version  7.3.0 - Migrated from WooCommerce Subscriptions v2.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
 			<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
 				<td class="subscription-id order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-id woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'ID', 'woocommerce-subscriptions' ); ?>">
-					<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>">
+					<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce' ), $subscription->get_order_number() ) ) ?>">
 						<?php echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) ); ?>
 					</a>
 				</td>

--- a/templates/myaccount/related-subscriptions.php
+++ b/templates/myaccount/related-subscriptions.php
@@ -29,6 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
 			<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
 				<td class="subscription-id order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-id woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'ID', 'woocommerce-subscriptions' ); ?>">
+					<?php // translators: placeholder is a subscription number. ?>
 					<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ) ?>">
 						<?php echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) ); ?>
 					</a>

--- a/templates/myaccount/related-subscriptions.php
+++ b/templates/myaccount/related-subscriptions.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
 			<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
 				<td class="subscription-id order-number woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-id woocommerce-orders-table__cell-order-number" data-title="<?php esc_attr_e( 'ID', 'woocommerce-subscriptions' ); ?>">
-					<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce' ), $subscription->get_order_number() ) ) ?>">
+					<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'View subscription number %s', 'woocommerce-subscriptions' ), $subscription->get_order_number() ) ) ?>">
 						<?php echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) ); ?>
 					</a>
 				</td>


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/43627

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Similar changes to https://github.com/Automattic/woocommerce-subscriptions-core/pull/632
Adding an `aria-label` to the subscription & order links with the subscription/order number for screen readers.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Related orders - merchant

- As a customer, create a subscription
- As a merchant, go to WooCommerce > Subscriptions
- Select one of the subscriptions
- Navigate to the "related orders" meta box
- The `aria-label` attribute on the link should now be present

Before:
<img width="848" alt="Screenshot 2024-06-26 at 12 44 52 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/619386ae-aff0-451f-a9fb-789f13592501">

After:
<img width="1034" alt="Screenshot 2024-06-26 at 12 48 14 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/24118af0-cfb7-4e91-9e17-561995338f81">


### Related orders - customer
- As a customer, create a subscription
- Go to My Account > Subscriptions
- Select one of the subscriptions
- Navigate to the "related orders" section of the page
- The `aria-label` attribute on the link should now be present

Before:
<img width="1105" alt="Screenshot 2024-06-26 at 12 51 29 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/285bd796-e00c-47d6-8f36-9cdae1a57940">

After:
<img width="1092" alt="Screenshot 2024-06-26 at 12 52 45 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/3d170674-b909-4f40-be90-cbafd4434e84">

### Related subscriptions
- As a customer, create a subscription
- Go to My Account > Orders
- Select the order related to the subscription
- Navigate to the "related subscriptions" section of the page
- The `aria-label` attribute on the link should now be present

Before:
<img width="1590" alt="Screenshot 2024-06-26 at 12 54 13 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/5d03298c-9269-43c7-9742-3eeff5936d7a">

After:
<img width="1290" alt="Screenshot 2024-06-26 at 12 55 43 PM" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/273592/8d09166f-552b-49ff-9249-1ccdd8977d2b">


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? no
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
