### PR TITLE
Fix error when purchasing subscription products on the block checkout with a limited recurring coupon

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Label improvements on subscription and order page templates.
 * Fix - Fixed an issue with subscriptions containing multiple renewal orders to mark a random item as processing, instead of the last order.
 * Fix - Prevent errors from invalid subscription objects during customer payment method updates.
+* Fix - Resolved an error when purchasing subscription products on the block checkout with a limited recurring coupon.
 
 = 7.2.0 - 2024-06-13 =
 * Fix - label improvement on my subscription page template.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -693,13 +693,13 @@ class WC_Subscriptions_Order {
 			return $needs_payment;
 		}
 
-		$has_next_payment                 = false;
-		$contains_expiring_limited_coupon = false;
-		$recurring_total                  = 0;
-		$contains_free_trial              = false;
-		$contains_synced                  = false;
-
+		// Check if there's a subscription attached to this order that will require a payment method.
 		foreach ( wcs_get_subscriptions_for_order( $order ) as $subscription ) {
+			$has_next_payment                 = false;
+			$contains_expiring_limited_coupon = false;
+			$contains_free_trial              = false;
+			$contains_synced                  = false;
+
 			// Check if there's a subscription with a recurring total that would require a payment method.
 			$recurring_total = $subscription->get_total();
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -701,7 +701,7 @@ class WC_Subscriptions_Order {
 			$contains_synced                  = false;
 
 			// Check if there's a subscription with a recurring total that would require a payment method.
-			$recurring_total = $subscription->get_total();
+			$recurring_total = (float) $subscription->get_total();
 
 			// Check that there is at least 1 subscription with a next payment that would require a payment method.
 			if ( $subscription->get_time( 'next_payment' ) ) {
@@ -727,7 +727,7 @@ class WC_Subscriptions_Order {
 			 * We need to collect a payment method if there's a subscription with a recurring total or a limited recurring coupon that is expiring and
 			 * there's a next payment date or a free trial or a synced product.
 			 */
-			if ( $contains_expiring_limited_coupon || $recurring_total > 0 && ( $has_next_payment || $contains_free_trial || $contains_synced ) ) {
+			if ( ( $contains_expiring_limited_coupon || $recurring_total > 0 ) && ( $has_next_payment || $contains_free_trial || $contains_synced ) ) {
 				$needs_payment = true;
 				break; // We've found a subscription that requires a payment method.
 			}

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -683,29 +683,54 @@ class WC_Subscriptions_Order {
 		}
 
 		// Skip checks if order total is greater than zero, or
-		// recurring total is zero, or
 		// order status isn't valid for payment.
-		if ( $order->get_total() > 0 || self::get_recurring_total( $order ) <= 0 || ! $order->has_status( $valid_order_statuses ) ) {
+		if ( $order->get_total() > 0 || ! $order->has_status( $valid_order_statuses ) ) {
 			return $needs_payment;
 		}
 
-		// Check that there is at least 1 subscription with a next payment that would require a payment method.
-		$has_next_payment = false;
+		// Skip checks if manual renewal is required.
+		if ( wcs_is_manual_renewal_required() ) {
+			return $needs_payment;
+		}
+
+		$has_next_payment                 = false;
+		$contains_expiring_limited_coupon = false;
+		$recurring_total                  = 0;
+		$contains_free_trial              = false;
+		$contains_synced                  = false;
 
 		foreach ( wcs_get_subscriptions_for_order( $order ) as $subscription ) {
+			// Check if there's a subscription with a recurring total that would require a payment method.
+			$recurring_total = $subscription->get_total();
+
+			// Check that there is at least 1 subscription with a next payment that would require a payment method.
 			if ( $subscription->get_time( 'next_payment' ) ) {
 				$has_next_payment = true;
-				break;
 			}
-		}
 
-		if ( ! $has_next_payment ) {
-			return $needs_payment;
-		}
+			// Check if there's a subscription with a limited recurring coupon that is expiring that would require a payment method after the coupon expires.
+			if ( class_exists( 'WCS_Limited_Recurring_Coupon_Manager' ) && WCS_Limited_Recurring_Coupon_Manager::order_has_limited_recurring_coupon( $subscription ) ) {
+				$contains_expiring_limited_coupon = true;
+			}
 
-		// If manual renewals are not required.
-		if ( ! wcs_is_manual_renewal_required() ) {
-			$needs_payment = true;
+			// Check if there's a subscription with a free trial that would require a payment method after the trial ends.
+			if ( $subscription->get_time( 'trial_end' ) ) {
+				$contains_free_trial = true;
+			}
+
+			// Check if there's a subscription with a synced product that would require a payment method.
+			if ( WC_Subscriptions_Synchroniser::subscription_contains_synced_product( $subscription ) ) {
+				$contains_synced = true;
+			}
+
+			/**
+			 * We need to collect a payment method if there's a subscription with a recurring total or a limited recurring coupon that is expiring and
+			 * there's a next payment date or a free trial or a synced product.
+			 */
+			if ( $contains_expiring_limited_coupon || $recurring_total > 0 && ( $has_next_payment || $contains_free_trial || $contains_synced ) ) {
+				$needs_payment = true;
+				break; // We've found a subscription that requires a payment method.
+			}
 		}
 
 		return $needs_payment;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4690

## Description

This PR fixes the error thrown when attempting to purchase a subscription product with a limited recurring coupon. 

<p align="center">
<img width="573" alt="345308592-670afdae-d281-4b62-af2d-68f21d6dc4e6" src="https://github.com/user-attachments/assets/10fbcecf-f214-4b00-9127-a89f30f1ba29">
</p> 

This error was being thrown because the WC block checkout checks if an order needs payment before engaging payment gateways ([here](https://github.com/woocommerce/woocommerce/blob/e750ba559215e73c09216f4970a9804beac2caa4/plugins/woocommerce/src/StoreApi/Routes/V1/Checkout.php#L293-L294)).

Prior to this PR, the order didn't require payment because the initial order total is $0, and the checks in our `order_needs_payment()` function, didn't take into consideration the scenario where a $0 order with a limited coupon does need payment. 

This PR updates the `order_needs_payment()` function to match the logic of [`cart_needs_payment()`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.3.0/includes/class-wc-subscriptions-cart.php#L878-L889) which does take into consideration those additional checks. 

## How to test this PR

1. Go to **Marketing → Coupons** from your admin dashboard.
2. Create a new coupon.
3. Give it the **"Recurring Product % Discount"** type
4. Make it 100% off. 
5. Next to **Active for x payments** limit it to 3 payments. See example below.

<p align="center">
<img width="500" alt="Screenshot 2024-07-03 at 4 36 27 PM" src="https://github.com/woocommerce/woocommerce-subscriptions/assets/8490476/2debcbcd-1046-46d9-9918-94686fbf8ff5">
</p>

6. Create a **virtual** subscription product or disable shipping.
   - _We want $0 upfront cost including no shipping._ 
7. Add the product to your cart. 
8. Apply the coupon.
9. Go to the checkout and confirm there's no upfront cost. 
10. Attempt to sign up.
   - On `trunk` you will get the error message I mentioned above. 
   - On this branch no error and the payment should process as expected. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
