### PR TITLE
Allow multiple cancellation emails to be sent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.5.1 - xxxx-xx-xx =
+* Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
+
 = 7.5.0 - 2024-09-12 =
 * Dev - Removing the unused method `maybe_remove_formatted_order_total_filter` hooked to `woocommerce_get_formatted_order_total` which was deprecated.
 * Fix - Resolved two issues preventing the correct display of the "Subscription items can no longer be edited." message on the Edit Subscription page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
-= 7.5.1 - xxxx-xx-xx =
+= 7.6.0 - xxxx-xx-xx =
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
 
 = 7.5.0 - 2024-09-12 =

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -497,6 +497,9 @@ class WC_Subscription extends WC_Order {
 								'trial_end'    => $this->meta_exists( 'trial_end_pre_cancellation' ) ? $this->get_meta( 'trial_end_pre_cancellation' ) : 0,
 								'next_payment' => $this->get_date( 'end' ),
 							) );
+
+							// If the subscription was cancelled, reset the cancelled email sent flag so the customer can be notified of a future cancellation
+							$this->set_cancelled_email_sent( 'false' );
 						} else {
 							// Recalculate and set next payment date
 							$stored_next_payment = $this->get_time( 'next_payment' );
@@ -514,11 +517,6 @@ class WC_Subscription extends WC_Order {
 							} else {
 								// In case plugins want to run some code when the subscription was reactivated, but the next payment date was not recalculated.
 								do_action( 'woocommerce_subscription_activation_next_payment_not_recalculated', $stored_next_payment, $old_status, $this );
-							}
-
-							// If the subscription was cancelled, reset the cancelled email sent flag so the customer can be notified of a future cancellation
-							if ( 'cancelled' === $old_status ) {
-								$this->set_cancelled_email_sent( 'false' );
 							}
 						}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -515,6 +515,11 @@ class WC_Subscription extends WC_Order {
 								// In case plugins want to run some code when the subscription was reactivated, but the next payment date was not recalculated.
 								do_action( 'woocommerce_subscription_activation_next_payment_not_recalculated', $stored_next_payment, $old_status, $this );
 							}
+
+							// If the subscription was cancelled, reset the cancelled email sent flag so the customer can be notified of a future cancellation
+							if ( 'cancelled' === $old_status ) {
+								$this->set_cancelled_email_sent( 'false' );
+							}
 						}
 
 						// Trial end date and end/expiration date don't change at all - they should be set when the subscription is first created

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -497,9 +497,6 @@ class WC_Subscription extends WC_Order {
 								'trial_end'    => $this->meta_exists( 'trial_end_pre_cancellation' ) ? $this->get_meta( 'trial_end_pre_cancellation' ) : 0,
 								'next_payment' => $this->get_date( 'end' ),
 							) );
-
-							// If the subscription was cancelled, reset the cancelled email sent flag so the customer can be notified of a future cancellation
-							$this->set_cancelled_email_sent( 'false' );
 						} else {
 							// Recalculate and set next payment date
 							$stored_next_payment = $this->get_time( 'next_payment' );

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -26,6 +26,8 @@ class WC_Subscriptions_Email {
 
 		add_action( 'woocommerce_subscriptions_email_order_details', __CLASS__ . '::order_download_details', 10, 4 );
 		add_action( 'woocommerce_subscriptions_email_order_details', __CLASS__ . '::order_details', 10, 4 );
+
+		add_action( 'woocommerce_subscription_pre_update_status', __CLASS__ . '::maybe_clear_cancelled_email_flag', 10, 4 );
 	}
 
 	/**
@@ -343,6 +345,21 @@ class WC_Subscriptions_Email {
 	public static function order_download_details( $order, $sent_to_admin = false, $plain_text = false, $email = '' ) {
 		if ( is_callable( array( 'WC_Emails', 'order_downloads' ) ) ) {
 			WC_Emails::instance()->order_downloads( $order, $sent_to_admin, $plain_text, $email );
+		}
+	}
+
+	/**
+	 * If the subscription was cancelled before, reset the cancelled email sent flag so the customer can be notified of a future cancellation.
+	 *
+	 * @param $old_status string The old status of the subscription.
+	 * @param $new_status string The new status of the subscription.
+	 * @param $subscription WC_Subscription The subscription object.
+	 * @return void
+	 */
+	public static function maybe_clear_cancelled_email_flag( $old_status, $new_status, $subscription ) {
+		if ( 'active' === $new_status && 'pending-cancel' === $old_status ) {
+			$subscription->set_cancelled_email_sent( 'false' );
+			$subscription->save();
 		}
 	}
 

--- a/tests/unit/test-class-wc-subscription.php
+++ b/tests/unit/test-class-wc-subscription.php
@@ -18,8 +18,8 @@ class WC_Subscription_Test extends WP_UnitTestCase {
 	public function test_update_status( $from, $to, $expected ) {
 		$subscription = WCS_Helper_Subscription::create_subscription(
 			array(
-				'status' => $from,
-				'requires_manual_renewal' => true // Required to allow the subscription status to be updated.
+				'status'                  => $from,
+				'requires_manual_renewal' => true, // Required to allow the subscription status to be updated.
 			)
 		);
 		$subscription->update_dates( [ 'end' => gmdate( 'Y-m-d H:i:s', wcs_add_months( time(), 1 ) ) ] );
@@ -38,11 +38,11 @@ class WC_Subscription_Test extends WP_UnitTestCase {
 	public function provide_test_update_status() {
 		return array(
 			'pending-cancel => active' => array(
-				'from' => 'pending-cancel',
-				'to' => 'active',
+				'from'     => 'pending-cancel',
+				'to'       => 'active',
 				'expected' => array(
 					'cancelled_email_sent' => 'false',
-				)
+				),
 			),
 		);
 	}

--- a/tests/unit/test-class-wc-subscription.php
+++ b/tests/unit/test-class-wc-subscription.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Class: WC_Subscription_Test
+ */
+class WC_Subscription_Test extends WP_UnitTestCase {
+	/**
+	 * Test for `update_status` method.
+	 *
+	 * @param string $from Subscription status before update.
+	 * @param string $to Subscription status after update.
+	 * @param array $expected Expected values after update.
+	 * @return void
+	 * @dataProvider provide_test_update_status
+	 * @throws Exception If the subscription status is invalid.
+	 * @group test_update_status
+	 */
+	public function test_update_status( $from, $to, $expected ) {
+		$subscription = WCS_Helper_Subscription::create_subscription(
+			array(
+				'status' => $from,
+				'requires_manual_renewal' => true // Required to allow the subscription status to be updated.
+			)
+		);
+		$subscription->update_dates( [ 'end' => gmdate( 'Y-m-d H:i:s', wcs_add_months( time(), 1 ) ) ] );
+		$subscription->update_status( $to );
+
+		foreach ( $expected as $data_key => $expected_value ) {
+			$this->assertEquals( $expected_value, $subscription->{ 'get_' . $data_key }() );
+		}
+	}
+
+	/**
+	 * Provider for `test_update_status` method.
+	 *
+	 * @return array
+	 */
+	public function provide_test_update_status() {
+		return array(
+			'pending-cancel => active' => array(
+				'from' => 'pending-cancel',
+				'to' => 'active',
+				'expected' => array(
+					'cancelled_email_sent' => 'false',
+				)
+			),
+		);
+	}
+}


### PR DESCRIPTION
Fixes #658
Ref. comment https://github.com/Automattic/woocommerce-subscriptions-core/issues/658#issuecomment-2321165662

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

When a subscription is canceled, we send a cancellation notification and update the `cancelled_email_sent` flag to `true` to avoid multiple triggers for the same email. However, this blocks the notification from being sent in the case of a reactivation.

This PR fixes that by clearing the flag upon reactivation, allowing the following cancellation to trigger the notification.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this change to your test store subscription extension
- As a customer, purchase a subscription using any payment method
- As a merchant, enable notifications for cancelled subscriptions at `wp-admin/admin.php?page=wc-settings&tab=email`
- As a customer, cancel the subscription at the "My Subscription" page
- Confirm that the cancellation email is sent
- As a customer, reactivate the same subscription to cancel it again
- Confirm that another cancellation email is sent

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
