### PR TITLE
[WC 9.2] Fix $0 simple product order totals when purchasing subscriptions and simple products with a coupon 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.4.2 - xxxx-xx-xx =
+* Fix - Resolved an issue where simple product prices were incorrectly set to $0 when purchasing subscriptions and simple products with a coupon in WC 9.2.
+
 = 7.4.1 - 2024-08-21 =
 * Fix - Add a year to the next renewal date billing interval is 12 months or more for a synced subscription.
 

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -63,7 +63,6 @@ class WC_Subscriptions_Cart {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v1.0
 	 */
 	public static function init() {
-
 		// Make sure WC calculates total on sign up fee + price per period, and keep a record of the price per period
 		add_action( 'woocommerce_before_calculate_totals', __CLASS__ . '::add_calculation_price_filter', 10 );
 		add_action( 'woocommerce_calculate_totals', __CLASS__ . '::remove_calculation_price_filter', 10 );

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -293,9 +293,14 @@ class WC_Subscriptions_Cart {
 			return $total;
 		}
 
+		// We're in the middle of a recalculation, let it run.
+		if ( 'none' !== self::$calculation_type ) {
+			return $total;
+		}
+
 		/**
-		 * If we're already calculating recurring totals, skip this calculation to avoid infinite loops.
-		 * We use whether there's a recurring cart key in the calculation stack to determine if we're in the middle calculating recurring totals.
+		 * If we're in the middle of calculating recurring totals, skip this calculation to avoid infinite loops.
+		 * We use whether there's a recurring cart key in the calculation stack (ie has started but hasn't finished) to determine if we're in the middle calculating recurring totals.
 		 */
 		if ( ! empty( array_diff( self::$recurring_totals_calculation_stack, [ 'none' ] ) ) ) {
 			return $total;

--- a/tests/unit/test-class-wc-subscriptions-cart.php
+++ b/tests/unit/test-class-wc-subscriptions-cart.php
@@ -19,15 +19,24 @@ class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down the test class.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->cart->empty_cart();
+	}
+
+	/**
 	 * Test that recurring carts are created when calculating totals.
 	 */
 	public function test_calculate_subscription_totals() {
 		$product = WCS_Helper_Product::create_simple_subscription_product( array( 'price' => 10 ) );
 
-		$this->cart->add_to_cart( $product->get_id() );
-
 		// First, check that there are no recurring carts.
 		$this->assertEmpty( $this->cart->recurring_carts );
+
+		$this->cart->add_to_cart( $product->get_id() );
 
 		// Calculate the totals. This should create a recurring cart.
 		$this->cart->calculate_totals();

--- a/tests/unit/test-class-wc-subscriptions-cart.php
+++ b/tests/unit/test-class-wc-subscriptions-cart.php
@@ -10,12 +10,28 @@ class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
 	private $cart;
 
 	/**
+	 * The number of times woocommerce_subscriptions_calculated_total was triggered.
+	 *
+	 * @var int
+	 */
+	private $calculated_subscription_totals_count = 0;
+
+	/**
 	 * Set up the test class.
 	 */
 	public function set_up() {
 		parent::set_up();
 
 		$this->cart = WC()->cart;
+
+		// Count the number of times woocommerce_subscriptions_calculated_total is triggered.
+		add_action(
+			'woocommerce_subscriptions_calculated_total',
+			function( $subscription_total ) {
+				$this->calculated_subscription_totals_count++;
+				return $subscription_total;
+			}
+		);
 	}
 
 	/**
@@ -26,6 +42,8 @@ class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
 
 		$this->cart->empty_cart();
 		$this->cart->recurring_carts = [];
+
+		$this->calculated_subscription_totals_count = 0;
 	}
 
 	/**
@@ -103,5 +121,68 @@ class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $this->cart->recurring_carts );
 		$this->assertCount( 1, $this->cart->recurring_carts ); // Only one recurring cart should be created for both items.
 		$this->assertCount( 2, reset( $this->cart->recurring_carts )->get_cart() );
+	}
+
+	/**
+	 * Test that recurring carts are created when calculating totals with a mixed cart.
+	 */
+	public function test_calculate_subscription_totals_with_mixed_cart() {
+		$subscription = WCS_Helper_Product::create_simple_subscription_product( [ 'price' => 10 ] );
+		$simple       = WC_Helper_Product::create_simple_product();
+
+		// First, check that there are no recurring carts.
+		$this->assertEmpty( $this->cart->recurring_carts );
+
+		$this->cart->add_to_cart( $subscription->get_id() );
+		$this->cart->add_to_cart( $simple->get_id() );
+
+		// Calculate the totals. This should create a recurring cart.
+		$this->cart->calculate_totals();
+
+		// Check that the recurring cart was created.
+		$this->assertNotEmpty( $this->cart->recurring_carts );
+		$this->assertCount( 1, $this->cart->recurring_carts );
+		$this->assertCount( 1, reset( $this->cart->recurring_carts )->get_cart() );
+	}
+
+	/**
+	 * Test that recurring carts are created only once when calculating totals with nested calls.
+	 */
+	public function test_calculate_subscription_totals_with_nested_calls() {
+		$subscription = WCS_Helper_Product::create_simple_subscription_product( [ 'price' => 10 ] );
+		$simple       = WC_Helper_Product::create_simple_product();
+
+		// First, check that there are no recurring carts.
+		$this->assertEmpty( $this->cart->recurring_carts );
+
+		$this->cart->add_to_cart( $subscription->get_id() );
+		$this->cart->add_to_cart( $simple->get_id() );
+
+		add_action( 'woocommerce_calculate_totals', [ $this, 'mock_nested_callback' ] );
+
+		$this->calculated_subscription_totals_count = 0;
+
+		// Calculate the totals. This should create a recurring cart.
+		$this->cart->calculate_totals();
+
+		// Check that the recurring cart was created.
+		$this->assertNotEmpty( $this->cart->recurring_carts );
+		$this->assertCount( 1, $this->cart->recurring_carts );
+		$this->assertCount( 1, reset( $this->cart->recurring_carts )->get_cart() );
+		$this->assertEquals( 1, $this->calculated_subscription_totals_count );
+	}
+
+	/**
+	 * A function to mock calling WC()->cart->calculate_totals() from within the calculate_totals action.
+	 *
+	 * @param WC_Cart $cart
+	 */
+	public function mock_nested_callback( $cart ) {
+		if ( ! isset( $cart->recurring_cart_key ) ) {
+			return;
+		}
+
+		// Nest the calculate_totals call by calling it again.
+		WC()->cart->calculate_totals();
 	}
 }

--- a/tests/unit/test-class-wc-subscriptions-cart.php
+++ b/tests/unit/test-class-wc-subscriptions-cart.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Tests for the WC_Subscriptions_Cart class.
+ */
+class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var WC_Cart
+	 */
+	private $cart;
+
+	/**
+	 * Set up the test class.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->cart = WC()->cart;
+	}
+
+	/**
+	 * Test that recurring carts are created when calculating totals.
+	 */
+	public function test_calculate_subscription_totals() {
+		$product = WCS_Helper_Product::create_simple_subscription_product( array( 'price' => 10 ) );
+
+		$this->cart->add_to_cart( $product->get_id() );
+
+		// First, check that there are no recurring carts.
+		$this->assertEmpty( $this->cart->recurring_carts );
+
+		// Calculate the totals. This should create a recurring cart.
+		$this->cart->calculate_totals();
+
+		// Check that the recurring cart was created.
+		$this->assertNotEmpty( $this->cart->recurring_carts );
+	}
+}

--- a/tests/unit/test-class-wc-subscriptions-cart.php
+++ b/tests/unit/test-class-wc-subscriptions-cart.php
@@ -25,13 +25,14 @@ class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
 		parent::tear_down();
 
 		$this->cart->empty_cart();
+		$this->cart->recurring_carts = [];
 	}
 
 	/**
 	 * Test that recurring carts are created when calculating totals.
 	 */
 	public function test_calculate_subscription_totals() {
-		$product = WCS_Helper_Product::create_simple_subscription_product( array( 'price' => 10 ) );
+		$product = WCS_Helper_Product::create_simple_subscription_product( [ 'price' => 10 ] );
 
 		// First, check that there are no recurring carts.
 		$this->assertEmpty( $this->cart->recurring_carts );
@@ -43,5 +44,64 @@ class WC_Subscriptions_Cart_Test extends WP_UnitTestCase {
 
 		// Check that the recurring cart was created.
 		$this->assertNotEmpty( $this->cart->recurring_carts );
+		$this->assertCount( 1, $this->cart->recurring_carts );
+	}
+
+	/**
+	 * Test that recurring carts are created when calculating totals.
+	 */
+	public function test_calculate_subscription_totals_multiple_recurring_carts() {
+		$product_1 = WCS_Helper_Product::create_simple_subscription_product( [ 'price' => 10 ] );
+		$product_2 = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'               => 20,
+				'subscription_period' => 'year',
+			]
+		);
+
+		// First, check that there are no recurring carts.
+		$this->assertEmpty( $this->cart->recurring_carts );
+
+		$this->cart->add_to_cart( $product_1->get_id() );
+		$this->cart->add_to_cart( $product_2->get_id() );
+
+		// Calculate the totals. This should create a recurring cart.
+		$this->cart->calculate_totals();
+
+		// Check that the recurring cart was created.
+		$this->assertNotEmpty( $this->cart->recurring_carts );
+		$this->assertCount( 2, $this->cart->recurring_carts );
+	}
+
+	/**
+	 * Test that recurring carts are created when calculating totals.
+	 */
+	public function test_calculate_subscription_totals_multiple_items_one_cart() {
+		$product_1 = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'               => 10,
+				'subscription_period' => 'year',
+			]
+		);
+		$product_2 = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'               => 20,
+				'subscription_period' => 'year',
+			]
+		);
+
+		// First, check that there are no recurring carts.
+		$this->assertEmpty( $this->cart->recurring_carts );
+
+		$this->cart->add_to_cart( $product_1->get_id() );
+		$this->cart->add_to_cart( $product_2->get_id() );
+
+		// Calculate the totals. This should create a recurring cart.
+		$this->cart->calculate_totals();
+
+		// Check that the recurring cart was created.
+		$this->assertNotEmpty( $this->cart->recurring_carts );
+		$this->assertCount( 1, $this->cart->recurring_carts ); // Only one recurring cart should be created for both items.
+		$this->assertCount( 2, reset( $this->cart->recurring_carts )->get_cart() );
 	}
 }

--- a/tests/unit/test-wcs-cart-functions.php
+++ b/tests/unit/test-wcs-cart-functions.php
@@ -9,7 +9,7 @@ class WCS_Cart_Functions_Test extends WP_UnitTestCase {
 	*/
 	public function provider_mock_cart() {
 		return array(
-			array( $this->getMockBuilder( 'WC_Cart' )->setMethods( array( 'get_cart', 'get_item_data' ) )->getMock() ),
+			array( $this->getMockBuilder( 'WC_Cart' )->setMethods( array( 'get_cart', 'get_item_data' ) )->disableOriginalConstructor()->getMock() ),
 		);
 	}
 
@@ -29,7 +29,7 @@ class WCS_Cart_Functions_Test extends WP_UnitTestCase {
 		$mock_subscription_product->expects( $this->any() )->method( 'is_type' )->will( $this->returnValueMap( $product_type_map ) );
 
 		return array(
-			array( $this->getMockBuilder( 'WC_Cart' )->getMock(), $mock_subscription_product ),
+			array( $this->getMockBuilder( 'WC_Cart' )->disableOriginalConstructor()->getMock(), $mock_subscription_product ),
 		);
 	}
 
@@ -82,7 +82,7 @@ class WCS_Cart_Functions_Test extends WP_UnitTestCase {
 	*/
 	public function provider_test_wcs_cart_price_string() {
 
-		$cart = $this->getMockBuilder( 'WC_Cart' )->setMethods( array( 'get_cart', 'get_item_data' ) )->getMock();
+		$cart = $this->getMockBuilder( 'WC_Cart' )->setMethods( array( 'get_cart', 'get_item_data' ) )->disableOriginalConstructor()->getMock();
 		return array(
 			array( $cart, 'month', 1, 11, 10, '10.00', '/ month for 11 months' ),
 			array( $cart, 'month', 1, 12, 10, '10.00', '/ month for 12 months' ),


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4716

## Description

When subscription recurring totals are being calculated in `calculate_subscription_totals()` we set the `self::$calculation_type` to `'recurring_total'`.

While we calculate the recurring totals we loop over the recurring carts and calculate their totals. ie `$recurring_cart->calculate_totals()`.

Calculating the recurring cart's totals causes us to also calculate discounts that apply to those recurring carts. If the cart contains a coupon and it is a standard cart coupon, we remove it because it doesn't apply to the recurring carts.

With a change to WC core in 9.2 (https://github.com/woocommerce/woocommerce/commit/d18a7225018d90b5f1ab06ff0a7bca6d0b969f0b), removing the coupon now triggers WC core to calculate cart totals again.

However, this time when the initial payment cart's totals are being calculated the `self::$calculation_type` is still set to `'recurring_total'` (because we were in the middle of calculating totals) and so the non-subscription product's price is being set to $0 [here](https://github.com/Automattic/woocommerce-subscriptions-core/blob/6.5.0/includes/class-wc-subscriptions-cart.php#L222). Setting the prices to $0 while calculating the initial payment cart but thinking we were calculating recurring totals resulted in the item's price being setting $0 on the order. 

This PR fixes that. 

When WC calculates a carts total, we now hook into the `before` and `after` hooks and make sure our `self::$calculation_type` and `self::$recurring_cart_key` are set appropriately to the cart type. This means we won't set a $0 amount when calculating an initial carts total, even if the calls are nested.

How this works.

**BEFORE**

- `WC()->cart->calculate_totals()`
   - Calls `calculate_subscription_totals()`
     - `self::$calculation_type` is set to `recurring_total`
       - Calls `$recurring_cart->calculate_totals()`
         - _Remove non-applicable coupons_
           - WC Calls `WC()->cart->calculate_totals()`
             - **Everything that runs here thinks we're still in `recurring_total` calculation type** ❌ 

**AFTER**

- `WC()->cart->calculate_totals()`
   - Calls `calculate_subscription_totals()`
     - `self::$calculation_type` is set to `recurring_total`
       - Calls `$recurring_cart->calculate_totals()` *
         - _Remove non-applicable coupons_
           - WC calls `WC()->cart->calculate_totals()`
             - We hook into the `before` hook and set the calculation type to `none` because we're calculating a initial cart total now.
             - When we finish calculating the initial cart total we hook on to the `after` hook and restore the previous recurring cart key and calculation type from * (above)

## How to test this PR

1. Make sure you have WC 9.2.0+ installed.
1. Add a simple product to the cart
2. Add a subscription product to the cart
3. Add a 10% discount coupon to the cart
4. The pricing will display as expected
5. Checkout
   - On `trunk` the simple product's Subtotal is incorrect ($0).

On this branch the line item total shouldn't be $0.

| `trunk` | This branch |
|--------|--------|
| <img width="732" alt="Screenshot 2024-08-26 at 5 30 27 PM" src="https://github.com/user-attachments/assets/a41156ef-0503-49ac-ac1b-68e67f599220"> | <img width="788" alt="Screenshot 2024-08-26 at 5 29 31 PM" src="https://github.com/user-attachments/assets/03d4d1ea-716c-4907-b60f-63866716e076"> |




## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
