### PR TITLE
Ensure trial period form data is set before use.

### DIFF
--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -536,9 +536,9 @@ class WC_Subscriptions_Admin {
 		// Make sure trial period is within allowable range
 		$subscription_ranges = wcs_get_subscription_ranges();
 
-		$max_trial_length = count( $subscription_ranges[ $_POST['_subscription_trial_period'] ] ) - 1;
+		$max_trial_length = ! empty( $_POST['_subscription_trial_period'] ) ? count( $subscription_ranges[ $_POST['_subscription_trial_period'] ] ) - 1 : 0;
 
-		$_POST['_subscription_trial_length'] = absint( $_POST['_subscription_trial_length'] );
+		$_POST['_subscription_trial_length'] = ! empty( $_POST['_subscription_trial_length'] ) ? absint( $_POST['_subscription_trial_length'] ) : 0;
 
 		if ( $_POST['_subscription_trial_length'] > $max_trial_length ) {
 			$_POST['_subscription_trial_length'] = $max_trial_length;
@@ -754,9 +754,9 @@ class WC_Subscriptions_Admin {
 
 		// Make sure trial period is within allowable range
 		$subscription_ranges = wcs_get_subscription_ranges();
-		$max_trial_length    = count( $subscription_ranges[ $_POST['variable_subscription_trial_period'][ $index ] ] ) - 1;
+		$max_trial_length    = ! empty( $_POST['variable_subscription_trial_period'][ $index ] ) ? count( $subscription_ranges[ $_POST['variable_subscription_trial_period'][ $index ] ] ) - 1 : 0;
 
-		$_POST['variable_subscription_trial_length'][ $index ] = absint( $_POST['variable_subscription_trial_length'][ $index ] );
+		$_POST['variable_subscription_trial_length'][ $index ] = ! empty( $_POST['variable_subscription_trial_length'][ $index ] ) ? absint( $_POST['variable_subscription_trial_length'][ $index ] ) : 0;
 
 		if ( $_POST['variable_subscription_trial_length'][ $index ] > $max_trial_length ) {
 			$_POST['variable_subscription_trial_length'][ $index ] = $max_trial_length;


### PR DESCRIPTION
Fixes #

## Description

Adds an `empty()` logic check before using the trial period form data. 

**Question:** At the moment if the data is not saved the fields are set to their defaults. Should I add some further logic checking to avoid replacing data if it's already set? 

## How to test this PR

1. Create a simple subscription product.
2. Remove the trial period from the form data by disabling the field (run `$$( '.wc_input_subscription_trial_period' ).forEach( el => el.setAttribute( 'disabled', 'disabled' ) );` in the browser console
3. Save the product
   - on trunk you will experience a fatal error
   - on this branch you will not
4. Reload the edit product page
5. Set a trial length and modify the period
6. Save the product
7. Ensure the trial length and period are set as expected
8. Create a variable subscription product
9. Create some attributes to use as variation
10. Generate the variations
11. Remove the trial period from the form data by disabling the field (run the same code in the browser console)
12. Save the product (there is currently no fatal on the trunk) 
13. Reload the edit product page
14. Set a trial length and modify the period for variations
15. Save the product

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
