### PR TITLE
Fix admin notices missing when HPOS enabled 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.4.0 - 2024-xx-xx =
 * Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
+* Fix - Ensure admin notices are displayed after performing bulk actions on subscriptions when HPOS is enabled.
 
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.

--- a/includes/privacy/class-wcs-privacy.php
+++ b/includes/privacy/class-wcs-privacy.php
@@ -124,7 +124,7 @@ class WCS_Privacy extends WC_Abstract_Privacy {
 	 */
 	public static function handle_privacy_bulk_actions( $redirect_url, $action, $subscription_ids ) {
 		if ( 'wcs_remove_personal_data' !== $action ) {
-			return;
+			return $redirect_url;
 		}
 
 		$changed       = 0;

--- a/includes/privacy/class-wcs-privacy.php
+++ b/includes/privacy/class-wcs-privacy.php
@@ -146,8 +146,7 @@ class WCS_Privacy extends WC_Abstract_Privacy {
 		$sendback_args['changed'] = $changed;
 		$sendback                 = add_query_arg( $sendback_args, $redirect_url );
 
-		wp_safe_redirect( esc_url_raw( $sendback ) );
-		exit();
+		return esc_url_raw( $sendback );
 	}
 
 	/**
@@ -178,7 +177,10 @@ class WCS_Privacy extends WC_Abstract_Privacy {
 		$subscription_ids  = array_map( 'absint', (array) $_REQUEST['post'] );
 		$base_redirect_url = wp_get_referer() ? wp_get_referer() : '';
 
-		self::handle_privacy_bulk_actions( $base_redirect_url, $action, $subscription_ids );
+		$redirect_url = self::handle_privacy_bulk_actions( $base_redirect_url, $action, $subscription_ids );
+
+		wp_safe_redirect( $redirect_url );
+		exit();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #641 

## Description
When HPOS is enabled, Admin notices such as "2 subscription statuses changed" are not shown to the user after performing a Bulk action on subscriptions.

This was happening because `handle_bulk_actions-woocommerce_page_wc-orders--shop_subscription` filter was [returning](https://github.com/Automattic/woocommerce-subscriptions-core/blob/trunk/includes/privacy/class-wcs-privacy.php#L127) `null` instead of the `redirect_url`.

## How to test this PR

1. Create a few subscriptions if you already don't have some.
2. Go to _WooCommerce > Subscriptions_ page. 
3. Select a few subscriptions, select a new status from the `Bulk actions` dropdown and apply the changes.
4. In `trunk`, notice that the statuses of the selected subscriptions have changed but there is no notice on the page.
5. Checkout to this branch and repeat step 3.
6. Confirm that the statuses of the selected subscriptions have changed and there is a notice on the page.

<img width="1286" alt="Screenshot 2024-07-30 at 11 43 34 AM" src="https://github.com/user-attachments/assets/e3f0d0f5-b3aa-4d27-9ad1-3c98416fe2a9">
