### PR TITLE
Introduce the Notifications Scheduler Debug Tool

### DIFF
--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -1,0 +1,311 @@
+<?php
+
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
+
+class WCS_Notifications_Debug_Tool_Processor implements BatchProcessorInterface {
+
+	/**
+	 * Option name for the tool state.
+	 * This is used to pass the state of the tool between requests.
+	 */
+	const TOOL_STATE_OPTION_NAME = 'wcs_notifications_debug_tool_state';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_debug_tools', array( $this, 'handle_woocommerce_debug_tools' ), 999, 1 );
+	}
+
+	/**
+	 * Get the state of the tool.
+	 *
+	 * @return array {
+	 *   @last_offset Last offset processed.
+	 * }
+	 */
+	private function get_tool_state(): array {
+		return (array) get_option( self::TOOL_STATE_OPTION_NAME, array() );
+	}
+
+	/**
+	 * Update the state of the tool.
+	 *
+	 * @param array $state New state of the tool.
+	 */
+	private function update_tool_state( $state ) {
+		update_option( self::TOOL_STATE_OPTION_NAME, $state );
+	}
+
+	/**
+	 * Delete the state of the tool.
+	 */
+	private function delete_tool_state() {
+		delete_option( self::TOOL_STATE_OPTION_NAME );
+	}
+
+	/**
+	 * Get a user-friendly name for this processor.
+	 *
+	 * @return string Name of the processor.
+	 */
+	public function get_name(): string {
+		return 'wcs_notifications_debug_tool_processor';
+	}
+
+	/**
+	 * Get a user-friendly description for this processor.
+	 *
+	 * @return string Description of what this processor does.
+	 */
+	public function get_description(): string {
+		return 'WooCommerce Notifications Debug Tool Processor';
+	}
+
+	/**
+	 * Get the allowed subscription statuses to process.
+	 */
+	protected function get_subscription_statuses(): array {
+		$allowed_statuses = array(
+			'active',
+			'pending',
+			'on-hold',
+		);
+
+		return array_map( 'wcs_sanitize_subscription_status_key', $allowed_statuses );
+	}
+
+	public function get_total_pending_count(): int {
+		global $wpdb;
+
+		$allowed_statuses = $this->get_subscription_statuses();
+		$placeholders     = implode( ', ', array_fill( 0, count( $allowed_statuses ), '%s' ) );
+
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			$total_subscriptions = $wpdb->get_var(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				$wpdb->prepare(
+					"SELECT 
+								COUNT(id)
+							FROM {$wpdb->prefix}wc_orders 
+							WHERE type='shop_subscription'
+							AND status IN ($placeholders)
+							",
+					...$allowed_statuses
+				)
+			);
+		} else {
+			$total_subscriptions = $wpdb->get_var(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				$wpdb->prepare(
+					"SELECT 
+								COUNT(ID)
+							FROM {$wpdb->prefix}posts 
+							WHERE post_type='shop_subscription'
+							AND post_status IN ($placeholders)
+							",
+					...$allowed_statuses
+				)
+			);
+		}
+
+		$state = $this->get_tool_state();
+		if ( isset( $state['last_offset'] ) ) {
+			$total_subscriptions -= (int) $state['last_offset'];
+		}
+
+		return $total_subscriptions;
+	}
+
+	/**
+	 * Returns the next batch of items that need to be processed.
+	 *
+	 * A batch item can be anything needed to identify the actual processing to be done,
+	 * but whenever possible items should be numbers (e.g. database record ids)
+	 * or at least strings, to ease troubleshooting and logging in case of problems.
+	 *
+	 * The size of the batch returned can be less than $size if there aren't that
+	 * many items pending processing (and it can be zero if there isn't anything to process),
+	 * but the size should always be consistent with what 'get_total_pending_count' returns
+	 * (i.e. the size of the returned batch shouldn't be larger than the pending items count).
+	 *
+	 * @param int $size Maximum size of the batch to be returned.
+	 *
+	 * @return array Batch of items to process, containing $size or less items.
+	 */
+	public function get_next_batch_to_process( int $size ): array {
+		global $wpdb;
+
+		$allowed_statuses = $this->get_subscription_statuses();
+		$placeholders     = implode( ', ', array_fill( 0, count( $allowed_statuses ), '%s' ) );
+		$state            = $this->get_tool_state();
+		$offset           = isset( $state['last_offset'] ) ? (int) $state['last_offset'] : 0;
+
+		$args = array_merge(
+			$allowed_statuses,
+			array( $size ),
+			array( $offset ),
+		);
+
+		if ( wcs_is_custom_order_tables_usage_enabled() ) {
+			$subscriptions_to_process = $wpdb->get_col(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+				$wpdb->prepare(
+					"SELECT 
+								id
+							FROM {$wpdb->prefix}wc_orders 
+							WHERE type='shop_subscription'
+							AND status IN ($placeholders)
+							ORDER BY id ASC
+							LIMIT %d
+							OFFSET %d",
+					...$args
+				)
+			);
+		} else {
+			$subscriptions_to_process = $wpdb->get_col(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+				$wpdb->prepare(
+					"SELECT 
+								ID
+							FROM {$wpdb->prefix}posts 
+							WHERE post_type='shop_subscription'
+							AND post_status IN ($placeholders)
+							ORDER BY ID ASC
+							LIMIT %d
+							OFFSET %d",
+					...$args
+				)
+			);
+		}
+
+		// Reset the tool state if there are no more subscriptions to process.
+		if ( empty( $subscriptions_to_process ) ) {
+			$this->delete_tool_state();
+		}
+
+		return $subscriptions_to_process;
+	}
+
+	/**
+	 * Process data for the supplied batch.
+	 *
+	 * This method should be prepared to receive items that don't actually need processing
+	 * (because they have been processed before) and ignore them, but if at least
+	 * one of the batch items that actually need processing can't be processed, an exception should be thrown.
+	 *
+	 * Once an item has been processed it shouldn't be counted in 'get_total_pending_count'
+	 * nor included in 'get_next_batch_to_process' anymore (unless something happens that causes it
+	 * to actually require further processing).
+	 *
+	 * @throw \Exception Something went wrong while processing the batch.
+	 *
+	 * @param array $batch Batch to process, as returned by 'get_next_batch_to_process'.
+	 */
+	public function process_batch( array $batch ): void {
+		// This is a bit unnecessary. Perhaps convert `update_status` to static to avoid instantiating the class?
+		$subscriptions_notifications = new WCS_Action_Scheduler_Customer_Notifications();
+
+		foreach ( $batch as $subscription_id ) {
+			$subscription = wcs_get_subscription( $subscription_id );
+			$subscriptions_notifications->update_status( $subscription, $subscription->get_status(), null );
+
+			// Update the subscription's update time to mark it as updated.
+			$subscription->set_date_modified( time() );
+			$subscription->save();
+		}
+
+		// Update tool state.
+		$state                = $this->get_tool_state();
+		$state['last_offset'] = isset( $state['last_offset'] ) ? absint( $state['last_offset'] ) + count( $batch ) : count( $batch );
+		$this->update_tool_state( $state );
+	}
+
+	/**
+	 * Default (preferred) batch size to pass to 'get_next_batch_to_process'.
+	 * The controller will pass this size unless it's externally configured
+	 * to use a different size.
+	 *
+	 * @return int Default batch size.
+	 */
+	public function get_default_batch_size(): int {
+		return 20;
+	}
+
+	/**
+	 * Start the background process for coupon data conversion.
+	 *
+	 * @return string Informative string to show after the tool is triggered in UI.
+	 */
+	public function enqueue(): string {
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		if ( $batch_processor->is_enqueued( self::class ) ) {
+			return __( 'Background process for updating subscritpion notifications already started, nothing done.', 'woocommerce-subscriptions' );
+		}
+
+		$batch_processor->enqueue_processor( self::class );
+		return __( 'Background process for updating subscritpion notifications started', 'woocommerce-subscriptions' );
+	}
+
+	/**
+	 * Stop the background process for coupon data conversion.
+	 *
+	 * @return string Informative string to show after the tool is triggered in UI.
+	 */
+	public function dequeue(): string {
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		if ( ! $batch_processor->is_enqueued( self::class ) ) {
+			return __( 'Background process for updating subscritpion notifications not started, nothing done.', 'woocommerce-subscriptions' );
+		}
+
+		$batch_processor->remove_processor( self::class );
+		return __( 'Background process for updating subscritpion notifications stopped', 'woocommerce-subscriptions' );
+	}
+
+	/**
+	 * Add the tool to start or stop the background process that manages notification batch processing.
+	 *
+	 * @param array $tools Old tools array.
+	 * @return array Updated tools array.
+	 */
+	public function handle_woocommerce_debug_tools( array $tools ): array {
+		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		$pending_count   = $this->get_total_pending_count();
+
+		if ( 0 === $pending_count ) {
+			$tools['start_add_subscription_notifications'] = array(
+				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
+				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
+				'disabled' => true,
+				'desc'     => __( 'This tool will add notifications to pending, active and on-hold subscriptions. This will happen overtime in the background (via Action Scheduler). There are currently no entries to convert.', 'woocommerce-subscriptions' ),
+			);
+		} elseif ( $batch_processor->is_enqueued( self::class ) ) {
+			$tools['stop_add_subscription_notifications'] = array(
+				'name'     => __( 'Stop adding subscription notifications', 'woocommerce-subscriptions' ),
+				'button'   => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
+				'desc'     =>
+				/* translators: %d=count of entries pending conversion */
+					sprintf( __( 'This will stop the background process that adds notifications to pending, active and on-hold subscriptions. There are currently %d entries that can be converted.', 'woocommerce-subscriptions' ), $pending_count ),
+				'callback' => array( $this, 'dequeue' ),
+			);
+		} else {
+			$tools['start_add_subscription_notifications'] = array(
+				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
+				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
+				'desc'     =>
+				/* translators: %d=count of entries pending conversion */
+					sprintf( __( 'This tool will add notifications to pending, active and on-hold subscriptions. This will happen overtime in the background (via Action Scheduler). There are currently %d entries that can be converted.', 'woocommerce-subscriptions' ), $pending_count ),
+				'callback' => array( $this, 'enqueue' ),
+			);
+		}
+
+		return $tools;
+	}
+}

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -247,11 +247,11 @@ class WCS_Notifications_Debug_Tool_Processor implements BatchProcessorInterface 
 	public function enqueue(): string {
 		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
 		if ( $batch_processor->is_enqueued( self::class ) ) {
-			return __( 'Background process for updating subscritpion notifications already started, nothing done.', 'woocommerce-subscriptions' );
+			return __( 'Background process for updating subscription notifications already started, nothing done.', 'woocommerce-subscriptions' );
 		}
 
 		$batch_processor->enqueue_processor( self::class );
-		return __( 'Background process for updating subscritpion notifications started', 'woocommerce-subscriptions' );
+		return __( 'Background process for updating subscription notifications started', 'woocommerce-subscriptions' );
 	}
 
 	/**
@@ -262,11 +262,11 @@ class WCS_Notifications_Debug_Tool_Processor implements BatchProcessorInterface 
 	public function dequeue(): string {
 		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
 		if ( ! $batch_processor->is_enqueued( self::class ) ) {
-			return __( 'Background process for updating subscritpion notifications not started, nothing done.', 'woocommerce-subscriptions' );
+			return __( 'Background process for updating subscription notifications not started, nothing done.', 'woocommerce-subscriptions' );
 		}
 
 		$batch_processor->remove_processor( self::class );
-		return __( 'Background process for updating subscritpion notifications stopped', 'woocommerce-subscriptions' );
+		return __( 'Background process for updating subscription notifications stopped', 'woocommerce-subscriptions' );
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -634,6 +634,7 @@ class WC_Subscriptions_Core_Plugin {
 	 */
 	public function init_notification_batch_processor() {
 		// Background processing for notifications
-		$notifications_batch_processor = new WCS_Notifications_Batch_Processor();
+		$notifications_batch_processor      = new WCS_Notifications_Batch_Processor();
+		$notifications_debug_tool_processor = new WCS_Notifications_Debug_Tool_Processor();
 	}
 }

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -5,10 +5,6 @@ use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
 
 class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 
-	public function __construct() {
-		add_filter( 'woocommerce_debug_tools', array( $this, 'handle_woocommerce_debug_tools' ), 999, 1 );
-	}
-
 	/**
 	 * Get a user-friendly name for this processor.
 	 *
@@ -224,45 +220,5 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 
 		$batch_processor->remove_processor( self::class );
 		return __( 'Background process for updating subscritpion notifications stopped', 'woocommerce-subscriptions' );
-	}
-
-	/**
-	 * Add the tool to start or stop the background process that manages notification batch processing.
-	 *
-	 * @param array $tools Old tools array.
-	 * @return array Updated tools array.
-	 */
-	public function handle_woocommerce_debug_tools( array $tools ): array {
-		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
-		$pending_count   = $this->get_total_pending_count();
-
-		if ( 0 === $pending_count ) {
-			$tools['start_add_subscription_notifications'] = array(
-				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
-				'disabled' => true,
-				'desc'     => __( 'This tool will add notifications to pending, active and on-hold subscriptions. This will happen overtime in the background (via Action Scheduler). There are currently no entries to convert.', 'woocommerce-subscriptions' ),
-			);
-		} elseif ( $batch_processor->is_enqueued( self::class ) ) {
-			$tools['stop_add_subscription_notifications'] = array(
-				'name'     => __( 'Stop adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'   => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
-				'desc'     =>
-				/* translators: %d=count of entries pending conversion */
-					sprintf( __( 'This will stop the background process that adds notifications to pending, active and on-hold subscriptions. There are currently %d entries that can be converted.', 'woocommerce-subscriptions' ), $pending_count ),
-				'callback' => array( $this, 'dequeue' ),
-			);
-		} else {
-			$tools['start_add_subscription_notifications'] = array(
-				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
-				'desc'     =>
-				/* translators: %d=count of entries pending conversion */
-					sprintf( __( 'This tool will add notifications to pending, active and on-hold subscriptions. This will happen overtime in the background (via Action Scheduler). There are currently %d entries that can be converted.', 'woocommerce-subscriptions' ), $pending_count ),
-				'callback' => array( $this, 'enqueue' ),
-			);
-		}
-
-		return $tools;
 	}
 }

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -1,0 +1,124 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test the "WCS_Notifications_Debug_Tool_Processor::process_batch()" method.
+	 *
+	 * @dataProvider process_batch_notifications_provider
+	 *
+	 * @param array $data
+	 * @return bool
+	 */
+	public function test_process_batch_notifications( $data ) {
+
+		// Hint: This should be required here (?)
+		// update_option(
+		//  WC_Subscriptions_Admin::$option_prefix . '_customer_notifications',
+		//  array(
+		//      'number' => '3',
+		//      'unit'   => 'days',
+		//  )
+		// );
+
+		$subscription = $data['subscription'];
+		$action_name  = $data['action_name'];
+		$action_args  = [ 'subscription_id' => $subscription->get_id() ];
+
+		$has_notification = false !== as_next_scheduled_action( $action_name, $action_args );
+		$this->assertTrue( $has_notification );
+
+		// Remove.
+		as_unschedule_action( $action_name, $action_args );
+
+		$has_notification = false !== as_next_scheduled_action( $action_name, $action_args );
+		$this->assertFalse( $has_notification );
+
+		// Run the debug processor.
+		$processor = new WCS_Notifications_Debug_Tool_Processor();
+		$processor->process_batch( [ $subscription->get_id() ] );
+
+		$has_notification = false !== as_next_scheduled_action( $action_name, $action_args );
+		$this->assertTrue( $has_notification );
+	}
+
+	/**
+	 * Data provider for the "test_process_batch_notifications()" method.
+	 *
+	 * @return array
+	 */
+	public function process_batch_notifications_provider() {
+
+		/*
+		 * Create a simple subscription.
+		 */
+		$simple_subscription = WCS_Helper_Subscription::create_subscription(
+			[
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+			]
+		);
+
+		$simple_subscription->update_status( 'active' );
+		$simple_subscription->save();
+
+		/*
+		 * Create a free trial subscription.
+		 */
+		$free_trial_subscription = WCS_Helper_Subscription::create_subscription(
+			[
+				'status'       => 'active',
+				'start_date'   => '2024-09-10 08:08:08',
+				'date_created' => '2024-09-10 08:08:08',
+			]
+		);
+
+		$free_trial_subscription->update_dates(
+			[
+				'trial_end' => '2024-09-20 08:08:08',
+				'end'       => '2024-09-20 08:08:08',
+			]
+		);
+
+		/**
+		 * Create an expiry subscription.
+		 */
+		$expiry_subscription = WCS_Helper_Subscription::create_subscription(
+			[
+				'status'       => 'active',
+				'start_date'   => '2024-09-10 08:08:08',
+				'date_created' => '2024-09-10 08:08:08',
+			]
+		);
+
+		$expiry_subscription->update_dates(
+			[
+				'trial_end' => '2024-09-20 08:08:08',
+				'end'       => '2024-09-20 08:08:08',
+			]
+		);
+
+		return [
+			[
+				[
+					'subscription' => $simple_subscription,
+					'action_name'  => 'woocommerce_scheduled_subscription_customer_notification_renewal',
+				],
+			],
+			[
+				[
+					'subscription' => $free_trial_subscription,
+					'action_name'  => 'woocommerce_scheduled_subscription_customer_notification_trial_expiration',
+				],
+			],
+			[
+				[
+					'subscription' => $expiry_subscription,
+					'action_name'  => 'woocommerce_scheduled_subscription_customer_notification_expiration',
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Description
This PR introduces a new debug tool for back-filling notification actions in the Action Scheduler. 

- It introduces a new class called `WCS_Notifications_Debug_Tool_Processor` which implements the `BatchProcessorInterface` interface. 
- This tool aims to target all active, pending, and on-hold subscriptions and schedules every notification. It will work by processing itself in batches and passing the current offset until there are no subscriptions left to process.
- The last offset used is stored and passed through the batches using an internal tool state based on an option.

## How to test this PR

1. Make sure that you have some active, pending, or on-hold subscriptions.
2. If you don't have any, create some.
3. Go to "Tools > Scheduled Actions" and look for notification actions (for example, `woocommerce_scheduled_subscription_customer_notification_renewal`) and cancel them.
4. Head to "WooCommerce > Status > Tools" and find the tool.
5. Click on the "Add notifications" button.
6. Keep an eye on the scheduled action for the `wc_run_batch_process` to run.
7. Once the processor has run, check to ensure that the notification actions have been added as expected.
