### PR TITLE
Better implementation for the clearing of the cancelled email flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.6.0 - xxxx-xx-xx =
+* Fix - Minor improvement to the clearing of the `cancelled_email_sent` meta to avoid issues with pre-paid subscriptions.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
 * Fix - Prevent deprecation notices after updating to WooCommerce 9.3.
 * Dev - Only initialise the `WCS_WC_Admin_Manager` class on stores running WC 9.2 or older. This class handled integration with the Woo Navigation feature that was removed in WC 9.3.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.6.0 - xxxx-xx-xx =
-* Fix - Minor improvement to the clearing of the `cancelled_email_sent` meta to avoid issues with pre-paid subscriptions.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
 * Fix - Prevent deprecation notices after updating to WooCommerce 9.3.
 * Dev - Only initialise the `WCS_WC_Admin_Manager` class on stores running WC 9.2 or older. This class handled integration with the Woo Navigation feature that was removed in WC 9.3.

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -27,7 +27,7 @@ class WC_Subscriptions_Email {
 		add_action( 'woocommerce_subscriptions_email_order_details', __CLASS__ . '::order_download_details', 10, 4 );
 		add_action( 'woocommerce_subscriptions_email_order_details', __CLASS__ . '::order_details', 10, 4 );
 
-		add_action( 'woocommerce_subscription_pre_update_status', __CLASS__ . '::maybe_clear_cancelled_email_flag', 10, 4 );
+		add_action( 'woocommerce_subscription_status_pending-cancel_to_active', __CLASS__ . '::maybe_clear_cancelled_email_flag', 10, 4 );
 	}
 
 	/**
@@ -351,16 +351,12 @@ class WC_Subscriptions_Email {
 	/**
 	 * If the subscription was cancelled before, reset the cancelled email sent flag so the customer can be notified of a future cancellation.
 	 *
-	 * @param $old_status string The old status of the subscription.
-	 * @param $new_status string The new status of the subscription.
 	 * @param $subscription WC_Subscription The subscription object.
 	 * @return void
 	 */
-	public static function maybe_clear_cancelled_email_flag( $old_status, $new_status, $subscription ) {
-		if ( 'active' === $new_status && 'pending-cancel' === $old_status ) {
-			$subscription->set_cancelled_email_sent( 'false' );
-			$subscription->save();
-		}
+	public static function maybe_clear_cancelled_email_flag( $subscription ) {
+		$subscription->set_cancelled_email_sent( 'false' );
+		$subscription->save();
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-subscriptions-core/issues/658
Base PR https://github.com/Automattic/woocommerce-subscriptions-core/pull/681
Ref. comment https://github.com/Automattic/woocommerce-subscriptions-core/pull/681#issuecomment-2354161207

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

The [original PR for this fix](https://github.com/Automattic/woocommerce-subscriptions-core/pull/681) may have introduced an issue with pre-paid subscriptions because it hooks to an action before the status transition is validated.

This PR improves the fix by hooking to `woocommerce_subscription_status_pending-cancel_to_active`, which runs after the validation, and only for the transition that matters to us.

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same as https://github.com/Automattic/woocommerce-subscriptions-core/pull/681

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
