### PR TITLE
Adding new period helper functions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.5.0 - 2024-xx-xx =
+* Add - Add two new period helper functions: wcs_get_valid_periods and wcs_is_valid_period.
 * Fix - Blocks the reactivation of a subscription when the end date is in the past.
 * Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
 

--- a/includes/wcs-time-functions.php
+++ b/includes/wcs-time-functions.php
@@ -70,6 +70,29 @@ function wcs_get_subscription_trial_period_strings( $number = 1, $period = '' ) 
 }
 
 /**
+ * Returns an array of valid subscription periods.
+ *
+ * @return string[] An array of valid subscription periods.
+ *
+ * @since 7.5.0
+ */
+function wcs_get_valid_periods() {
+	return array( 'day', 'week', 'month', 'year' );
+}
+
+/**
+ * Checks if a period is valid.
+ *
+ * @param $period string The period to check.
+ * @return bool True if the period is valid, false otherwise.
+ *
+ * @since 7.5.0
+ */
+function wcs_is_valid_period( $period ) {
+	return in_array( $period, wcs_get_valid_periods(), true );
+}
+
+/**
  * Returns an array of subscription lengths.
  *
  * PayPal Standard Allowable Ranges
@@ -82,7 +105,7 @@ function wcs_get_subscription_trial_period_strings( $number = 1, $period = '' ) 
  */
 function wcs_get_non_cached_subscription_ranges() {
 
-	foreach ( array( 'day', 'week', 'month', 'year' ) as $period ) {
+	foreach ( wcs_get_valid_periods() as $period ) {
 
 		$subscription_lengths = array(
 			_x( 'Do not stop until cancelled', 'Subscription length', 'woocommerce-subscriptions' ),

--- a/tests/unit/test-wcs-time-functions.php
+++ b/tests/unit/test-wcs-time-functions.php
@@ -826,6 +826,31 @@ class WCS_Time_Functions_Tests extends WP_UnitTestCase {
 		date_default_timezone_set( 'UTC' );
 	}
 
+	/**
+	 * Test for `wcs_get_valid_periods` function.
+	 *
+	 * @return void
+	 */
+	public function test_wcs_get_valid_periods() {
+		$this->assertEquals( array( 'day', 'week', 'month', 'year' ), wcs_get_valid_periods() );
+	}
+
+	/**
+	 * Test for `wcs_is_valid_period` function.
+	 *
+	 * @return void
+	 */
+	public function test_wcs_is_valid_period() {
+		// Valid periods.
+		$this->assertTrue( wcs_is_valid_period( 'day' ) );
+		$this->assertTrue( wcs_is_valid_period( 'week' ) );
+		$this->assertTrue( wcs_is_valid_period( 'month' ) );
+		$this->assertTrue( wcs_is_valid_period( 'year' ) );
+
+		// Invalid periods.
+		$this->assertFalse( wcs_is_valid_period( 'foo' ) );
+	}
+
 	public function wcs_number_of_leap_days_error_provider() {
 		return array(
 			array( '', '' ),


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

This PR introduces 2 new helper functions when dealing with periods:
- `wcs_get_valid_periods`: Returns a list of valid periods
- `wcs_is_valid_period`: Checks if the provided period is valid

This will be useful when validating period parameters on other functions, such as the one mentioned on [this issue](https://github.com/woocommerce/woocommerce-subscriptions/issues/4501).

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

Code review should be enough since these functions are new and still unused. Check if the new tests are valid and passes.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
