### PR TITLE
WC version from constant should be checked if defined before accessed

### DIFF
--- a/includes/class-wcs-dependent-hook-manager.php
+++ b/includes/class-wcs-dependent-hook-manager.php
@@ -48,7 +48,7 @@ class WCS_Dependent_Hook_Manager {
 		foreach ( self::$dependent_callbacks['woocommerce'] as $wc_version => $operators ) {
 			foreach ( $operators as $operator => $callbacks ) {
 
-				if ( ! version_compare( WC_VERSION, $wc_version, $operator ) ) {
+				if ( ! defined( 'WC_VERSION' ) || ! version_compare( WC_VERSION, $wc_version, $operator ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #678 

## Description

See #678 -- this PR merely introduces a sanity check around `WC_VERSION`.

As an alternative or fallback, you could also check for `get_option( 'woocommerce_version' )`.


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
