### PR TITLE
Exclude switch orders from order needs payment checks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,12 +10,12 @@
 * Dev - Introduce new parameter to WC_Subscription::get_last_order() to enable filtering out orders with specific statuses.
 * Update - Schedule subscription-related events with a priority of 1 to allow for earlier execution within the Action Scheduler.
 * Fix - Ensure admin notices are displayed after performing bulk actions on subscriptions when HPOS is enabled.
+* Fix - Resolved an error when purchasing subscription products on the block checkout with a limited recurring coupon.
 
 = 7.3.0 - 2024-07-16 =
 * Fix - Label improvements on subscription and order page templates.
 * Fix - Fixed an issue with subscriptions containing multiple renewal orders to mark a random item as processing, instead of the last order.
 * Fix - Prevent errors from invalid subscription objects during customer payment method updates.
-* Fix - Resolved an error when purchasing subscription products on the block checkout with a limited recurring coupon.
 
 = 7.2.0 - 2024-06-13 =
 * Fix - label improvement on my subscription page template.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.4.3 - 2024-xx-xx =
+Fix - Exclude switch orders from the order_needs_payment logic to prevent errors during customer switch requests that result in $0 checkout scenarios.
+
 = 7.4.2 - 2024-08-27 =
 * Fix - Resolved an issue where simple product prices were incorrectly set to $0 when purchasing subscriptions and simple products with a coupon in WC 9.2.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.4.3 - 2024-xx-xx =
-Fix - Exclude switch orders from the order_needs_payment logic to prevent errors during customer switch requests that result in $0 checkout scenarios.
+Fix - Prevent errors during checkout when a customer is switching their subscription product and does not require payment.
 
 = 7.4.2 - 2024-08-27 =
 * Fix - Resolved an issue where simple product prices were incorrectly set to $0 when purchasing subscriptions and simple products with a coupon in WC 9.2.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -694,7 +694,7 @@ class WC_Subscriptions_Order {
 		}
 
 		// Check if there's a subscription attached to this order that will require a payment method.
-		foreach ( wcs_get_subscriptions_for_order( $order ) as $subscription ) {
+		foreach ( wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'parent' ] ) as $subscription ) {
 			$has_next_payment                 = false;
 			$contains_expiring_limited_coupon = false;
 			$contains_free_trial              = false;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4722

## Description

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/642 I attempted to fix an issue where customers reduce the upfront cost of their subscription to $0 when using a limited use coupon where their upfront cost might be $0, but their subscription will eventually need a payment method. In that scenario, if the customer used the block checkout they would get an error because payment methods would have been displayed to the customer, but WC's block integration didn't expect payment method information because they use `$order->needs_payment()` in the Store API to determine if payment is needed, not `cart_needs_payment()`. _See that PR for more details._ 

In that PR I updated our `order_needs_payment` function to be more inline with the `cart_needs_payment` logic because with the block checkout, those two things are more or less treated the same. 

However a small detail I missed was this logic in the `cart_needs_payment()` function. 

https://github.com/Automattic/woocommerce-subscriptions-core/blob/3a60f0e24f2ea2cb92484bb932497ca7ef880dd3/includes/class-wc-subscriptions-cart.php#L925-L928
<p align="center">
<sup>Switch carts are excluded from the <code>cart_needs_payment()</code> logic.</sup>
</p> 

This PR updates our `order_needs_payment()` function to also exclude switch orders from the logic. 

## How to test this PR

1. Create a variable subscription product with at least 2 variations.
   - both variations should be the same price and same period eg $10/month
2. Purchase 1 of the variation.
3. On the My Account > Subscription page click the Switch button.
4. Select the other variation.
5. On checkout you should notice the $0 upgrade cost.
6. Attempt to complete the checkout.
   - On `trunk` you should receive the following error message.
   - On this branch there should be no errors. 

<p align="center">
<img width="600" alt="364580094-5689ad59-5064-4a1a-a322-84a8cea1fe7f" src="https://github.com/user-attachments/assets/3d062d11-c633-4a08-baf2-2629e4e961af">
</br>
</p>

> [!important]
> More investigation will need to be taken into whether this change has wider ramifications. 
> - ~~Prior to my changes in https://github.com/Automattic/woocommerce-subscriptions-core/pull/642/, it included switch orders in it's `wcs_get_subscriptions_for_order( $order )` so switch orders have always been considered by this function.~~ see https://github.com/Automattic/woocommerce-subscriptions-core/pull/669#issuecomment-2330404304
> - ~~There is also logic in the switch class for checking if carts which contain switches need payment (see [`WC_Subscriptions_Switcher::cart_needs_payment()`](https://github.com/woocommerce/woocommerce-subscriptions/blob/6.6.1/includes/switching/class-wc-subscriptions-switcher.php#L2167-L2189) ), I'll need to double check if we need to include that logic too~~. see https://github.com/Automattic/woocommerce-subscriptions-core/pull/669#issuecomment-2330434056 and https://github.com/woocommerce/woocommerce-subscriptions/issues/4723

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
