### PR TITLE
Blocking subscription reactivation when end date is in the past

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.5.0 - 2024-xx-xx =
+* Fix - Blocks the reactivation of a subscription when the end date is in the past.
 * Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
 
 = 7.4.2 - 2024-08-27 =

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -340,7 +340,11 @@ class WC_Subscription extends WC_Order {
 			case 'completed': // core WC order status mapped internally to avoid exceptions
 			case 'active':
 				if ( $this->payment_method_supports( 'subscription_reactivation' ) && $this->has_status( 'on-hold' ) ) {
-					$can_be_updated = true;
+					if ( $this->get_time( 'end' ) > gmdate( 'U' ) ) {
+						$can_be_updated = true;
+					} else {
+						$can_be_updated = false;
+					}
 				} elseif ( $this->has_status( 'pending' ) ) {
 					$can_be_updated = true;
 				} elseif ( $this->has_status( 'pending-cancel' ) && $this->get_time( 'end' ) > gmdate( 'U' ) && ( $this->is_manual() || ( false === $this->payment_method_supports( 'gateway_scheduled_payments' ) && $this->payment_method_supports( 'subscription_date_changes' ) && $this->payment_method_supports( 'subscription_reactivation' ) ) ) ) {
@@ -364,7 +368,7 @@ class WC_Subscription extends WC_Order {
 					$can_be_updated = false;
 				}
 				break;
-			case 'pending-cancel' :
+			case 'pending-cancel':
 				// Only active subscriptions can be given the "pending cancellation" status, because it is used to account for a prepaid term
 				if ( $this->payment_method_supports( 'subscription_cancellation' ) ) {
 					if ( $this->has_status( 'active' ) ) {

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -143,10 +143,10 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function provide_test_can_be_updated_to_active_with_different_end_dates() {
-		return array(
-			'pending-cancel',
-			'on-hold',
-		);
+		return [
+			[ 'pending-cancel' ],
+			[ 'on-hold' ],
+		];
 	}
 
 	/**

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -1186,7 +1186,7 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 
 			if ( in_array( $status, $expected_to_pass, true ) ) {
 
-				if ( 'pending-cancel' === $status ) {
+				if ( 'pending-cancel' === $status || 'on-hold' === $status ) {
 					$subscription->update_dates( [ 'end' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ) ] );
 				}
 

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -89,6 +89,8 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 				continue;
 			}
 
+			$subscription->update_dates( [ 'end' => gmdate( 'Y-m-d H:i:s', wcs_add_months( time(), 1 ) ) ] );
+
 			$expected_result = $expected_results[ $status ];
 			$actual_result   = $subscription->can_be_updated_to( 'active' );
 


### PR DESCRIPTION
Fixes: 4236-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

This PR blocks a subscription with the on-hold status from being activated when the end date is in the past, ensuring that expired subscriptions are not mistakenly set as active. This update aligns the subscription behavior with expected standards, preventing potential issues with invalid activations.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As a merchant, create any subscription product
- As a customer, purchase the subscription
- On wp-admin, update the new subscription status manually to `on-hold`
- Set the end date to any date (just to create the meta)
- Update the meta with a date in the past (`_schedule_end`) directly accessing your database (i.e. using PHPMyAdmin)
- Try to set the status to `active` again
- Confirm you receive an error like:
![Screenshot 2024-08-27 at 13 57 38](https://github.com/user-attachments/assets/0339881e-415a-468b-b4da-72521f94db51)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes
- [x] Will this PR affect WooCommerce Payments? yes
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
