### PR TITLE
Handle Subscription Notifications Rollout

### DIFF
--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -516,6 +516,18 @@ class WC_Subscriptions_Core_Plugin {
 				update_option( WC_Subscriptions_admin::$option_prefix . '_paypal_debugging_default_set', 'true' );
 			}
 
+			// If this is the first time activating WooCommerce Subscription we want to enable the customer email notifications (default to 3 days before.)
+			if ( '0' === get_option( WC_Subscriptions_Admin::$option_prefix . '_previous_version', '0' ) && false === get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string, false ) ) {
+				update_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'yes' );
+				update_option(
+					WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
+					[
+						'number' => '3',
+						'unit'   => 'days',
+					]
+				);
+			}
+
 			update_option( WC_Subscriptions_Admin::$option_prefix . '_is_active', true );
 
 			set_transient( $this->get_activation_transient(), true, 60 * 60 );


### PR DESCRIPTION
## Description

This PR includes a default value for two options that manage customer notifications. These options will only be updated for new installations by verifying the WCS's option for the previous version. The default offset for sending notifications is set to 3 days before.

Please follow these steps to test this PR:

1. Make sure that the `woocommerce_subscriptions_customer_notifications_enabled` and `woocommerce_subscriptions_customer_notifications_offset` options do not exist. If they do, please delete them.
2. Use one of the following: (a) a new store, (b) a store that has never installed subscriptions, or (c) delete the `woocommerce_subscriptions_previous_version` option from your test store.
3. Refresh a page.
4. Verify that the option defaults are added as expected.

## Product impact

<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
