### PR TITLE
Schedule subscription related actions on priority 1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.4.0 - 2024-xx-xx =
+* Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
+
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.
 * Fix - Fixed an issue with subscriptions containing multiple renewal orders to mark a random item as processing, instead of the last order.

--- a/includes/class-wcs-action-scheduler.php
+++ b/includes/class-wcs-action-scheduler.php
@@ -11,6 +11,16 @@
 class WCS_Action_Scheduler extends WCS_Scheduler {
 
 	/**
+	 * The action scheduler group to use for scheduled subscription events.
+	 */
+	const ACTION_GROUP = 'wc_subscription_scheduled_event';
+
+	/**
+	 * The priority of the subscription-related scheduled action.
+	 */
+	const ACTION_PRIORITY = 5;
+
+	/**
 	 * An internal cache of action hooks and corresponding date types.
 	 *
 	 * This variable has been deprecated and will be removed completely in the future. You should use WCS_Action_Scheduler::get_scheduled_action_hook() and WCS_Action_Scheduler::get_date_types_to_schedule() instead.
@@ -55,7 +65,7 @@ class WCS_Action_Scheduler extends WCS_Scheduler {
 
 					// Only schedule it if it's valid. It's active, it's a payment retry or it's pending cancelled and the end date being updated.
 					if ( 'payment_retry' === $date_type || $subscription->has_status( 'active' ) || ( $subscription->has_status( 'pending-cancel' ) && 'end' === $date_type ) ) {
-						as_schedule_single_action( $timestamp, $action_hook, $action_args );
+						$this->schedule_action( $timestamp, $action_hook, $action_args );
 					}
 				}
 			}
@@ -110,7 +120,7 @@ class WCS_Action_Scheduler extends WCS_Scheduler {
 					}
 
 					if ( 0 != $event_time && $event_time > current_time( 'timestamp', true ) && $next_scheduled !== $event_time ) {
-						as_schedule_single_action( $event_time, $action_hook, $action_args );
+						$this->schedule_action( $event_time, $action_hook, $action_args );
 					}
 				}
 
@@ -139,7 +149,7 @@ class WCS_Action_Scheduler extends WCS_Scheduler {
 
 				// The end date was set in WC_Subscriptions::update_dates() to the appropriate value, so we can schedule our action for that time
 				if ( $end_time > current_time( 'timestamp', true ) && $next_scheduled !== $end_time ) {
-					as_schedule_single_action( $end_time, 'woocommerce_scheduled_subscription_end_of_prepaid_term', $action_args );
+					$this->schedule_action( $end_time, 'woocommerce_scheduled_subscription_end_of_prepaid_term', $action_args );
 				}
 				break;
 			case 'on-hold':
@@ -225,5 +235,37 @@ class WCS_Action_Scheduler extends WCS_Scheduler {
 	 */
 	protected function unschedule_actions( $action_hook, $action_args ) {
 		as_unschedule_all_actions( $action_hook, $action_args );
+	}
+
+	/**
+	 * Gets the priority of the subscription-related scheduled action.
+	 *
+	 * @return int The priority of the subscription-related scheduled action.
+	 */
+	public function get_action_priority( $action_hook ) {
+		return apply_filters( 'woocommerce_subscriptions_scheduled_action_priority', self::ACTION_PRIORITY, $action_hook );
+	}
+
+	/**
+	 * Schedule an subscription-related action with the Action Scheduler.
+	 *
+	 * Subscription events are scheduled with a priority of 5 (see self::ACTION_PRIORITY) and the
+	 * group 'wc_subscription_scheduled_event' (see self::ACTION_GROUP).
+	 *
+	 * @param int    $timestamp Unix timestamp of when the action should run.
+	 * @param string $action_hook Name of event used as the hook for the scheduled action.
+	 * @param array  $action_args Array of name => value pairs stored against the scheduled action.
+	 *
+	 * @return int The action ID.
+	 */
+	protected function schedule_action( $timestamp, $action_hook, $action_args ) {
+		$as_version = ActionScheduler_Versions::instance()->latest_version();
+
+		// On older versions of Action Scheduler, we cannot specify a priority.
+		if ( version_compare( $as_version, '3.6.0', '<' ) ) {
+			return as_schedule_single_action( $timestamp, $action_hook, $action_args, self::ACTION_GROUP );
+		}
+
+		return as_schedule_single_action( $timestamp, $action_hook, $action_args, self::ACTION_GROUP, false, $this->get_action_priority( $action_hook ) );
 	}
 }

--- a/includes/class-wcs-action-scheduler.php
+++ b/includes/class-wcs-action-scheduler.php
@@ -18,7 +18,7 @@ class WCS_Action_Scheduler extends WCS_Scheduler {
 	/**
 	 * The priority of the subscription-related scheduled action.
 	 */
-	const ACTION_PRIORITY = 5;
+	const ACTION_PRIORITY = 1;
 
 	/**
 	 * An internal cache of action hooks and corresponding date types.
@@ -249,7 +249,7 @@ class WCS_Action_Scheduler extends WCS_Scheduler {
 	/**
 	 * Schedule an subscription-related action with the Action Scheduler.
 	 *
-	 * Subscription events are scheduled with a priority of 5 (see self::ACTION_PRIORITY) and the
+	 * Subscription events are scheduled with a priority of 1 (see self::ACTION_PRIORITY) and the
 	 * group 'wc_subscription_scheduled_event' (see self::ACTION_GROUP).
 	 *
 	 * @param int    $timestamp Unix timestamp of when the action should run.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4701

## Description

This PR updates the Subscription `WCS_Action_Scheduler` to scheduled subscription-related events with a priority of 1. 

In v3.6.0 of Action Scheduler they introduced a new feature that enables actions to be scheduled with a priority. This enables plugins like Subscriptions to schedule their events on an earlier priority than the default (10).

This PR does exactly that and schedules all subscription date related events (see list below) on a priority of 1. 

**Why 1?**
I chose 1 because I think there might be occasion to have events that run before subscription related events. eg pre-renewal emails, background scripts that need to update assets before subscriptions run etc. If I had chosen 0, that would leave no room for actions to be scheduled ahead of subscriptions. 

**Subscription-related scheduled actions => date-types**
```php
'woocommerce_scheduled_subscription_trial_end'     => 'trial_end',
'woocommerce_scheduled_subscription_payment'       => 'next_payment',
'woocommerce_scheduled_subscription_payment_retry' => 'payment_retry',
'woocommerce_scheduled_subscription_expiration'    => 'end',
````

## How to test this PR

1. Checkout this branch. 
2. Purchase a subscription if you don't have one already. 
3. Go to **Tools → Scheduled actions**
   - `/wp-admin/tools.php?page=action-scheduler`
4. Search for `woocommerce_scheduled_subscription_payment`
5. Notice there's no group for subscription payment related events:

<p align="center">
<img width="2344" alt="Screenshot 2024-08-07 at 4 41 24 PM" src="https://github.com/user-attachments/assets/2a4013d4-108d-4220-a419-ff85940f260e">
</p> 

6. If you look in the database in the `wp_actionscheduler_actions` you'll also notice that all the subscription scheduled actions also have `10` as the priority.
7. On the **Tools → Scheduled actions** page hover over a subscription related event and click **run**. 

<img width="445" alt="Screenshot 2024-08-07 at 4 48 50 PM" src="https://github.com/user-attachments/assets/12ba2b2d-e6de-4632-9295-66cd6ad5b6d3">

8. View the newly created scheduled action for that subscription in the database and notice 2 things:
   - The new action has a priority 1.
   - The new action has a group id. If you view the action in the UI it will have a group name of `wc_subscription_scheduled_event`.

<img width="883" alt="Screenshot 2024-08-07 at 4 52 57 PM" src="https://github.com/user-attachments/assets/892cd49d-a5e8-4ab7-a78e-8546025f02ac">
<img width="1369" alt="Screenshot 2024-08-07 at 4 54 22 PM" src="https://github.com/user-attachments/assets/ec062fe4-f986-43b6-a773-1c0a2f8c6ddb">

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
