### PR TITLE
Fix tax inclusive calculations when applying discounts to manual renewal carts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Blocks the reactivation of a subscription when the end date is in the past.
 * Fix - Ensure a subscription's modified date is updated when its related order cache is updated on non-HPOS sites.
 * Fix - Ensure trial period form data is set before use to prevent fatal errors when the data is missing.
+* Fix - Resolved an error with coupon discount calculations for manual or early renewal orders on stores with tax-inclusive pricing.
 
 = 7.4.3 - 2024-09-05 =
 * Fix - Prevent errors during checkout when a customer is switching their subscription product and does not require payment.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1383,7 +1383,7 @@ class WCS_Cart_Renewal {
 		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) );
 
 		if ( $order_includes_tax ) {
-			$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
+			$total_coupon_discount += floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		}
 
 		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1371,8 +1371,8 @@ class WCS_Cart_Renewal {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.4.3
 	 */
 	public function setup_discounts( $order ) {
-		$order_includes_tax = $order->get_prices_include_tax();
-		$order_discount     = $order->get_total_discount( ! $order_includes_tax );
+		$prices_include_tax = $order->get_prices_include_tax();
+		$order_discount     = $order->get_total_discount( ! $prices_include_tax );
 		$coupon_items       = $order->get_items( 'coupon' );
 
 		if ( empty( $order_discount ) && empty( $coupon_items ) ) {
@@ -1382,7 +1382,7 @@ class WCS_Cart_Renewal {
 		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) );
 		$coupons               = array();
 
-		if ( $order_includes_tax ) {
+		if ( $prices_include_tax ) {
 			$total_coupon_discount += floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1379,8 +1379,8 @@ class WCS_Cart_Renewal {
 			return;
 		}
 
-		$coupons               = array();
 		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) );
+		$coupons               = array();
 
 		if ( $order_includes_tax ) {
 			$total_coupon_discount += floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1371,15 +1371,20 @@ class WCS_Cart_Renewal {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.4.3
 	 */
 	public function setup_discounts( $order ) {
-		$order_discount = $order->get_total_discount( ! $order->get_prices_include_tax() );
-		$coupon_items   = $order->get_items( 'coupon' );
+		$order_includes_tax = $order->get_prices_include_tax();
+		$order_discount     = $order->get_total_discount( ! $order_includes_tax );
+		$coupon_items       = $order->get_items( 'coupon' );
 
 		if ( empty( $order_discount ) && empty( $coupon_items ) ) {
 			return;
 		}
 
-		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) ) + floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		$coupons               = array();
+		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) );
+
+		if ( $order_includes_tax ) {
+			$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
+		}
 
 		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.
 		$order_has_manual_discount = $order_discount !== $total_coupon_discount;

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1378,7 +1378,7 @@ class WCS_Cart_Renewal {
 			return;
 		}
 
-		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) );
+		$total_coupon_discount = floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount' ) ) ) + floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		$coupons               = array();
 
 		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4330

## Description

If a customer adds a renewal order to their cart, we try to honor any applied coupons to the cart. As part of that we first determine if we can apply the coupon directly or if we need to create a mock coupon to honor the actual discount amount. To do that we add up all the coupons applied to the order/subscription and then compare it to the discount total. 

If they match then we know the order just contains coupons and we can apply coupons. If they don't match then we assume that there must also be manual discounts involved. 

There was an error in that comparison calculation that led to issues on stores with tax inclusives prices. That bug caused us to not add the original coupon and that had knock on implications for limited coupons.

This PR fixes the original issue of the mismatch in the calculation.

## How to test this PR

1. Go to **WooCommerce → Settings** and enable taxes.
2. Go to **WooCommerce → Settings → Tax** and enable inclusive taxes.
3. Create a tax rate of 10%. Make sure it applies to your store's location and you as a customer.
3. Go to **WooCommerce → Settings → Subscriptions** and disable early renewal via a modal if it's enabled.
5. Create a $20 subscription product.
6. In **Marketing → Discounts** create a recurring coupon of 15% off and make it only apply to 2 payments.

<p align="center">
<img width="1038" alt="Screenshot 2024-09-09 at 10 28 02 A" src="https://github.com/user-attachments/assets/8325f603-0f68-4d1d-a7e5-6448bbf6fd9b">
</p>  

7. Place the $20 product in your cart apply the coupon. 
   - Your cart should like this: 
   
<p align="center">
<img width="400" alt="Screenshot 2024-09-09 at 10 30 10 AM" src="https://github.com/user-attachments/assets/c43b5ffa-55c8-4f6b-b8c6-b6f6df72bc63">
</p> 

8. Complete the purchase. 
9. On the **My Account → Subscription** page click the **Renew now** button
   - On `trunk` the order total and discount amount is incorrect. 
   - On this branch it should be fixed. 

| `trunk` | This branch |
|--------|--------|
| <img width="609" alt="Screenshot 2024-09-09 at 9 07 17 AM" src="https://github.com/user-attachments/assets/728631fd-9051-4a66-81c1-7c7f428286c8"> | <img width="621" alt="Screenshot 2024-09-09 at 9 42 51 AM" src="https://github.com/user-attachments/assets/239bd840-c87b-477f-a2ca-167041cc3ba5"> | 

10. Place the order.
   - On trunk the coupon will still be applied to the subscription (ie that order wasn't registered as a use)
   - On this branch the coupon should be removed.


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
