### PR TITLE
Correctly update a subscription status upon losing a dispute

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.6.0 - xxxx-xx-xx =
+* Fix - Correctly updates a subscription status to `cancelled` when a dispute is lost.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
 * Fix - Prevent deprecation notices after updating to WooCommerce 9.3.
 * Dev - Only initialise the `WCS_WC_Admin_Manager` class on stores running WC 9.2 or older. This class handled integration with the Woo Navigation feature that was removed in WC 9.3.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.6.0 - xxxx-xx-xx =
-* Fix - Correctly updates a subscription status to `cancelled` when a dispute is lost.
+* Fix - Correctly updates a subscription status to `cancelled` during a payment failure call when the current status is `pending-cancel`.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
 * Fix - Prevent deprecation notices after updating to WooCommerce 9.3.
 * Dev - Only initialise the `WCS_WC_Admin_Manager` class on stores running WC 9.2 or older. This class handled integration with the Woo Navigation feature that was removed in WC 9.3.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -459,7 +459,7 @@ class WC_Subscription extends WC_Order {
 
 					case 'pending':
 						// Nothing to do here
-						break;
+					break;
 
 					case 'pending-cancel':
 						// Store the subscription's end date and trial end date before overriding/deleting them.
@@ -470,7 +470,7 @@ class WC_Subscription extends WC_Order {
 						$end_date = $this->calculate_date( 'end_of_prepaid_term' );
 
 						// If there is no future payment and no expiration date set, or the end date is before now, the customer has no prepaid term (this shouldn't be possible as only active subscriptions can be set to pending cancellation and an active subscription always has either an end date or next payment), so set the end date and cancellation date to now
-						if ( 0 == $end_date || wcs_date_to_time( $end_date ) < time() ) {
+						if ( 0 == $end_date || wcs_date_to_time( $end_date ) < current_time( 'timestamp', true ) ) {
 							$cancelled_date = $end_date = current_time( 'mysql', true );
 						} else {
 							// the cancellation date is now, and the end date is the end of prepaid term date
@@ -485,19 +485,18 @@ class WC_Subscription extends WC_Order {
 								'end'       => $end_date,
 							)
 						);
-						break;
+					break;
 
 					case 'completed': // core WC order status mapped internally to avoid exceptions
 					case 'active':
+
 						if ( 'pending-cancel' === $old_status ) {
-							$this->update_dates(
-								array(
-									'cancelled'    => 0,
-									'end'          => $this->meta_exists( 'end_date_pre_cancellation' ) ? $this->get_meta( 'end_date_pre_cancellation' ) : 0,
-									'trial_end'    => $this->meta_exists( 'trial_end_pre_cancellation' ) ? $this->get_meta( 'trial_end_pre_cancellation' ) : 0,
-									'next_payment' => $this->get_date( 'end' ),
-								)
-							);
+							$this->update_dates( array(
+								'cancelled'    => 0,
+								'end'          => $this->meta_exists( 'end_date_pre_cancellation' ) ? $this->get_meta( 'end_date_pre_cancellation' ) : 0,
+								'trial_end'    => $this->meta_exists( 'trial_end_pre_cancellation' ) ? $this->get_meta( 'trial_end_pre_cancellation' ) : 0,
+								'next_payment' => $this->get_date( 'end' ),
+							) );
 						} else {
 							// Recalculate and set next payment date
 							$stored_next_payment = $this->get_time( 'next_payment' );
@@ -520,13 +519,13 @@ class WC_Subscription extends WC_Order {
 
 						// Trial end date and end/expiration date don't change at all - they should be set when the subscription is first created
 						wcs_make_user_active( $this->get_user_id() );
-						break;
+					break;
 
 					case 'failed': // core WC order status mapped internally to avoid exceptions
 					case 'on-hold':
 						// Record date of suspension - 'post_modified' column?
 						$this->set_suspension_count( $this->get_suspension_count() + 1 );
-						break;
+					break;
 					case 'cancelled':
 					case 'switched':
 					case 'expired':
@@ -543,7 +542,7 @@ class WC_Subscription extends WC_Order {
 						}
 
 						$this->update_dates( $dates_to_update );
-						break;
+					break;
 				}
 
 				// Make sure status is saved when WC 3.0+ is active, similar to WC_Order::update_status() with WC 3.0+ - set_status() can be used to avoid saving.
@@ -1308,14 +1307,14 @@ class WC_Subscription extends WC_Order {
 
 		if ( $timestamp_gmt > 0 ) {
 
-			$time_diff = $timestamp_gmt - time();
+			$time_diff = $timestamp_gmt - current_time( 'timestamp', true );
 
 			if ( $time_diff > 0 && $time_diff < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( time(), $timestamp_gmt ) );
+				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
 			} elseif ( $time_diff < 0 && absint( $time_diff ) < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( time(), $timestamp_gmt ) );
+				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
 			} else {
 				$date_to_display = date_i18n( wc_date_format(), $this->get_time( $date_type, 'site' ) );
 			}
@@ -1439,18 +1438,18 @@ class WC_Subscription extends WC_Order {
 		switch ( $date_type ) {
 			case 'date_created':
 				$message = __( 'The creation date of a subscription can not be deleted, only updated.', 'woocommerce-subscriptions' );
-				break;
+			break;
 			case 'start':
 				$message = __( 'The start date of a subscription can not be deleted, only updated.', 'woocommerce-subscriptions' );
-				break;
+			break;
 			case 'last_order_date_created':
 			case 'last_order_date_modified':
 				// translators: %s: date type (e.g. "trial_end").
 				$message = sprintf( __( 'The %s date of a subscription can not be deleted. You must delete the order.', 'woocommerce-subscriptions' ), $date_type );
-				break;
+			break;
 			default:
 				$message = '';
-				break;
+			break;
 		}
 
 		if ( ! empty( $message ) ) {
@@ -1532,14 +1531,15 @@ class WC_Subscription extends WC_Order {
 				}
 				break;
 			case 'end_of_prepaid_term':
+
 				$next_payment_time = $this->get_time( 'next_payment' );
 				$end_time          = $this->get_time( 'end' );
 
 				// If there was a future payment, the customer has paid up until that payment date
-				if ( $this->get_time( 'next_payment' ) >= time() ) {
+				if ( $this->get_time( 'next_payment' ) >= current_time( 'timestamp', true ) ) {
 					$date = $this->get_date( 'next_payment' );
-					// If there is no future payment and no expiration date set, the customer has no prepaid term (this shouldn't be possible as only active subscriptions can be set to pending cancellation and an active subscription always has either an end date or next payment)
-				} elseif ( 0 == $next_payment_time || $end_time <= time() ) {
+				// If there is no future payment and no expiration date set, the customer has no prepaid term (this shouldn't be possible as only active subscriptions can be set to pending cancellation and an active subscription always has either an end date or next payment)
+				} elseif ( 0 == $next_payment_time || $end_time <= current_time( 'timestamp', true ) ) {
 					$date = current_time( 'mysql', true );
 				} else {
 					$date = $this->get_date( 'end' );
@@ -1573,7 +1573,7 @@ class WC_Subscription extends WC_Order {
 		$end_time          = $this->get_time( 'end' );
 
 		// If the subscription has a free trial period, and we're still in the free trial period, the next payment is due at the end of the free trial
-		if ( $trial_end_time > time() ) {
+		if ( $trial_end_time > current_time( 'timestamp', true ) ) {
 
 			$next_payment_timestamp = $trial_end_time;
 
@@ -1594,9 +1594,9 @@ class WC_Subscription extends WC_Order {
 
 			// Make sure the next payment is more than 2 hours in the future, this ensures changes to the site's timezone because of daylight savings will never cause a 2nd renewal payment to be processed on the same day
 			$i = 1;
-			while ( $next_payment_timestamp < ( time() + 2 * HOUR_IN_SECONDS ) && $i < 3000 ) {
+			while ( $next_payment_timestamp < ( current_time( 'timestamp', true ) + 2 * HOUR_IN_SECONDS ) && $i < 3000 ) {
 				$next_payment_timestamp = wcs_add_time( $this->get_billing_interval(), $this->get_billing_period(), $next_payment_timestamp, 'offset_site_time' );
-				$i                     += 1;
+				$i += 1;
 			}
 		}
 
@@ -1788,12 +1788,12 @@ class WC_Subscription extends WC_Order {
 
 			$this->update_status( 'pending-cancel', $note );
 
-			// If the subscription has already ended or can't be cancelled for some other reason, just record the note.
+		// If the subscription has already ended or can't be cancelled for some other reason, just record the note.
 		} elseif ( ! $this->can_be_updated_to( 'cancelled' ) ) {
 
 			$this->add_order_note( $note );
 
-			// Cancel for real if we're already pending cancellation
+		// Cancel for real if we're already pending cancellation
 		} else {
 
 			$this->update_status( 'cancelled', $note );
@@ -2151,12 +2151,12 @@ class WC_Subscription extends WC_Order {
 
 			$payment_method_to_display = __( 'Manual Renewal', 'woocommerce-subscriptions' );
 
-			// Use the current title of the payment gateway when available
+		// Use the current title of the payment gateway when available
 		} elseif ( false !== ( $payment_gateway = wc_get_payment_gateway_by_order( $this ) ) ) {
 
 			$payment_method_to_display = $payment_gateway->get_title();
 
-			// Fallback to the title of the payment method when the subscription was created
+		// Fallback to the title of the payment method when the subscription was created
 		} else {
 
 			$payment_method_to_display = $this->get_payment_method_title();
@@ -2211,7 +2211,7 @@ class WC_Subscription extends WC_Order {
 
 					// Set the payment gateway ID depending on whether we have a string or WC_Payment_Gateway or string key
 					if ( is_a( $payment_method, 'WC_Payment_Gateway' ) ) {
-						$payment_gateway = $payment_method;
+						$payment_gateway  = $payment_method;
 					} else {
 						$payment_gateways = WC()->payment_gateways->payment_gateways();
 						$payment_gateway  = isset( $payment_gateways[ $payment_method_id ] ) ? $payment_gateways[ $payment_method_id ] : null;
@@ -2273,7 +2273,7 @@ class WC_Subscription extends WC_Order {
 	 * @return bool
 	 */
 	public function is_download_permitted() {
-		$sending_email         = did_action( 'woocommerce_email_header' ) > did_action( 'woocommerce_email_footer' );
+		$sending_email = did_action( 'woocommerce_email_header' ) > did_action( 'woocommerce_email_footer' );
 		$is_download_permitted = $this->has_status( 'active' ) || $this->has_status( 'pending-cancel' );
 
 		// WC Emails are sent before the subscription status is updated to active etc. so we need a way to ensure download links are added to the emails before being sent
@@ -2431,8 +2431,8 @@ class WC_Subscription extends WC_Order {
 				if ( $subscription_order_count < 2 && 0 != ( $next_payment_timestamp = $this->get_time( 'next_payment' ) ) ) {
 					$from_timestamp = $next_payment_timestamp;
 
-					// when we have a sync'd subscription after its 1st payment, we need to base the calculations for the next payment on the last payment timestamp.
-				} elseif ( ! ( $subscription_order_count > 2 ) && 0 != ( $last_payment_timestamp = $this->get_time( 'last_order_date_created' ) ) ) {
+				// when we have a sync'd subscription after its 1st payment, we need to base the calculations for the next payment on the last payment timestamp.
+				} else if ( ! ( $subscription_order_count > 2 ) && 0 != ( $last_payment_timestamp = $this->get_time( 'last_order_date_created' ) ) ) {
 					$from_timestamp = $last_payment_timestamp;
 				}
 			}
@@ -2535,7 +2535,7 @@ class WC_Subscription extends WC_Order {
 
 					$timestamps[ $date_type ] = wcs_date_to_time( $datetime );
 				}
-				// otherwise get the current subscription time
+			// otherwise get the current subscription time
 			} else {
 				$timestamps[ $date_type ] = $this->get_time( $date_type );
 			}
@@ -2627,23 +2627,19 @@ class WC_Subscription extends WC_Order {
 	protected function get_valid_date_types() {
 
 		if ( empty( $this->valid_date_types ) ) {
-			$this->valid_date_types = apply_filters(
-				'woocommerce_subscription_valid_date_types',
-				array_merge(
-					array_keys( wcs_get_subscription_date_types() ),
-					array(
-						'date_created',
-						'date_modified',
-						'date_paid',
-						'date_completed',
-						'last_order_date_created',
-						'last_order_date_paid',
-						'last_order_date_completed',
-						'payment_retry',
-					)
-				),
-				$this
-			);
+			$this->valid_date_types = apply_filters( 'woocommerce_subscription_valid_date_types', array_merge(
+				array_keys( wcs_get_subscription_date_types() ),
+				array(
+					'date_created',
+					'date_modified',
+					'date_paid',
+					'date_completed',
+					'last_order_date_created',
+					'last_order_date_paid',
+					'last_order_date_completed',
+					'payment_retry',
+				)
+			), $this );
 		}
 
 		return $this->valid_date_types;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1914,13 +1914,11 @@ class WC_Subscription extends WC_Order {
 
 		// Allow a short circuit for plugins & payment gateways to force max failed payments exceeded
 		// This also forces the new status to be 'cancelled' if the filter is applied or the subscription is pending-cancel
-		$status_note                                 = '';
-		$max_failed_payments_exceeded_filter_applied = apply_filters( 'woocommerce_subscription_max_failed_payments_exceeded', false, $this );
-		if ( $max_failed_payments_exceeded_filter_applied || $this->has_status( 'pending-cancel' ) ) {
+		$max_failed_payments = apply_filters( 'woocommerce_subscription_max_failed_payments_exceeded', false, $this );
+		$status_note         = $max_failed_payments ? __( 'Subscription Cancelled: maximum number of failed payments reached.', 'woocommerce-subscriptions' ) : '';
+
+		if ( $max_failed_payments || $this->has_status( 'pending-cancel' ) ) {
 			$new_status = 'cancelled';
-			if ( $max_failed_payments_exceeded_filter_applied ) {
-				$status_note = __( 'Subscription Cancelled: maximum number of failed payments reached.', 'woocommerce-subscriptions' );
-			}
 		}
 
 		if ( $this->can_be_updated_to( $new_status ) ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1913,12 +1913,13 @@ class WC_Subscription extends WC_Order {
 		$this->add_order_note( __( 'Payment failed.', 'woocommerce-subscriptions' ) );
 
 		// Allow a short circuit for plugins & payment gateways to force max failed payments exceeded
-		if ( 'cancelled' == $new_status || apply_filters( 'woocommerce_subscription_max_failed_payments_exceeded', false, $this ) ) {
-			if ( $this->can_be_updated_to( 'cancelled' ) ) {
-				$this->update_status( 'cancelled', __( 'Subscription Cancelled: maximum number of failed payments reached.', 'woocommerce-subscriptions' ) );
-			}
-		} elseif ( $this->can_be_updated_to( $new_status ) ) {
-			$this->update_status( $new_status );
+		$status_note = '';
+		if ( apply_filters( 'woocommerce_subscription_max_failed_payments_exceeded', false, $this ) ) {
+			$status_note = __( 'Subscription Cancelled: maximum number of failed payments reached.', 'woocommerce-subscriptions' );
+		}
+
+		if ( $this->can_be_updated_to( $new_status ) ) {
+			$this->update_status( $new_status, $status_note );
 		}
 
 		do_action( 'woocommerce_subscription_payment_failed', $this, $new_status );

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -454,17 +454,10 @@ class WC_Subscriptions_Manager {
 				$order->update_status( 'failed', __( 'Subscription sign up failed.', 'woocommerce-subscriptions' ) );
 			}
 
-			$new_status = 'on-hold';
-
-			// If the order dispute status meta is set to lost, cancel the subscription
-			if ( $order->get_meta( '_dispute_closed_status' ) === 'lost' ) {
-				$new_status = 'cancelled';
-			}
-
 			foreach ( $subscriptions as $subscription ) {
 
 				try {
-					$subscription->payment_failed( $new_status );
+					$subscription->payment_failed( $subscription->has_status( 'pending-cancel' ) ? 'cancelled' : 'on-hold' );
 
 				} catch ( Exception $e ) {
 					// translators: $1: order number, $2: error message

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -456,19 +456,8 @@ class WC_Subscriptions_Manager {
 
 			$new_status = 'on-hold';
 
-			// Get last order note
-			$latest_notes = wc_get_order_notes(
-				array(
-					'order_id' => $order->get_id(),
-					'limit'    => 1,
-					'orderby'  => 'date_created_gmt',
-				)
-			);
-
-			$latest_note = current( $latest_notes );
-
-			// If the last note contains the dispute message, set the status to cancelled
-			if ( isset( $latest_note->content ) && false !== strpos( $latest_note->content, 'The dispute was lost or accepted.' ) ) {
+			// If the order dispute status meta is set to lost, cancel the subscription
+			if ( $order->get_meta( '_dispute_closed_status' ) === 'lost' ) {
 				$new_status = 'cancelled';
 			}
 

--- a/includes/class-wc-subscriptions-manager.php
+++ b/includes/class-wc-subscriptions-manager.php
@@ -457,7 +457,7 @@ class WC_Subscriptions_Manager {
 			foreach ( $subscriptions as $subscription ) {
 
 				try {
-					$subscription->payment_failed( $subscription->has_status( 'pending-cancel' ) ? 'cancelled' : 'on-hold' );
+					$subscription->payment_failed();
 
 				} catch ( Exception $e ) {
 					// translators: $1: order number, $2: error message

--- a/tests/unit/test-class-wc-subscriptions-manager.php
+++ b/tests/unit/test-class-wc-subscriptions-manager.php
@@ -7,19 +7,20 @@ class WC_Subscriptions_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Test for `failed_subscription_sign_ups_for_order` method.
 	 *
-	 * @param string $dispute_meta Dispute meta.
+	 * @param string $initial_status Initial subscription status.
 	 * @param string $expected_status Expected subscription status.
 	 * @return void
 	 * @dataProvider provide_test_failed_subscription_sign_ups_for_order
+	 * @group test_failed_subscription_sign_ups_for_order
 	 */
-	public function test_failed_subscription_sign_ups_for_order( $dispute_meta, $expected_status ) {
+	public function test_failed_subscription_sign_ups_for_order( $initial_status, $expected_status ) {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'failed' );
-		$order->update_meta_data( '_dispute_closed_status', $dispute_meta );
 		$order->save();
 
 		$subscription = WCS_Helper_Subscription::create_subscription(
 			[
+				'status'   => $initial_status,
 				'order_id' => $order->get_id(),
 			]
 		);
@@ -39,11 +40,11 @@ class WC_Subscriptions_Manager_Test extends WP_UnitTestCase {
 	public function provide_test_failed_subscription_sign_ups_for_order() {
 		return [
 			'order failed, dispute won'  => [
-				'dispute meta'    => 'won',
+				'initial status'  => 'active',
 				'expected status' => 'on-hold',
 			],
 			'order failed, dispute lost' => [
-				'dispute meta'    => 'lost',
+				'initial status'  => 'pending-cancel',
 				'expected status' => 'cancelled',
 			],
 		];

--- a/tests/unit/test-class-wc-subscriptions-manager.php
+++ b/tests/unit/test-class-wc-subscriptions-manager.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Class WC_Subscriptions_Manager_Test
+ */
+class WC_Subscriptions_Manager_Test extends WP_UnitTestCase {
+	/**
+	 * Test for `failed_subscription_sign_ups_for_order` method.
+	 *
+	 * @param string $dispute_meta Dispute meta.
+	 * @param string $expected_status Expected subscription status.
+	 * @return void
+	 * @dataProvider provide_test_failed_subscription_sign_ups_for_order
+	 */
+	public function test_failed_subscription_sign_ups_for_order( $dispute_meta, $expected_status ) {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'failed' );
+		$order->update_meta_data( '_dispute_closed_status', $dispute_meta );
+		$order->save();
+
+		$subscription = WCS_Helper_Subscription::create_subscription(
+			[
+				'order_id' => $order->get_id(),
+			]
+		);
+
+		WC_Subscriptions_Manager::failed_subscription_sign_ups_for_order( $order->get_id() );
+
+		// Reload the subscription.
+		$subscription = wcs_get_subscription( $subscription->get_id() );
+		$this->assertTrue( $subscription->has_status( $expected_status ) );
+	}
+
+	/**
+	 * Provider for `test_failed_subscription_sign_ups_for_order` method.
+	 *
+	 * @return array
+	 */
+	public function provide_test_failed_subscription_sign_ups_for_order() {
+		return [
+			'order failed, dispute won'  => [
+				'dispute meta'    => 'won',
+				'expected status' => 'on-hold',
+			],
+			'order failed, dispute lost' => [
+				'dispute meta'    => 'lost',
+				'expected status' => 'cancelled',
+			],
+		];
+	}
+}


### PR DESCRIPTION
Fixes 4465-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

This PR correctly changes a subscription status when the related order loses a dispute. This is done by checking the current status of the subscription before updating it. If the status is `pending-cancel` we just update it to `cancelled`. 
<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should be enough. Check if the tests are still passing. I have included specific unit tests for this change.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
