### PR TITLE
Update limit subscriptions docs link

### DIFF
--- a/includes/class-wcs-limiter.php
+++ b/includes/class-wcs-limiter.php
@@ -46,7 +46,7 @@ class WCS_Limiter {
 				'class'       => 'wc-enhanced-select',
 				'label'       => __( 'Limit subscription', 'woocommerce-subscriptions' ),
 				// translators: placeholders are opening and closing link tags
-				'description' => sprintf( __( 'Only allow a customer to have one subscription to this product. %1$sLearn more%2$s.', 'woocommerce-subscriptions' ), '<a href="http://docs.woocommerce.com/document/subscriptions/store-manager-guide/#limit-subscription">', '</a>' ),
+				'description' => sprintf( __( 'Only allow a customer to have one subscription to this product. %1$sLearn more%2$s.', 'woocommerce-subscriptions' ), '<a href="https://woocommerce.com/document/subscriptions/creating-subscription-products/#limit-subscriptions">', '</a>' ),
 				'options'     => array(
 					'no'     => __( 'Do not limit', 'woocommerce-subscriptions' ),
 					'active' => __( 'Limit to one active subscription', 'woocommerce-subscriptions' ),


### PR DESCRIPTION
This PR updates a wrong link in the Limit Subscriptions to links to outdated docs page.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
