### PR TITLE
Update the subscription modified date when a related order cache is updated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 7.5.0 - 2024-09-13 =
+= 7.5.0 - 2024-xx-xx =
 * Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
 
 = 7.4.1 - 2024-08-21 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Dev - Introduce new parameter to WC_Subscription::get_last_order() to enable filtering out orders with specific statuses.
 * Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
 * Fix - Ensure admin notices are displayed after performing bulk actions on subscriptions when HPOS is enabled.
-* Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites
+* Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
 
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.5.0 - 2024-09-13 =
+* Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
+
 = 7.4.1 - 2024-08-21 =
 * Fix - Add a year to the next renewal date billing interval is 12 months or more for a synced subscription.
 
@@ -7,7 +10,6 @@
 * Dev - Introduce new parameter to WC_Subscription::get_last_order() to enable filtering out orders with specific statuses.
 * Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
 * Fix - Ensure admin notices are displayed after performing bulk actions on subscriptions when HPOS is enabled.
-* Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
 
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.4.0 - 2024-xx-xx =
+* Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
+
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.
 * Fix - Fixed an issue with subscriptions containing multiple renewal orders to mark a random item as processing, instead of the last order.

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -671,25 +671,17 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$subscription_modified = $subscription->get_date_modified( 'edit' );
 
 		// If the subscription's modified date is already up-to-date, don't update it again.
-		if ( $subscription_modified && $subscription_modified->getTimestamp() === time() ) {
+		if ( $subscription_modified && $subscription_modified->getTimestamp() === gmdate( 'U' ) ) {
 			return;
 		}
 
 		$related_orders_have_changed = false;
 
 		// If the new related order IDs are different from the current ones, update the cache.
-		if ( $current_metadata ) {
-			$current_related_order_ids = maybe_unserialize( $current_metadata->meta_value );
+		$current_related_order_ids = $current_metadata ? maybe_unserialize( $current_metadata->meta_value ) : null;
 
-			if ( $current_related_order_ids !== $related_order_ids ) {
-				$related_orders_have_changed = true;
-			}
-		} elseif ( ! empty( $related_order_ids ) ) {
-			$related_orders_have_changed = true;
-		}
-
-		if ( $related_orders_have_changed ) {
-			$subscription->set_date_modified( time() );
+		if ( $current_related_order_ids !== $related_order_ids ) {
+			$subscription->set_date_modified( gmdate( 'U' ) );
 			$subscription->save();
 		}
 	}

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -283,19 +283,17 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			}
 		}
 
-		// On non-HPOS sites, make sure the subscription's modified date is updated when a related order cache is updated.
-		// On HPOS sites this isn't necessary because calling update_meta() or add_meta() will update the modified date.
-		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
-			$subscription->set_date_modified( time() );
-			$subscription->save();
-		}
-
 		$subscription_data_store = WC_Data_Store::load( 'subscription' );
 		$current_metadata        = $this->get_related_order_metadata( $subscription, $relation_type );
 		$new_metadata            = array(
 			'key'   => $this->get_cache_meta_key( $relation_type ),
 			'value' => $related_order_ids,
 		);
+
+		// Update the subscription's modified date if the related order cache has changed. Only necessary on non-HPOS environments.
+		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
+			$this->update_modified_date_for_related_order_cache( $subscription, $related_order_ids, $current_metadata );
+		}
 
 		// Check if HPOS and data syncing is enabled then manually backfill the related orders cache values to WP Posts table.
 		$this->maybe_backfill_related_order_cache( $subscription, $relation_type, $new_metadata );
@@ -660,5 +658,39 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		}
 
 		return false;
+	}
+
+	/**
+	 * Updates the subscription's modified date if the related order cache has changed.
+	 *
+	 * @param WC_Subscription $subscription      The subscription to update the modified date for.
+	 * @param array           $related_order_ids The related order IDs to compare with the current related order IDs.
+	 * @param object          $current_metadata  The current related order cache metadata.
+	 */
+	protected function update_modified_date_for_related_order_cache( $subscription, $related_order_ids, $current_metadata ) {
+		$subscription_modified = $subscription->get_date_modified( 'edit' );
+
+		// If the subscription's modified date is already up-to-date, don't update it again.
+		if ( $subscription_modified && $subscription_modified->getTimestamp() === time() ) {
+			return;
+		}
+
+		$related_orders_have_changed = false;
+
+		// If the new related order IDs are different from the current ones, update the cache.
+		if ( $current_metadata ) {
+			$current_related_order_ids = maybe_unserialize( $current_metadata->meta_value );
+
+			if ( $current_related_order_ids !== $related_order_ids ) {
+				$related_orders_have_changed = true;
+			}
+		} elseif ( ! empty( $related_order_ids ) ) {
+			$related_orders_have_changed = true;
+		}
+
+		if ( $related_orders_have_changed ) {
+			$subscription->set_date_modified( time() );
+			$subscription->save();
+		}
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -671,7 +671,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$subscription_modified = $subscription->get_date_modified( 'edit' );
 
 		// If the subscription's modified date is already up-to-date, don't update it again.
-		if ( $subscription_modified && $subscription_modified->getTimestamp() === gmdate( 'U' ) ) {
+		if ( $subscription_modified && (int) $subscription_modified->getTimestamp() === (int) gmdate( 'U' ) ) {
 			return;
 		}
 

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -675,8 +675,6 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			return;
 		}
 
-		$related_orders_have_changed = false;
-
 		// If the new related order IDs are different from the current ones, update the cache.
 		$current_related_order_ids = $current_metadata ? maybe_unserialize( $current_metadata->meta_value ) : null;
 

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -675,9 +675,9 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			return;
 		}
 
-		// If the new related order IDs are different from the current ones, update the cache.
-		$current_related_order_ids = $current_metadata ? maybe_unserialize( $current_metadata->meta_value ) : null;
+		$current_related_order_ids = $current_metadata ? maybe_unserialize( $current_metadata->meta_value ) : [];
 
+		// If the new related order IDs are different from the current ones, update the subscription's modified date.
 		if ( $current_related_order_ids !== $related_order_ids ) {
 			$subscription->set_date_modified( gmdate( 'U' ) );
 			$subscription->save();

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -283,8 +283,14 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			}
 		}
 
-		// Make sure the subscription's modified date is updated when a related order cache is updated.
-		$subscription->set_date_modified( current_time( 'mysql' ) );
+		/**
+		 * On non-HPOS sites, make sure the subscription's modified date is updated when a related order cache is updated.
+		 * On HPOS sites this isn't necessary because calling update_meta() will update the post_modified date.
+		 */
+		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
+			$subscription->set_date_modified( current_time( 'mysql' ) );
+			$subscription->save();
+		}
 
 		$subscription_data_store = WC_Data_Store::load( 'subscription' );
 		$current_metadata        = $this->get_related_order_metadata( $subscription, $relation_type );

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -283,6 +283,9 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			}
 		}
 
+		// Make sure the subscription's modified date is updated when a related order cache is updated.
+		$subscription->set_date_modified( current_time( 'mysql' ) );
+
 		$subscription_data_store = WC_Data_Store::load( 'subscription' );
 		$current_metadata        = $this->get_related_order_metadata( $subscription, $relation_type );
 		$new_metadata            = array(

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -283,10 +283,8 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			}
 		}
 
-		/**
-		 * On non-HPOS sites, make sure the subscription's modified date is updated when a related order cache is updated.
-		 * On HPOS sites this isn't necessary because calling update_meta() will update the post_modified date.
-		 */
+		// On non-HPOS sites, make sure the subscription's modified date is updated when a related order cache is updated.
+		// On HPOS sites this isn't necessary because calling update_meta() or add_meta() will update the modified date.
 		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
 			$subscription->set_date_modified( current_time( 'mysql' ) );
 			$subscription->save();

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -286,7 +286,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		// On non-HPOS sites, make sure the subscription's modified date is updated when a related order cache is updated.
 		// On HPOS sites this isn't necessary because calling update_meta() or add_meta() will update the modified date.
 		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
-			$subscription->set_date_modified( current_time( 'mysql' ) );
+			$subscription->set_date_modified( time() );
 			$subscription->save();
 		}
 

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -671,7 +671,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$subscription_modified = $subscription->get_date_modified( 'edit' );
 
 		// If the subscription's modified date is already up-to-date, don't update it again.
-		if ( $subscription_modified && (int) $subscription_modified->getTimestamp() === (int) gmdate( 'U' ) ) {
+		if ( $subscription_modified && (int) $subscription_modified->getTimestamp() === time() ) {
 			return;
 		}
 
@@ -679,7 +679,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 
 		// If the new related order IDs are different from the current ones, update the subscription's modified date.
 		if ( $current_related_order_ids !== $related_order_ids ) {
-			$subscription->set_date_modified( gmdate( 'U' ) );
+			$subscription->set_date_modified( time() );
 			$subscription->save();
 		}
 	}

--- a/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
+++ b/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
@@ -315,7 +315,7 @@ class WCS_Related_Order_Store_Cached_CPT_Test extends WCS_Base_Related_Order_Sto
 		self::$cache_store->add_relation( $related_order, $subscription, 'renewal' );
 
 		$this->assertNotEquals( $original_modified_date->getTimestamp(), $subscription->get_date_modified()->getTimestamp() );
-		$this->assertEqualsWithDelta( gmdate( 'U' ), $subscription->get_date_modified()->getTimestamp(), 1 );
+		$this->assertEqualsWithDelta( time(), $subscription->get_date_modified()->getTimestamp(), 1 );
 	}
 
 	/**

--- a/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
+++ b/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
@@ -303,6 +303,38 @@ class WCS_Related_Order_Store_Cached_CPT_Test extends WCS_Base_Related_Order_Sto
 	}
 
 	/**
+	 * Test that when a related order is added, the subscription's modified date is updated.
+	 */
+	public function test_modified_date_is_updated() {
+		$subscription  = WCS_Helper_Subscription::create_subscription();
+		$related_order = WCS_Helper_Subscription::create_order();
+
+		$subscription->set_date_modified( strtotime( '- 2 days' ) );
+		$original_modified_date = $subscription->get_date_modified();
+
+		self::$cache_store->add_relation( $related_order, $subscription, 'renewal' );
+
+		$this->assertNotEquals( $original_modified_date->getTimestamp(), $subscription->get_date_modified()->getTimestamp() );
+		$this->assertEqualsWithDelta( gmdate( 'U' ), $subscription->get_date_modified()->getTimestamp(), 1 );
+	}
+
+	/**
+	 * Test that updating the related order cache to the same value (empty in this case), does not update the subscription's modified date.
+	 */
+	public function test_modified_date_is_not_updated() {
+		$subscription = WCS_Helper_Subscription::create_subscription();
+
+		self::$cache_store->set_empty_renewal_order_cache( $subscription );
+
+		$subscription->set_date_modified( strtotime( '- 2 days' ) );
+		$original_modified_date = $subscription->get_date_modified();
+
+		self::$cache_store->set_empty_renewal_order_cache( $subscription );
+
+		$this->assertEquals( $original_modified_date->getTimestamp(), $subscription->get_date_modified()->getTimestamp() );
+	}
+
+	/**
 	 * Provide a method to set the relation directly to avoid a breaking change in WCS_Related_Order_Store::add_relation()
 	 * breaking tests that aren't primarily designed to test WCS_Related_Order_Store::add_relation().
 	 *

--- a/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
+++ b/tests/unit/data-stores/test-class-wcs-related-order-store-cached-cpt.php
@@ -313,6 +313,23 @@ class WCS_Related_Order_Store_Cached_CPT_Test extends WCS_Base_Related_Order_Sto
 		$original_modified_date = $subscription->get_date_modified();
 
 		self::$cache_store->add_relation( $related_order, $subscription, 'renewal' );
+		$this->assertNotEquals( $original_modified_date->getTimestamp(), $subscription->get_date_modified()->getTimestamp() );
+		$this->assertEqualsWithDelta( time(), $subscription->get_date_modified()->getTimestamp(), 1 );
+	}
+
+	/**
+	 * Test that when a related order cache is emptied, the subscription's modified date is updated.
+	 */
+	public function test_modified_date_is_updated_when_emptied() {
+		$subscription  = WCS_Helper_Subscription::create_subscription();
+		$related_order = WCS_Helper_Subscription::create_order();
+
+		self::$cache_store->add_relation( $related_order, $subscription, 'renewal' );
+
+		$subscription->set_date_modified( strtotime( '- 3 days' ) );
+		$original_modified_date = $subscription->get_date_modified();
+
+		self::$cache_store->set_empty_renewal_order_cache( $subscription );
 
 		$this->assertNotEquals( $original_modified_date->getTimestamp(), $subscription->get_date_modified()->getTimestamp() );
 		$this->assertEqualsWithDelta( time(), $subscription->get_date_modified()->getTimestamp(), 1 );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4702

## Description

On WP Post sites (not HPOS), when a subscription has it's related order cache updated, it's modified date wasn't being updated. This causes issues for services like Metorik because it uses the modified date to pick up on the fact that the subscription was changed.

This PR fixes that by ensuring that a subscriptions modified date is updated when it's related order cache is updated. ie when an order is added or removed from a subscription's list of related order, the modified date is updated.

This approach seemed to make the most sense. A subscription's list of related order is a core property and so changes to that list justify a subscription modification. 

## How to test this PR

1. Disable HPOS in **WooCommerce → Settings → Advanced → Features (tab)**
1. Go into your database WP Posts table and make a note of a subscriptions `post_modified_date` (wp-posts) date.
2. Go to the scheduled actions page and search for the subscription ID.
3. Find the `pending` `woocommerce_scheduled_subscription_payment` action and run it. 
5. In your database check the modified date again:
   - On `trunk` it **wouldn't** have been updated.
   - On this branch the subscription's modified date should be updated.

Another approach would be to use a code snippet. Something like this:

```
wcs_create_renewal_order( wcs_get_subscription( 8241 ) ); // Replace 8241 with your subscription ID. 
```


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
