### PR TITLE
Allow activation of subscription that has no end date

### DIFF
--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -340,7 +340,7 @@ class WC_Subscription extends WC_Order {
 			case 'completed': // core WC order status mapped internally to avoid exceptions
 			case 'active':
 				if ( $this->payment_method_supports( 'subscription_reactivation' ) && $this->has_status( 'on-hold' ) ) {
-					// If the subscription's end date is in the past, it cannot be reactivated
+					// If the subscription's end date is in the past, it cannot be reactivated.
 					if ( $this->get_time( 'end' ) && $this->get_time( 'end' ) < gmdate( 'U' ) ) {
 						$can_be_updated = false;
 					} else {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -341,7 +341,8 @@ class WC_Subscription extends WC_Order {
 			case 'active':
 				if ( $this->payment_method_supports( 'subscription_reactivation' ) && $this->has_status( 'on-hold' ) ) {
 					// If the subscription's end date is in the past, it cannot be reactivated.
-					if ( $this->get_time( 'end' ) && $this->get_time( 'end' ) < gmdate( 'U' ) ) {
+					$end_time = $this->get_time( 'end' );
+					if ( 0 !== $end_time && $end_time < gmdate( 'U' ) ) {
 						$can_be_updated = false;
 					} else {
 						$can_be_updated = true;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -340,7 +340,7 @@ class WC_Subscription extends WC_Order {
 			case 'completed': // core WC order status mapped internally to avoid exceptions
 			case 'active':
 				if ( $this->payment_method_supports( 'subscription_reactivation' ) && $this->has_status( 'on-hold' ) ) {
-					if ( $this->get_time( 'end' ) > gmdate( 'U' ) ) {
+					if ( 0 === $this->get_time( 'end' ) || $this->get_time( 'end' ) > gmdate( 'U' ) ) {
 						$can_be_updated = true;
 					} else {
 						$can_be_updated = false;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -341,7 +341,7 @@ class WC_Subscription extends WC_Order {
 			case 'active':
 				if ( $this->payment_method_supports( 'subscription_reactivation' ) && $this->has_status( 'on-hold' ) ) {
 					// If the subscription's end date is in the past, it cannot be reactivated
-					if ( $this->get_time( 'end' ) < gmdate( 'U' ) ) {
+					if ( $this->get_time( 'end' ) && $this->get_time( 'end' ) < gmdate( 'U' ) ) {
 						$can_be_updated = false;
 					} else {
 						$can_be_updated = true;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -340,10 +340,11 @@ class WC_Subscription extends WC_Order {
 			case 'completed': // core WC order status mapped internally to avoid exceptions
 			case 'active':
 				if ( $this->payment_method_supports( 'subscription_reactivation' ) && $this->has_status( 'on-hold' ) ) {
-					if ( 0 === $this->get_time( 'end' ) || $this->get_time( 'end' ) > gmdate( 'U' ) ) {
-						$can_be_updated = true;
-					} else {
+					// If the subscription's end date is in the past, it cannot be reactivated
+					if ( $this->get_time( 'end' ) < gmdate( 'U' ) ) {
 						$can_be_updated = false;
+					} else {
+						$can_be_updated = true;
 					}
 				} elseif ( $this->has_status( 'pending' ) ) {
 					$can_be_updated = true;


### PR DESCRIPTION
## Description

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/662 we blocked activating subscriptions which have an end date in the past. 

This had the inadvertent effect of blocking subscriptions from activation that don't have an end date. 
ie `0 > current-time => false`

This PR flips the logic to default to `true` and only return `false` when the subscription has an end date and it's in the past.

## How to test this PR

1. Purchase a subscription using any payment gateway. 
2. Go to WooCommerce > Subscriptions. 
3. Put the subscription on-hold. 
4. Notice you cannot activate it. 
5. On this branch you can activate it. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] ~Added changelog entry (or does not apply)~ - not applicable. 
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
