### PR TITLE
Update in-product docs links to subscriptions documentation.

### DIFF
--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1926,7 +1926,7 @@ class WC_Subscriptions_Admin {
 
 				array(
 					// translators: placeholders are opening and closing link tags
-					'desc' => sprintf( __( 'Payment gateways which don\'t support automatic recurring payments can be used to process %1$smanual subscription renewal payments%2$s.', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/renewal-process/">', '</a>' ),
+					'desc' => sprintf( __( 'Payment gateways which don\'t support automatic recurring payments can be used to process %1$smanual subscription renewal payments%2$s.', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/subscriptions/renewal-process/">', '</a>' ),
 					'id'   => self::$option_prefix . '_payment_gateways_additional',
 					'type' => 'informational',
 				),

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -158,7 +158,7 @@ class WCS_Admin_System_Status {
 				$debug_data['wcs_theme_overrides'] += array(
 					'mark_icon' => 'warning',
 					// translators: placeholders are opening/closing tags linking to documentation on outdated templates.
-					'note'      => sprintf( __( '%1$sLearn how to update%2$s', 'woocommerce-subscriptions' ), '<a href="https://docs.woocommerce.com/document/fix-outdated-templates-woocommerce/" target="_blank">', '</a>' ),
+					'note'      => sprintf( __( '%1$sLearn how to update%2$s', 'woocommerce-subscriptions' ), '<a href="https://developer.woocommerce.com/docs/how-to-fix-outdated-woocommerce-templates/" target="_blank">', '</a>' ),
 				);
 			}
 		}

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order_id ) );
 		?>
 		<div class="wcs-unknown-order-info-wrapper">
-			<a href="https://docs.woocommerce.com/document/subscriptions/orders/#section-8">
+			<a href="https://woocommerce.com/document/subscriptions/orders/#why-are-some-orders-in-the-related-orders-table-not-linking-to-the-order">
 				<?php
 				// Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
 				echo wcs_help_tip( sprintf( __( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ), $relationship, '</br>' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -21,7 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<a href="https://woocommerce.com/document/subscriptions/orders/#why-are-some-orders-in-the-related-orders-table-not-linking-to-the-order">
 				<?php
 				// Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
-				echo wcs_help_tip( sprintf( __( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ), $relationship, '</br>' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo wcs_help_tip( 
+					sprintf( 
+						__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
+						$relationship,
+						'</br>' 
+					) 
+				); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</a>
 		</div>

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -27,6 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							$relationship,
 							'</br>'
 							)
+						)
 				); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</a>

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -20,13 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="wcs-unknown-order-info-wrapper">
 			<a href="https://woocommerce.com/document/subscriptions/orders/#why-are-some-orders-in-the-related-orders-table-not-linking-to-the-order">
 				<?php
-				// Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
-				echo wcs_help_tip( 
-					sprintf( 
-						__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
-						$relationship,
-						'</br>' 
-					) 
+				echo esc_html(
+					wcs_help_tip(
+						sprintf( // Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
+							__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
+							$relationship,
+							'</br>'
+							)
 				); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</a>

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -19,16 +19,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 		<div class="wcs-unknown-order-info-wrapper">
 			<a href="https://woocommerce.com/document/subscriptions/orders/#why-are-some-orders-in-the-related-orders-table-not-linking-to-the-order">
-				<?php
-				echo esc_html(
-					wcs_help_tip(
-						sprintf( // Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
-							__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
-							$relationship,
-							'</br>'
-						)
+				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo wcs_help_tip(
+					sprintf( // Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
+						__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
+						esc_html($relationship),
+						'</br>'
 					)
-				); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				);
 				?>
 			</a>
 		</div>

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -26,8 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
 							$relationship,
 							'</br>'
-							)
 						)
+					)
 				); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
 			</a>

--- a/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-unknown-related-orders-row.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				echo wcs_help_tip(
 					sprintf( // Translators: The %1 placeholder is the translated order relationship ("Parent Order"), %2 placeholder is a <br> HTML tag.
 						__( 'This %1$s couldn\'t be loaded from the database. %1$s Click to learn more.', 'woocommerce-subscriptions' ),
-						esc_html($relationship),
+						esc_html( $relationship ),
 						'</br>'
 					)
 				);

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -569,8 +569,8 @@ class WC_Subscriptions_Core_Plugin {
 		}
 
 		$update_notice = '<div class="wc_plugin_upgrade_notice">';
-		// translators: placeholders are opening and closing tags. Leads to docs on version 2
-		$update_notice .= sprintf( __( 'Warning! Version 2.0 is a major update to the WooCommerce Subscriptions extension. Before updating, please create a backup, update all WooCommerce extensions and test all plugins, custom code and payment gateways with version 2.0 on a staging site. %1$sLearn more about the changes in version 2.0 &raquo;%2$s', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/version-2/">', '</a>' );
+		// translators: placeholders are opening and closing tags. Leads to docs on upgrading WooCommerce Subscriptions
+		$update_notice .= sprintf( __( 'Warning! Version 2.0 is a major update to the WooCommerce Subscriptions extension. Before updating, please create a backup, update all WooCommerce extensions and test all plugins, custom code and payment gateways with version 2.0 on a staging site. %1$sLearn more about updating older versions of WooCommerce Subscriptions &raquo;%2$s', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/upgrade-instructions/">', '</a>' );
 		$update_notice .= '</div> ';
 
 		echo wp_kses_post( $update_notice );

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -200,7 +200,7 @@ class WC_Subscriptions_Synchroniser {
 				'name' => __( 'Synchronisation', 'woocommerce-subscriptions' ),
 				'type' => 'title',
 				// translators: placeholders are opening and closing link tags
-				'desc' => sprintf( _x( 'Align subscription renewal to a specific day of the week, month or year. For example, the first day of the month. %1$sLearn more%2$s.', 'used in the general subscription options page', 'woocommerce-subscriptions' ), '<a href="' . esc_url( 'http://docs.woocommerce.com/document/subscriptions/renewal-synchronisation/' ) . '">', '</a>' ),
+				'desc' => sprintf( _x( 'Align subscription renewal to a specific day of the week, month or year. For example, the first day of the month. %1$sLearn more%2$s.', 'used in the general subscription options page', 'woocommerce-subscriptions' ), '<a href="' . esc_url( 'https://woocommerce.com/document/subscriptions/renewal-synchronisation/' ) . '">', '</a>' ),
 				'id'   => self::$setting_id . '_title',
 			),
 

--- a/includes/class-wcs-failed-scheduled-action-manager.php
+++ b/includes/class-wcs-failed-scheduled-action-manager.php
@@ -230,7 +230,7 @@ class WCS_Failed_Scheduled_Action_Manager {
 			),
 			array(
 				'name'  => __( 'Learn more', 'woocommerce-subscriptions' ),
-				'url'   => 'https://docs.woocommerce.com/document/subscriptions/scheduled-action-errors/',
+				'url'   => 'https://woocommerce.com/document/subscriptions/scheduled-action-errors/',
 				'class' => 'button button-primary',
 			),
 		) );

--- a/includes/class-wcs-limiter.php
+++ b/includes/class-wcs-limiter.php
@@ -46,7 +46,7 @@ class WCS_Limiter {
 				'class'       => 'wc-enhanced-select',
 				'label'       => __( 'Limit subscription', 'woocommerce-subscriptions' ),
 				// translators: placeholders are opening and closing link tags
-				'description' => sprintf( __( 'Only allow a customer to have one subscription to this product. %1$sLearn more%2$s.', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/store-manager-guide/#limit-subscription">', '</a>' ),
+				'description' => sprintf( __( 'Only allow a customer to have one subscription to this product. %1$sLearn more%2$s.', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/subscriptions/creating-subscription-products/#limit-subscriptions">', '</a>' ),
 				'options'     => array(
 					'no'     => __( 'Do not limit', 'woocommerce-subscriptions' ),
 					'active' => __( 'Limit to one active subscription', 'woocommerce-subscriptions' ),

--- a/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
+++ b/includes/gateways/class-wc-subscriptions-core-payment-gateways.php
@@ -175,7 +175,7 @@ class WC_Subscriptions_Core_Payment_Gateways {
 		if ( WC_Subscriptions_Cart::cart_contains_subscription() && ! wcs_is_manual_renewal_enabled() ) {
 			if ( current_user_can( 'manage_woocommerce' ) ) {
 				// translators: 1-2: opening/closing tags - link to documentation.
-				$no_gateways_message = sprintf( __( 'Sorry, it seems there are no available payment methods which support subscriptions. Please see %1$sEnabling Payment Gateways for Subscriptions%2$s if you require assistance.', 'woocommerce-subscriptions' ), '<a href="https://docs.woocommerce.com/document/subscriptions/enabling-payment-gateways-for-subscriptions/">', '</a>' );
+				$no_gateways_message = sprintf( __( 'Sorry, it seems there are no available payment methods which support subscriptions. Please see %1$sEnabling Payment Gateways for Subscriptions%2$s if you require assistance.', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/subscriptions/payment-gateways/enabling-payment-gateways-for-subscriptions/">', '</a>' );
 			} else {
 				$no_gateways_message = __( 'Sorry, it seems there are no available payment methods which support subscriptions. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce-subscriptions' );
 			}

--- a/includes/gateways/paypal/includes/admin/class-wcs-paypal-admin.php
+++ b/includes/gateways/paypal/includes/admin/class-wcs-paypal-admin.php
@@ -322,7 +322,8 @@ class WCS_PayPal_Admin {
 			$setting['description'] = sprintf(
 				/* translators: Placeholders are the opening and closing link tags.*/
 				__( "Before enabling PayPal Standard for Subscriptions, please note, when using PayPal Standard, customers are locked into using PayPal Standard for the life of their subscription, and PayPal Standard has a number of limitations. Please read the guide on %1\$swhy we don't recommend PayPal Standard%2\$s for Subscriptions before choosing to enable this option.", 'woocommerce-subscriptions' ),
-				'<a href="https://woocommerce.com/document/limitations-of-paypal-standard/">', '</a>'
+				'<a href="https://woocommerce.com/document/limitations-of-paypal-standard/">',
+				'</a>'
 			);
 		}
 

--- a/includes/gateways/paypal/includes/admin/class-wcs-paypal-admin.php
+++ b/includes/gateways/paypal/includes/admin/class-wcs-paypal-admin.php
@@ -112,7 +112,7 @@ class WCS_PayPal_Admin {
 					'type' => 'warning',
 					// translators: placeholders are opening and closing link tags. 1$-2$: to docs on woocommerce, 3$-4$ to gateway settings on the site
 					'text' => sprintf( esc_html__( 'PayPal is inactive for subscription transactions. Please %1$sset up the PayPal IPN%2$s and %3$senter your API credentials%4$s to enable PayPal for Subscriptions.', 'woocommerce-subscriptions' ),
-						'<a href="https://docs.woocommerce.com/document/subscriptions/store-manager-guide/#ipn-setup" target="_blank">',
+						'<a href="https://woocommerce.com/document/subscriptions/payment-gateways/paypal-standard-subscriptions-guide/#ipn-setup" target="_blank">',
 						'</a>',
 						'<a href="' . esc_url( $payment_gateway_tab_url ) . '">',
 						'</a>'
@@ -136,7 +136,7 @@ class WCS_PayPal_Admin {
 				'text' => sprintf( $notice_text,
 					'<strong>',
 					'</strong>',
-					'<a href="https://docs.woocommerce.com/document/subscriptions/faq/paypal-reference-transactions/" target="_blank">',
+					'<a href="https://woocommerce.com/document/subscriptions/payment-gateways/paypal-standard-subscriptions-guide/paypal-standard-reference-transactions/" target="_blank">',
 					'</a>',
 					'</p><p><a class="button" href="' . esc_url( wp_nonce_url( add_query_arg( 'wcs_paypal', 'check_reference_transaction_support' ), __CLASS__ ) ) . '">',
 					'</a>',
@@ -163,7 +163,7 @@ class WCS_PayPal_Admin {
 				'text' => sprintf( esc_html__( 'There is a problem with PayPal. Your API credentials may be incorrect. Please update your %1$sAPI credentials%2$s. %3$sLearn more%4$s.', 'woocommerce-subscriptions' ),
 					'<a href="' . esc_url( $payment_gateway_tab_url ) . '">',
 					'</a>',
-					'<a href="https://docs.woocommerce.com/document/subscriptions-canceled-suspended-paypal/#section-2" target="_blank">',
+					'<a href="https://woocommerce.com/document/subscriptions-canceled-suspended-paypal/#paypal-api-credentials" target="_blank">',
 					'</a>'
 				),
 			);
@@ -174,7 +174,7 @@ class WCS_PayPal_Admin {
 				'type' => 'error',
 				// translators: placeholders are opening and closing link tags. 1$-2$: docs on woocommerce, 3$-4$: dismiss link
 				'text' => sprintf( esc_html__( 'There is a problem with PayPal. Your PayPal account is issuing out-of-date subscription IDs. %1$sLearn more%2$s. %3$sDismiss%4$s.', 'woocommerce-subscriptions' ),
-					'<a href="https://docs.woocommerce.com/document/subscriptions-canceled-suspended-paypal/#section-3" target="_blank">',
+					'<a href="https://woocommerce.com/document/subscriptions-canceled-suspended-paypal/#old-paypal-accounts" target="_blank">',
 					'</a>',
 					'<a href="' . esc_url( add_query_arg( 'wcs_disable_paypal_invalid_profile_id_notice', 'true' ) ) . '">',
 					'</a>'
@@ -322,7 +322,7 @@ class WCS_PayPal_Admin {
 			$setting['description'] = sprintf(
 				/* translators: Placeholders are the opening and closing link tags.*/
 				__( "Before enabling PayPal Standard for Subscriptions, please note, when using PayPal Standard, customers are locked into using PayPal Standard for the life of their subscription, and PayPal Standard has a number of limitations. Please read the guide on %1\$swhy we don't recommend PayPal Standard%2\$s for Subscriptions before choosing to enable this option.", 'woocommerce-subscriptions' ),
-				'<a href="https://docs.woocommerce.com/document/subscriptions/payment-gateways/#paypal-limitations">', '</a>'
+				'<a href="https://woocommerce.com/document/limitations-of-paypal-standard/">', '</a>'
 			);
 		}
 

--- a/includes/gateways/paypal/includes/class-wcs-paypal-standard-change-payment-method.php
+++ b/includes/gateways/paypal/includes/class-wcs-paypal-standard-change-payment-method.php
@@ -4,7 +4,7 @@
  *
  * Handles the process of a customer changing the payment method on a subscription via their My Account page from or to PayPal Standard.
  *
- * @link http://docs.woocommerce.com/document/subscriptions/customers-view/#section-5
+ * @link https://woocommerce.com/document/subscriptions/customers-view/
  *
  * @package     WooCommerce Subscriptions
  * @subpackage  Gateways/PayPal

--- a/includes/gateways/paypal/includes/templates/html-ipn-failure-notice.php
+++ b/includes/gateways/paypal/includes/templates/html-ipn-failure-notice.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	// translators: $1 and $2 are opening link tags, $3 is a closing link tag.
 	printf(
 		esc_html__( 'A fatal error has occurred while processing a recent subscription payment with PayPal. Please %1$sopen a new ticket at WooCommerce Support%3$s immediately to get this resolved. See our documentation on %2$sdebugging IPN issues in PayPal Standard to Learn more &raquo;%3$s', 'woocommerce-subscriptions' ),
-		'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">',
+		'<a href="https://woocommerce.com/my-account/contact-support/?form=ticket" target="_blank">',
 		'<a href="https://woocommerce.com/document/debug-subscriptions-paypal-ipn-issues/">',
 		'</a>'
 	);

--- a/includes/gateways/paypal/includes/templates/html-ipn-failure-notice.php
+++ b/includes/gateways/paypal/includes/templates/html-ipn-failure-notice.php
@@ -15,24 +15,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php
 	// translators: $1 and $2 are opening link tags, $3 is a closing link tag.
 	printf(
-		esc_html__( 'A fatal error has occurred while processing a recent subscription payment with PayPal. Please %1$sopen a new ticket at WooCommerce Support%3$s immediately to get this resolved. %2$sLearn more &raquo;%3$s', 'woocommerce-subscriptions' ),
+		esc_html__( 'A fatal error has occurred while processing a recent subscription payment with PayPal. Please %1$sopen a new ticket at WooCommerce Support%3$s immediately to get this resolved. See our documentation on %2$sdebugging IPN issues in PayPal Standard to Learn more &raquo;%3$s', 'woocommerce-subscriptions' ),
 		'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">',
-		'<a href="https://docs.woocommerce.com/document/debug-subscriptions-paypal-ipn-issues/#section-1">',
+		'<a href="https://woocommerce.com/document/debug-subscriptions-paypal-ipn-issues/">',
 		'</a>'
 	);
 	?>
 </p>
-<p>
-	<?php
-	// translators: $1 and $2 are opening link tags, $3 is a closing link tag.
-	printf(
-		esc_html__( 'To resolve this as quickly as possible, please create a %1$stemporary administrator account%3$s with the user email woologin@woocommerce.com and share the credentials with us via %2$sQuickForget.com%3$s.', 'woocommerce-subscriptions' ),
-		'<a href="https://docs.woocommerce.com/document/create-new-admin-account-wordpress/" target="_blank">',
-		'<a href="https://quickforget.com/" target="_blank">',
-		'</a>'
-	);
-	?>
-</p>
+
 <?php esc_html_e( 'Last recorded error:', 'woocommerce-subscriptions' ); ?>
 <code>
 <?php

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -967,7 +967,7 @@ class WC_Subscriptions_Upgrader {
 				'<code>' . WC_Subscriptions_Core_Plugin::instance()->get_library_version() . '</code>',
 				'<a href="https://woocommerce.com/my-account/marketplace-ticket-form/" target="_blank">',
 				'</a>',
-				'<a href="https://docs.woocommerce.com/document/subscriptions/upgrade-instructions/#section-12" target="_blank">',
+				'<a href="https://woocommerce.com/document/subscriptions/upgrade-instructions/#section-12" target="_blank">',
 				'</a>'
 			)
 		);

--- a/includes/upgrades/templates/wcs-about.php
+++ b/includes/upgrades/templates/wcs-about.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<p class="woocommerce-actions">
 		<a href="<?php echo esc_url( $settings_page ); ?>" class="button button-primary"><?php esc_html_e( 'Settings', 'woocommerce-subscriptions' ); ?></a>
-		<a class="docs button button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'http://docs.woocommerce.com/document/subscriptions/', 'woocommerce-subscriptions' ) ); ?>"><?php echo esc_html_x( 'Documentation', 'short for documents', 'woocommerce-subscriptions' ); ?></a>
+		<a class="docs button button-primary" href="<?php echo esc_url( apply_filters( 'woocommerce_docs_url', 'https://woocommerce.com/document/subscriptions/', 'woocommerce-subscriptions' ) ); ?>"><?php echo esc_html_x( 'Documentation', 'short for documents', 'woocommerce-subscriptions' ); ?></a>
 		<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://docs.woocommerce.com/document/subscriptions/version-2-1/" data-text="I just updated to WooCommerce Subscriptions v2.1, woot!" data-via="WooCommerce" data-size="large" data-hashtags="WooCommerce">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 	</p>
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<p><?php esc_html_e( 'Prior to Subscriptions 2.1, they were not easy to answer. Subscriptions 2.1 introduces new reports to answer these questions, and many more.', 'woocommerce-subscriptions' ); ?></p>
 				<p class="woocommerce-actions">
 					<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=subscriptions' ) ); ?>" ><?php esc_html_e( 'View Reports', 'woocommerce-subscriptions' ); ?></a>
-					<a class="button" href="http://docs.woocommerce.com/document/subscriptions/reports/"><?php echo esc_html_x( 'Learn More', 'learn more link to subscription reports documentation', 'woocommerce-subscriptions' ); ?></a>
+					<a class="button" href="https://woocommerce.com/document/subscriptions/store-manager-guide/reports/"><?php echo esc_html_x( 'Learn More', 'learn more link to subscription reports documentation', 'woocommerce-subscriptions' ); ?></a>
 				</p>
 			</div>
 		</div>
@@ -76,7 +76,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<p><?php esc_html_e( 'The retry system is disabled by default. To enable it, visit the Subscriptions settings administration screen.', 'woocommerce-subscriptions' ); ?></p>
 				<p class="woocommerce-actions">
 					<a class="button button-primary" href="<?php echo esc_url( $settings_page ); ?>" ><?php esc_html_e( 'Enable Automatic Retry', 'woocommerce-subscriptions' ); ?></a>
-					<a class="button" href="http://docs.woocommerce.com/document/subscriptions/failed-payment-retry/"><?php echo esc_html_x( 'Learn More', 'learn more link to failed payment retry documentation', 'woocommerce-subscriptions' ); ?></a>
+					<a class="button" href="https://woocommerce.com/document/subscriptions/failed-payment-retry/"><?php echo esc_html_x( 'Learn More', 'learn more link to failed payment retry documentation', 'woocommerce-subscriptions' ); ?></a>
 				</p>
 			</div>
 		</div>
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<p><?php printf( esc_html__( 'These emails can be enabled, disabled and customised under the %sWooCommerce > Settings > Emails%s administration screen.', 'woocommerce-subscriptions' ), '<strong>', '</strong>' ); ?></p>
 				<p class="woocommerce-actions">
 					<a class="button button-primary" href="<?php echo esc_url( $settings_page ); ?>" ><?php esc_html_e( 'View Email Settings', 'woocommerce-subscriptions' ); ?></a>
-					<a class="button" href="https://docs.woocommerce.com/document/subscriptions/store-manager-guide/#section-8"><?php echo esc_html_x( 'Learn More', 'learn more link to subscription emails documentation', 'woocommerce-subscriptions' ); ?></a>
+					<a class="button" href="https://woocommerce.com/document/subscriptions/subscription-emails/"><?php echo esc_html_x( 'Learn More', 'learn more link to subscription emails documentation', 'woocommerce-subscriptions' ); ?></a>
 				</p>
 			</div>
 		</div>
@@ -167,7 +167,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</p>
 				<p><?php
 					// translators: placeholders are opening and closing anchor tags linking to documentation
-					printf( esc_html__( '%sLearn more &raquo;%s', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/develop/failed-payment-retry/">', '</a>' ); ?>
+					printf( esc_html__( '%sLearn more &raquo;%s', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/subscriptions/develop/failed-payment-retry/">', '</a>' ); ?>
 				</p>
 			</div>
 			<div class="col">
@@ -203,7 +203,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</p>
 				<p><?php
 					// translators: placeholders are opening and closing <a> tags
-					printf( esc_html__( 'Subscriptions also now uses the renewal order to setup the cart for %smanual renewals%s, making it easier to add products or discounts to a single renewal paid manually.', 'woocommerce-subscriptions' ), '<a href="https://docs.woocommerce.com/document/subscriptions/renewal-process/">', '</a>' ); ?>
+					printf( esc_html__( 'Subscriptions also now uses the renewal order to setup the cart for %smanual renewals%s, making it easier to add products or discounts to a single renewal paid manually.', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/subscriptions/renewal-process/">', '</a>' ); ?>
 				</p>
 			</div>
 	</div>

--- a/templates/admin/html-failed-scheduled-action-notice.php
+++ b/templates/admin/html-failed-scheduled-action-notice.php
@@ -29,7 +29,7 @@ if ( defined( 'WC_LOG_HANDLER' ) && 'WC_Log_Handler_DB' === WC_LOG_HANDLER ) {
 			count( $failed_scheduled_actions ),
 			'woocommerce-subscriptions'
 		) ),
-		'<a href="https://docs.woocommerce.com/document/subscriptions/scheduled-action-errors/" target="_blank">',
+		'<a href="https://woocommerce.com/document/subscriptions/scheduled-action-errors/" target="_blank">',
 		'</a>'
 	)?>
 </p>


### PR DESCRIPTION
In the product data area there is a "Learn More" link to the docs. After some recent work in the documentation, this link was no longer resolving. This PR updates the old link from 
- http://docs.woocommerce.com/document/subscriptions/store-manager-guide/#limit-subscription 
to 
- https://woocommerce.com/document/subscriptions/creating-subscription-products/#limit-subscriptions

![CleanShot 2024-08-08 at 09 50 17@2x](https://github.com/user-attachments/assets/74fdc273-4389-4dd3-b916-2400f0be501f)

After some discussion with @james-allan I went ahead and updated all old references to docs.woocommerce.com that were redirecting (most still to the correct documentation) so they point to the correct places now.

Fixes #

## Description

This PR mostly just changes in-product doc link references. I also removed a message asking users to submit login credentials for their site when opening tickets about PayPal Payments IPN errors ([commit])(https://github.com/Automattic/woocommerce-subscriptions-core/pull/650/commits/128fea5c3bc5aa392b1967f06d99911455eb598b))

In some cases PHPCS was failing after making changes to only the urls, in these cases I resolved errors with my best effort, including breaking arguments from multi-line function calls on to their own lines, and adding an escape HTML function in [this commit](https://github.com/Automattic/woocommerce-subscriptions-core/pull/650/commits/caf79beb0d77064e712874e898820734320cb3be) which should be reviewed for correctness.

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new subscription product
2. Go to the "Advanced" tab of the product data area
3. Hover over the "Learn More" link to check it points to https://woocommerce.com/document/subscriptions/creating-subscription-products/#limit-subscriptions
4. Click the "Learn More" link and confirm it resolves to https://woocommerce.com/document/subscriptions/creating-subscription-products/#limit-subscriptions


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply) No Changelog entry needed
- [x] NO -  Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] NO - Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [x] None <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
