### PR TITLE
Move to next year when 12 months are added to first payment date

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.4.0 - 2024-xx-xx =
 * Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
 * Fix - Ensure admin notices are displayed after performing bulk actions on subscriptions when HPOS is enabled.
+* Fix - Add a year to the next renewal date billing interval is 12 months or more for a synced subscription.
 
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,12 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.4.1 - 2024-xx-xx =
+* Fix - Add a year to the next renewal date billing interval is 12 months or more for a synced subscription.
+
 = 7.4.0 - 2024-08-16 =
 * Dev - Introduce new parameter to WC_Subscription::get_last_order() to enable filtering out orders with specific statuses.
 * Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
 * Fix - Ensure admin notices are displayed after performing bulk actions on subscriptions when HPOS is enabled.
-* Fix - Add a year to the next renewal date billing interval is 12 months or more for a synced subscription.
 
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -686,10 +686,9 @@ class WC_Subscriptions_Synchroniser {
 					$month_number = gmdate( 'm', wcs_add_months( $from_timestamp, $interval ) );
 				}
 			}
-			$number_of_months = WC_Subscriptions_Product::get_interval( $product );
 
 			// when a certain number of months are added and the first payment date moves to next year
-			if ( $month_number < gmdate( 'm', $from_timestamp ) || $number_of_months >= 12 ) {
+			if ( $month_number < gmdate( 'm', $from_timestamp ) || $interval >= 12 ) {
 				$year       = gmdate( 'Y', $from_timestamp );
 				$year++;
 				$first_payment_timestamp = wcs_strtotime_dark_knight( "{$payment_day} {$month} {$year}", $from_timestamp );

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -686,8 +686,10 @@ class WC_Subscriptions_Synchroniser {
 					$month_number = gmdate( 'm', wcs_add_months( $from_timestamp, $interval ) );
 				}
 			}
+			$number_of_months = WC_Subscriptions_Product::get_interval( $product );
+
 			// when a certain number of months are added and the first payment date moves to next year
-			if ( $month_number <= gmdate( 'm', $from_timestamp ) ) {
+			if ( $month_number < gmdate( 'm', $from_timestamp ) || $number_of_months >= 12 ) {
 				$year       = gmdate( 'Y', $from_timestamp );
 				$year++;
 				$first_payment_timestamp = wcs_strtotime_dark_knight( "{$payment_day} {$month} {$year}", $from_timestamp );

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -687,7 +687,7 @@ class WC_Subscriptions_Synchroniser {
 				}
 			}
 			// when a certain number of months are added and the first payment date moves to next year
-			if ( $month_number < gmdate( 'm', $from_timestamp ) ) {
+			if ( $month_number <= gmdate( 'm', $from_timestamp ) ) {
 				$year       = gmdate( 'Y', $from_timestamp );
 				$year++;
 				$first_payment_timestamp = wcs_strtotime_dark_knight( "{$payment_day} {$month} {$year}", $from_timestamp );


### PR DESCRIPTION
Fixes #652 

## Description
When calculating the first renewal date for a synced subscription, we added a year for months less than the current month.
✅ If the current month is August and the month for the first renewal date is in September to December, we do not add a year.
✅ If the current month is August and the month for the first renewal date is in January to July, we add a year.
🔴 If the current month is August and the month for the first renewal date is also in August, we do not add a year. This is the cause of the issue. 

The changes made in this PR will now add a year when the first renewal date is in January to August for the above example. 

## How to test this PR
- Detailed reproduction steps are shared in the issue description https://github.com/Automattic/woocommerce-subscriptions-core/issues/652.
- Confirm that the issue is not reproducible in this branch.
- Confirm that these changes caused no regression with the sync feature. Test this with and without [Prepaid for WooCommerce Subscriptions](https://woocommerce.com/products/prepaid-for-woocommerce-subscriptions/) plugin. [⚠️  IMPORTANT]