### PR TITLE
Only load our WC Navigation compatibility code on stores running WC < 9.3 to prevent deprecation warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 7.6.0 - xxxx-xx-xx =
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
+* Fix - Prevent deprecation notices after updating to WooCommerce 9.3.
+* Dev - Only initialise the `WCS_WC_Admin_Manager` class on stores running WC 9.2 or older. This class handled integration with the Woo Navigation feature that was removed in WC 9.3.
 
 = 7.5.0 - 2024-09-12 =
 * Dev - Removing the unused method `maybe_remove_formatted_order_total_filter` hooked to `woocommerce_get_formatted_order_total` which was deprecated.

--- a/includes/admin/class-wcs-wc-admin-manager.php
+++ b/includes/admin/class-wcs-wc-admin-manager.php
@@ -16,6 +16,9 @@ class WCS_WC_Admin_Manager {
 
 	/**
 	 * Initialise the class and attach hook callbacks.
+	 *
+	 * WooCommerce 9.3 removed the new Navigation feature making this class obsolete.
+	 * This class will only be inited on stores running WooCommerce 9.2 or older.
 	 */
 	public static function init() {
 		if ( ! defined( 'WC_ADMIN_PLUGIN_FILE' ) ) {

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -148,7 +148,6 @@ class WC_Subscriptions_Core_Plugin {
 		add_action( 'init', array( 'WC_Subscriptions_Synchroniser', 'init' ) );
 		add_action( 'after_setup_theme', array( 'WC_Subscriptions_Upgrader', 'init' ), 11 );
 		add_action( 'init', array( 'WC_PayPal_Standard_Subscriptions', 'init' ), 11 );
-		add_action( 'init', array( 'WCS_WC_Admin_Manager', 'init' ), 11 );
 
 		// Attach the callback to load version dependant classes.
 		add_action( 'plugins_loaded', array( $this, 'init_version_dependant_classes' ) );
@@ -211,6 +210,11 @@ class WC_Subscriptions_Core_Plugin {
 		// Only load privacy handling on WC applicable versions.
 		if ( class_exists( 'WC_Abstract_Privacy' ) ) {
 			new WCS_Privacy();
+		}
+
+		// Loads Subscriptions support for the WooCommerce Navigation feature. This feature was removed in WC 9.3.
+		if ( wcs_is_woocommerce_pre( '9.3' ) ) {
+			add_action( 'init', array( 'WCS_WC_Admin_Manager', 'init' ), 11 );
 		}
 	}
 


### PR DESCRIPTION
Fixes #674

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

WooCommerce 9.3 removed their Navigation feature and deprecated all related functions. See PR: https://github.com/woocommerce/woocommerce/issues/48997

Stores running WooCommerce 9.3 with Subscriptions are getting the following deprecated notices:

```
[16-Sep-2024 06:05:32 UTC] Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item is deprecated since 9.3 with no alternative. Navigation classes will be removed in WooCommerce 9.4
[16-Sep-2024 06:05:32 UTC] Automattic\WooCommerce\Admin\Features\Navigation\Screen::register_post_type is deprecated since 9.3 with no alternative. Navigation classes will be removed in WooCommerce 9.4
```

This PR addresses this issue by moving our initing of our `WCS_WC_Admin_Manager` class, which was added to provide support for this feature, to only on stores running WooCommerce 9.2 or older.

> [!WARNING]
> Moving the hook from `init()` to `init_version_dependant_classes()` is technically a breaking change. But it's zero-low enough risk that I'm fine with shipping this.
> The reason I moved the hook into `init_version_dependant_classes()` is so that we can reliably get the WC version using the `WC_VERSION` constant

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install and activate the WooCommerce 9.3.1 ([download zip](https://github.com/woocommerce/woocommerce/releases/download/9.3.1/woocommerce.zip))
2. On `trunk`, loading any WP Admin page will produce the above deprecated notices
3. On this branch, deprecated notices no longer present

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
