### PR TITLE
Version 7.4.3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 7.4.3 - 2024-xx-xx =
+= 7.4.3 - 2024-09-05 =
 Fix - Prevent errors during checkout when a customer is switching their subscription product and does not require payment.
 
 = 7.4.2 - 2024-08-27 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.4.3 - 2024-09-05 =
-Fix - Prevent errors during checkout when a customer is switching their subscription product and does not require payment.
+* Fix - Prevent errors during checkout when a customer is switching their subscription product and does not require payment.
 
 = 7.4.2 - 2024-08-27 =
 * Fix - Resolved an issue where simple product prices were incorrectly set to $0 when purchasing subscriptions and simple products with a coupon in WC 9.2.

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -16,7 +16,7 @@ class WC_Subscriptions_Core_Plugin {
 	 * The version of subscriptions-core library.
 	 * @var string
 	 */
-	protected $library_version = '7.4.2'; // WRCS: DEFINED_VERSION.
+	protected $library_version = '7.4.3'; // WRCS: DEFINED_VERSION.
 
 	/**
 	 * The subscription scheduler instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-subscriptions-core",
-	"version": "7.4.2",
+	"version": "7.4.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-subscriptions-core",
-			"version": "7.4.2",
+			"version": "7.4.3",
 			"hasInstallScript": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"title": "WooCommerce Subscriptions Core",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
-	"version": "7.4.2",
+	"version": "7.4.3",
 	"description": "",
 	"homepage": "https://github.com/Automattic/woocommerce-subscriptions-core",
 	"main": "Gruntfile.js",

--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -6,5 +6,5 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Requires WP: 5.6
- * Version: 7.4.2
+ * Version: 7.4.3
  */


### PR DESCRIPTION
This is a manual tagging of 7.4.3 due to it being a patch release. It should reflect similar changes to the automated ones like https://github.com/Automattic/woocommerce-subscriptions-core/pull/661

```
* Fix - Prevent errors during checkout when a customer is switching their subscription product and does not require payment.
```