### PR TITLE
Add hosted version of the batch processor controller and fix related unit tests

### DIFF
--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -210,7 +210,7 @@ class WCS_Notifications_Debug_Tool_Processor implements BatchProcessorInterface 
 	 * @param array $batch Batch to process, as returned by 'get_next_batch_to_process'.
 	 */
 	public function process_batch( array $batch ): void {
-		// This is a bit unnecessary. Perhaps convert `update_status` to static to avoid instantiating the class?
+
 		$subscriptions_notifications = new WCS_Action_Scheduler_Customer_Notifications();
 
 		foreach ( $batch as $subscription_id ) {

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -5,7 +5,7 @@
  *
  * @package  WooCommerce Subscriptions
  * @category Class
- * @since    8.0.0
+ * @since    x.x.x
  */
 class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -215,11 +215,16 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 	 */
 	public function process_batch( array $batch ): void {
 
-		$subscriptions_notifications = new WCS_Action_Scheduler_Customer_Notifications();
+		$subscriptions_notifications = WC_Subscriptions_Core_Plugin::instance()->notifications_scheduler;
 
 		foreach ( $batch as $subscription_id ) {
 			$subscription = wcs_get_subscription( $subscription_id );
-			$subscriptions_notifications->update_status( $subscription, $subscription->get_status(), null );
+
+			if ( WC_Subscriptions_Email_Notifications::notifications_globally_enabled() ) {
+				$subscriptions_notifications->update_status( $subscription, $subscription->get_status(), null );
+			} else {
+				$subscriptions_notifications->unschedule_all_notifications( $subscription );
+			}
 
 			// Update the subscription's update time to mark it as updated.
 			$subscription->set_date_modified( time() );

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -296,7 +296,7 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
 				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
 				'disabled' => true,
-				'desc'     => __( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler. Currently, there are no entries to convert.', 'woocommerce-subscriptions' ),
+				'desc'     => __( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler. Currently, there are no subscriptions to process.', 'woocommerce-subscriptions' ),
 			);
 		} elseif ( $batch_processor->is_enqueued( self::class ) ) {
 			$tools['stop_add_subscription_notifications'] = array(
@@ -304,7 +304,7 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 				'button'   => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
 				'desc'     =>
 				/* translators: %1$d=count of total entries needing conversion */
-					sprintf( __( 'Stopping this will halt the background process that adds notifications to pending, active, and on-hold subscriptions. %1$d of %2$d entries remain to be converted.', 'woocommerce-subscriptions' ), $pending_count, ( $pending_count + $total_done ) ),
+					sprintf( __( 'Stopping this will halt the background process that adds notifications to pending, active, and on-hold subscriptions. %1$d of %2$d subscriptions remain to be processed.', 'woocommerce-subscriptions' ), $pending_count, ( $pending_count + $total_done ) ),
 				'callback' => array( $this, 'dequeue' ),
 			);
 		} else {
@@ -313,7 +313,7 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
 				'desc'     =>
 				/* translators: %d=count of entries pending conversion */
-					sprintf( __( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler. Currently, there are %d entries available for conversion.', 'woocommerce-subscriptions' ), $pending_count ),
+					sprintf( __( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler. Currently, there are %d subscriptions to process.', 'woocommerce-subscriptions' ), $pending_count ),
 				'callback' => array( $this, 'enqueue' ),
 			);
 		}

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -164,10 +164,14 @@ class WC_Subscriptions_Core_Plugin {
 		add_action( 'plugins_loaded', 'WCS_Related_Order_Store::instance' );
 		add_action( 'plugins_loaded', 'WCS_Customer_Store::instance' );
 
+		// Initialise the batch processing controller.
+		add_action( 'init', 'WCS_Batch_Processing_Controller::instance' );
+
 		// Initialise the scheduler.
 		$scheduler_class = apply_filters( 'woocommerce_subscriptions_scheduler', 'WCS_Action_Scheduler' );
 		$this->scheduler = new $scheduler_class();
 
+		// Custom notifications scheduler.
 		$this->notifications_scheduler = new WCS_Action_Scheduler_Customer_Notifications();
 
 		// Initialise the cache.

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -171,7 +171,7 @@ class WC_Subscriptions_Core_Plugin {
 		$scheduler_class = apply_filters( 'woocommerce_subscriptions_scheduler', 'WCS_Action_Scheduler' );
 		$this->scheduler = new $scheduler_class();
 
-		// Custom notifications scheduler.
+		// Customer notifications scheduler.
 		$this->notifications_scheduler = new WCS_Action_Scheduler_Customer_Notifications();
 
 		// Initialise the cache.
@@ -533,7 +533,7 @@ class WC_Subscriptions_Core_Plugin {
 				update_option( WC_Subscriptions_admin::$option_prefix . '_paypal_debugging_default_set', 'true' );
 			}
 
-			// Enable customer notifications by default.
+			// Enable customer notifications by default for new stores.
 			if ( '0' === get_option( WC_Subscriptions_Admin::$option_prefix . '_previous_version', '0' ) && 'no' === get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'no' ) ) {
 				update_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'yes' );
 			}

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -529,16 +529,9 @@ class WC_Subscriptions_Core_Plugin {
 				update_option( WC_Subscriptions_admin::$option_prefix . '_paypal_debugging_default_set', 'true' );
 			}
 
-			// If this is the first time activating WooCommerce Subscription we want to enable the customer email notifications (default to 3 days before.)
-			if ( '0' === get_option( WC_Subscriptions_Admin::$option_prefix . '_previous_version', '0' ) && false === get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string, false ) ) {
+			// Enable customer notifications by default.
+			if ( '0' === get_option( WC_Subscriptions_Admin::$option_prefix . '_previous_version', '0' ) && 'no' === get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'no' ) ) {
 				update_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'yes' );
-				update_option(
-					WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
-					[
-						'number' => '3',
-						'unit'   => 'days',
-					]
-				);
 			}
 
 			update_option( WC_Subscriptions_Admin::$option_prefix . '_is_active', true );

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -21,6 +21,9 @@ class WC_Subscriptions_Email_Notifications {
 	 */
 	public static $switch_setting_string = '_customer_notifications_enabled';
 
+	/**
+	 * Init.
+	 */
 	public static function init() {
 
 		add_action( 'woocommerce_email_classes', __CLASS__ . '::add_emails', 10, 1 );
@@ -82,6 +85,9 @@ class WC_Subscriptions_Email_Notifications {
 		add_action( 'update_option_' . WC_Subscriptions_Admin::$option_prefix . self::$switch_setting_string, [ 'WC_Subscriptions_Email_Notifications', 'update_update_time' ] );
 	}
 
+	/**
+	 * Stores the timestamp that the self::$offset_setting_string was last updated.
+	 */
 	public static function update_update_time() {
 		update_option( 'wcs_notification_settings_update_time', time() );
 
@@ -102,12 +108,20 @@ class WC_Subscriptions_Email_Notifications {
 		return $email_classes;
 	}
 
+	/**
+	 * Hook the notification emails with our custom trigger.
+	 */
 	public static function hook_notification_emails() {
 		add_action( 'woocommerce_scheduled_subscription_customer_notification_renewal', [ __CLASS__, 'send_notification' ] );
 		add_action( 'woocommerce_scheduled_subscription_customer_notification_trial_expiration', [ __CLASS__, 'send_notification' ] );
 		add_action( 'woocommerce_scheduled_subscription_customer_notification_expiration', [ __CLASS__, 'send_notification' ] );
 	}
 
+	/**
+	 * Send the notification emails.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 */
 	public static function send_notification( $subscription_id ) {
 
 		// Init email classes.
@@ -144,6 +158,11 @@ class WC_Subscriptions_Email_Notifications {
 		}
 	}
 
+	/**
+	 * Is the notifications feature enabled?
+	 *
+	 * @return bool
+	 */
 	public static function notifications_globally_enabled() {
 		return ( 'yes' === get_option( WC_Subscriptions_Admin::$option_prefix . self::$switch_setting_string )
 				&& get_option( WC_Subscriptions_Admin::$option_prefix . self::$offset_setting_string ) );
@@ -186,8 +205,9 @@ class WC_Subscriptions_Email_Notifications {
 	}
 
 	/**
-	 * @param $subscription
+	 * Check if the subscription period is too short to send a renewal notification.
 	 *
+	 * @param $subscription
 	 * @return bool
 	 */
 	public static function subscription_period_too_short( $subscription ) {
@@ -195,7 +215,7 @@ class WC_Subscriptions_Email_Notifications {
 		$interval = $subscription->get_billing_interval();
 
 		// By default, there are no shorter periods than days in WCS, so we ignore hours, minutes, etc.
-		if ( $period <= 2 && 'day' === $interval ) {
+		if ( $interval <= 2 && 'day' === $period ) {
 			return true;
 		}
 

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -35,6 +35,7 @@ class WC_Subscriptions_Email_Notifications {
 
 		add_action( 'woocommerce_init', __CLASS__ . '::hook_notification_emails' );
 
+		// Add notification actions to the admin edit subscriptions page.
 		add_filter( 'woocommerce_order_actions', [ __CLASS__, 'add_notification_actions' ], 10, 1 );
 
 		// TODO this is a bit ugly...
@@ -99,7 +100,6 @@ class WC_Subscriptions_Email_Notifications {
 	 */
 	public static function add_emails( $email_classes ) {
 
-		// Customer notifications.
 		$email_classes['WCS_Email_Customer_Notification_Free_Trial_Expiration']   = new WCS_Email_Customer_Notification_Free_Trial_Expiration();
 		$email_classes['WCS_Email_Customer_Notification_Subscription_Expiration'] = new WCS_Email_Customer_Notification_Subscription_Expiration();
 		$email_classes['WCS_Email_Customer_Notification_Manual_Renewal']          = new WCS_Email_Customer_Notification_Manual_Renewal();

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -21,11 +21,6 @@ class WC_Subscriptions_Email_Notifications {
 	public static $switch_setting_string = '_customer_notifications_enabled';
 
 	/**
-	 * @var string Update time option identifier.
-	 */
-	public static $update_time_setting_string = '_notification_settings_update_time';
-
-	/**
 	 * Init.
 	 */
 	public static function init() {

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -200,7 +200,7 @@ class WC_Subscriptions_Email_Notifications {
 		 *
 		 * Values 'yes' or 'no' expected, since it works with WC_Settings_API.
 		 *
-		 * @since 8.0.0
+		 * @since x.x.x
 		 *
 		 * @param string $notification_enabled
 		 */
@@ -268,8 +268,6 @@ class WC_Subscriptions_Email_Notifications {
 
 	/**
 	 * Adds the subscription notification setting.
-	 *
-	 * @since 8.0.0
 	 *
 	 * @param  array $settings Subscriptions settings.
 	 * @return array Subscriptions settings.

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -37,7 +37,7 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		/**
 		 * Offset between a subscription event and related notification.
 		 *
-		 * @since 8.0.0
+		 * @since x.x.x
 		 *
 		 * @param int $time_offset
 		 */

--- a/includes/class-wcs-batch-processing-controller.php
+++ b/includes/class-wcs-batch-processing-controller.php
@@ -18,7 +18,7 @@
  *
  * @package  WooCommerce Subscriptions
  * @category Class
- * @since    8.0.0
+ * @since    x.x.x
  */
 class WCS_Batch_Processing_Controller {
 	/*
@@ -130,7 +130,7 @@ class WCS_Batch_Processing_Controller {
 			/**
 			 * Modify the delay interval for the batch processor's watchdog events.
 			 *
-			 * @since 8.0.0
+			 * @since x.x.x
 			 *
 			 * @param int $delay Time, in seconds, before the watchdog process will run. Defaults to 3600 (1 hour).
 			 */
@@ -466,7 +466,7 @@ class WCS_Batch_Processing_Controller {
 		 * @param array $error_context Context to be passed to the logging function.
 		 * @return string The actual error message that will be logged.
 		 *
-		 * @since 8.0.0
+		 * @since x.x.x
 		 */
 		$error_message = apply_filters( 'wcs_batch_processing_log_message', $error_message, $error, $batch_processor, $batch, $error_context );
 
@@ -487,7 +487,7 @@ class WCS_Batch_Processing_Controller {
 			 * process a batch that has resulted in a failure. Once above this threshold, the processor won't be
 			 * re-scheduled and will be removed from the queue.
 			 *
-			 * @since 8.0.0
+			 * @since x.x.x
 			 *
 			 * @param int $failure_threshold Maximum number of times for the processor to try processing a given batch.
 			 * @param WCS_Batch_Processor $batch_processor The processor instance.

--- a/includes/class-wcs-batch-processing-controller.php
+++ b/includes/class-wcs-batch-processing-controller.php
@@ -1,0 +1,572 @@
+<?php
+/**
+ * This class is a helper intended to handle data processings that need to happen in batches in a deferred way.
+ * It abstracts away the nuances of (re)scheduling actions and dealing with errors.
+ *
+ * Usage:
+ *
+ * 1. Create a class that implements WCS_Batch_Processor.
+ *
+ * 2. Whenever there's data to be processed invoke the 'enqueue_processor' method in this class,
+ *    passing the class name of the processor.
+ *
+ * That's it, processing will be performed in batches inside scheduled actions; enqueued processors will only
+ * be dequeued once they notify that no more items are left to process (or when `force_clear_all_processes` is invoked).
+ * Failed batches will be retried after a while.
+ *
+ * This is heavily inspired by core's version at Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController.
+ *
+ * @package  WooCommerce Subscriptions
+ * @category Class
+ * @since    8.0.0
+ */
+class WCS_Batch_Processing_Controller {
+	/*
+	 * Identifier of a "watchdog" action that will schedule a processing action
+	 * for any processor that is enqueued but not yet scheduled
+	 * (because it's been just enqueued or because it threw an error while processing a batch),
+	 * that's one single action that reschedules itself continuously.
+	 */
+	const WATCHDOG_ACTION_NAME = 'wcs_schedule_pending_batch_processes';
+
+	/*
+	 * Identifier of the action that will do the actual batch processing.
+	 * There's one action per enqueued processor that will keep rescheduling itself
+	 * as long as there are still pending items to process
+	 * (except if there's an error that caused no items to be processed at all).
+	 */
+	const PROCESS_SINGLE_BATCH_ACTION_NAME = 'wcs_run_batch_process';
+
+	const ENQUEUED_PROCESSORS_OPTION_NAME = 'wcs_pending_batch_processes';
+	const ACTION_GROUP                    = 'wcs_batch_processes';
+	const LOGS_CONTEXT                    = 'wcs-batch-processing';
+
+	/**
+	 * Maximum number of failures per processor before it gets dequeued.
+	 */
+	const FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT = 5;
+
+	/**
+	 * Instance of WC_Logger class.
+	 *
+	 * @var \WC_Logger_Interface
+	 */
+	private $logger;
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var WCS_Batch_Processing_Controller
+	 */
+	private static $instance;
+
+	/**
+	 * Constructor.
+	 *
+	 * Schedules the necessary actions to process batches.
+	 */
+	private function __construct() {
+		add_action(
+			self::WATCHDOG_ACTION_NAME,
+			function () {
+				$this->handle_watchdog_action();
+			}
+		);
+
+		add_action(
+			self::PROCESS_SINGLE_BATCH_ACTION_NAME,
+			function ( $batch_process ) {
+				$this->process_next_batch_for_single_processor( $batch_process );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'shutdown',
+			function () {
+				$this->remove_or_retry_failed_processors();
+			}
+		);
+
+		$this->logger = wc_get_logger();
+	}
+
+	/**
+	 * Get the singleton instance of this class.
+	 *
+	 * @return WCS_Batch_Processing_Controller
+	 */
+	final public static function instance(): WCS_Batch_Processing_Controller {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Enqueue a processor so that it will get batch processing requests from within scheduled actions.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the processor, must implement `WCS_Batch_Processor`.
+	 */
+	public function enqueue_processor( string $processor_class_name ): void {
+		$pending_updates = $this->get_enqueued_processors();
+		if ( ! in_array( $processor_class_name, array_keys( $pending_updates ), true ) ) {
+			$pending_updates[] = $processor_class_name;
+			$this->set_enqueued_processors( $pending_updates );
+		}
+		$this->schedule_watchdog_action( false, true );
+	}
+
+	/**
+	 * Schedule the watchdog action.
+	 *
+	 * @param bool $with_delay Whether to delay the action execution. Should be true when rescheduling, false when enqueueing.
+	 * @param bool $unique     Whether to make the action unique.
+	 */
+	private function schedule_watchdog_action( bool $with_delay = false, bool $unique = false ): void {
+		$time = time();
+		if ( $with_delay ) {
+			/**
+			 * Modify the delay interval for the batch processor's watchdog events.
+			 *
+			 * @since 8.0.0
+			 *
+			 * @param int $delay Time, in seconds, before the watchdog process will run. Defaults to 3600 (1 hour).
+			 */
+			$time += apply_filters( 'wcs_batch_processor_watchdog_delay_seconds', HOUR_IN_SECONDS );
+		}
+
+		if ( ! as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
+			as_schedule_single_action(
+				$time,
+				self::WATCHDOG_ACTION_NAME,
+				array(),
+				self::ACTION_GROUP,
+				$unique
+			);
+		}
+	}
+
+	/**
+	 * Schedule a processing action for all the processors that are enqueued but not scheduled
+	 * (because they have just been enqueued, or because the processing for a batch failed).
+	 */
+	private function handle_watchdog_action(): void {
+		$pending_processes = $this->get_enqueued_processors();
+		if ( empty( $pending_processes ) ) {
+			return;
+		}
+		foreach ( $pending_processes as $process_name ) {
+			if ( ! $this->is_scheduled( $process_name ) ) {
+				$this->schedule_batch_processing( $process_name );
+			}
+		}
+		$this->schedule_watchdog_action( true );
+	}
+
+	/**
+	 * Process a batch for a single processor, and handle any required rescheduling or state cleanup.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the processor.
+	 *
+	 * @throws \Exception If error occurred during batch processing.
+	 */
+	private function process_next_batch_for_single_processor( string $processor_class_name ): void {
+		if ( ! $this->is_enqueued( $processor_class_name ) ) {
+			return;
+		}
+
+		$batch_processor = $this->get_processor_instance( $processor_class_name );
+		$error           = $this->process_next_batch_for_single_processor_core( $batch_processor );
+		$still_pending   = count( $batch_processor->get_next_batch_to_process( 1 ) ) > 0;
+		if ( ( $error instanceof \Exception ) ) {
+			// The batch processing failed and no items were processed:
+			// reschedule the processing with a delay, unless this is a repeatead failure.
+			if ( $this->is_consistently_failing( $batch_processor ) ) {
+				$this->log_consistent_failure( $batch_processor, $this->get_process_details( $batch_processor ) );
+				$this->remove_processor( $processor_class_name );
+			} else {
+				$this->schedule_batch_processing( $processor_class_name, true );
+			}
+
+			throw $error;
+		}
+		if ( $still_pending ) {
+			$this->schedule_batch_processing( $processor_class_name );
+		} else {
+			$this->dequeue_processor( $processor_class_name );
+		}
+	}
+
+	/**
+	 * Process a batch for a single processor, updating state and logging any error.
+	 *
+	 * @param WCS_Batch_Processor $batch_processor Batch processor instance.
+	 *
+	 * @return null|\Exception Exception if error occurred, null otherwise.
+	 */
+	private function process_next_batch_for_single_processor_core( WCS_Batch_Processor $batch_processor ): ?\Exception {
+		$details    = $this->get_process_details( $batch_processor );
+		$time_start = microtime( true );
+		$batch      = $batch_processor->get_next_batch_to_process( $details['current_batch_size'] );
+		if ( empty( $batch ) ) {
+			return null;
+		}
+		try {
+			$batch_processor->process_batch( $batch );
+			$time_taken = microtime( true ) - $time_start;
+			$this->update_processor_state( $batch_processor, $time_taken );
+		} catch ( \Exception $exception ) {
+			$time_taken = microtime( true ) - $time_start;
+			$this->log_error( $exception, $batch_processor, $batch );
+			$this->update_processor_state( $batch_processor, $time_taken, $exception );
+			return $exception;
+		}
+		return null;
+	}
+
+	/**
+	 * Get the current state for a given enqueued processor.
+	 *
+	 * @param WCS_Batch_Processor $batch_processor Batch processor instance.
+	 *
+	 * @return array Current state for the processor, or a "blank" state if none exists yet.
+	 */
+	private function get_process_details( WCS_Batch_Processor $batch_processor ): array {
+		$defaults = array(
+			'total_time_spent'    => 0,
+			'current_batch_size'  => $batch_processor->get_default_batch_size(),
+			'last_error'          => null,
+			'recent_failures'     => 0,
+			'batch_first_failure' => null,
+			'batch_last_failure'  => null,
+		);
+
+		$process_details = get_option( $this->get_processor_state_option_name( $batch_processor ) );
+		$process_details = wp_parse_args( is_array( $process_details ) ? $process_details : array(), $defaults );
+
+		return $process_details;
+	}
+
+	/**
+	 * Get the name of the option where we will be saving state for a given processor.
+	 *
+	 * @param WCS_Batch_Processor|string $batch_processor Batch processor instance or class name.
+	 *
+	 * @return string Option name.
+	 */
+	private function get_processor_state_option_name( $batch_processor ): string {
+		$class_name = is_a( $batch_processor, WCS_Batch_Processor::class ) ? get_class( $batch_processor ) : $batch_processor;
+		$class_md5  = md5( $class_name );
+		// truncate the class name so we know that it will fit in the option name column along with md5 hash and prefix.
+		$class_name = substr( $class_name, 0, 140 );
+		return 'wcs_batch_' . $class_name . '_' . $class_md5;
+	}
+
+	/**
+	 * Update the state for a processor after a batch has completed processing.
+	 *
+	 * @param WCS_Batch_Processor $batch_processor Batch processor instance.
+	 * @param float                   $time_taken Time take by the batch to complete processing.
+	 * @param \Exception|null         $last_error Exception object in processing the batch, if there was one.
+	 */
+	private function update_processor_state( WCS_Batch_Processor $batch_processor, float $time_taken, \Exception $last_error = null ): void {
+		$current_status                      = $this->get_process_details( $batch_processor );
+		$current_status['total_time_spent'] += $time_taken;
+		$current_status['last_error']        = null !== $last_error ? $last_error->getMessage() : null;
+
+		if ( null !== $last_error ) {
+			$current_status['recent_failures']    = ( $current_status['recent_failures'] ?? 0 ) + 1;
+			$current_status['batch_last_failure'] = current_time( 'mysql' );
+
+			if ( is_null( $current_status['batch_first_failure'] ) ) {
+				$current_status['batch_first_failure'] = $current_status['batch_last_failure'];
+			}
+		} else {
+			$current_status['recent_failures']     = 0;
+			$current_status['batch_first_failure'] = null;
+			$current_status['batch_last_failure']  = null;
+		}
+
+		update_option( $this->get_processor_state_option_name( $batch_processor ), $current_status, false );
+	}
+
+	/**
+	 * Removes the option where we store state for a given processor.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the processor.
+	 */
+	private function clear_processor_state( string $processor_class_name ): void {
+		delete_option( $this->get_processor_state_option_name( $processor_class_name ) );
+	}
+
+	/**
+	 * Schedule a processing action for a single processor.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the processor.
+	 * @param bool   $with_delay   Whether to schedule the action for immediate execution or for later.
+	 */
+	private function schedule_batch_processing( string $processor_class_name, bool $with_delay = false ): void {
+		$time = $with_delay ? time() + MINUTE_IN_SECONDS : time();
+		as_schedule_single_action( $time, self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+	}
+
+	/**
+	 * Check if a batch processing action is already scheduled for a given processor.
+	 * Differs from `as_has_scheduled_action` in that this excludes actions in progress.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the batch processor.
+	 *
+	 * @return bool True if a batch processing action is already scheduled for the processor.
+	 */
+	public function is_scheduled( string $processor_class_name ): bool {
+		return as_has_scheduled_action( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+	}
+
+	/**
+	 * Get an instance of a processor given its class name.
+	 *
+	 * @param string $processor_class_name Full class name of the batch processor.
+	 *
+	 * @return WCS_Batch_Processor Instance of batch processor for the given class.
+	 * @throws \Exception If it's not possible to get an instance of the class.
+	 */
+	private function get_processor_instance( string $processor_class_name ): WCS_Batch_Processor {
+		if ( ! isset( $processor ) && class_exists( $processor_class_name ) ) {
+			// This is a fallback for when the batch processor is not registered in the container.
+			$processor = new $processor_class_name();
+		}
+		if ( ! is_a( $processor, WCS_Batch_Processor::class ) ) {
+			throw new \Exception( "Unable to initialize batch processor instance for $processor_class_name" );
+		}
+		return $processor;
+	}
+
+	/**
+	 * Helper method to get list of all the enqueued processors.
+	 *
+	 * @return array List (of string) of the class names of the enqueued processors.
+	 */
+	public function get_enqueued_processors(): array {
+		$enqueued_processors = get_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, array() );
+		if ( ! is_array( $enqueued_processors ) ) {
+			$this->logger->error( 'Could not fetch list of processors. Clearing up queue.', array( 'source' => self::LOGS_CONTEXT ) );
+			delete_option( self::ENQUEUED_PROCESSORS_OPTION_NAME );
+			$enqueued_processors = array();
+		}
+
+		return $enqueued_processors;
+	}
+
+	/**
+	 * Dequeue a processor once it has no more items pending processing.
+	 *
+	 * @param string $processor_class_name Full processor class name.
+	 */
+	private function dequeue_processor( string $processor_class_name ): void {
+		$pending_processes = $this->get_enqueued_processors();
+		if ( in_array( $processor_class_name, $pending_processes, true ) ) {
+			$this->clear_processor_state( $processor_class_name );
+			$pending_processes = array_diff( $pending_processes, array( $processor_class_name ) );
+			$this->set_enqueued_processors( $pending_processes );
+		}
+	}
+
+	/**
+	 * Helper method to set the enqueued processor class names.
+	 *
+	 * @param array $processors List of full processor class names.
+	 */
+	private function set_enqueued_processors( array $processors ): void {
+		update_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, $processors, false );
+	}
+
+	/**
+	 * Check if a particular processor is enqueued.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the processor.
+	 *
+	 * @return bool True if the processor is enqueued.
+	 */
+	public function is_enqueued( string $processor_class_name ): bool {
+		return in_array( $processor_class_name, $this->get_enqueued_processors(), true );
+	}
+
+	/**
+	 * Dequeue and de-schedule a processor instance so that it won't be processed anymore.
+	 *
+	 * @param string $processor_class_name Fully qualified class name of the processor.
+	 * @return bool True if the processor has been dequeued, false if the processor wasn't enqueued (so nothing has been done).
+	 */
+	public function remove_processor( string $processor_class_name ): bool {
+		$enqueued_processors = $this->get_enqueued_processors();
+		if ( ! in_array( $processor_class_name, $enqueued_processors, true ) ) {
+			return false;
+		}
+
+		$enqueued_processors = array_diff( $enqueued_processors, array( $processor_class_name ) );
+		if ( empty( $enqueued_processors ) ) {
+			$this->force_clear_all_processes();
+		} else {
+			update_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, $enqueued_processors, false );
+			as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME, array( $processor_class_name ) );
+			$this->clear_processor_state( $processor_class_name );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Dequeues and de-schedules all the processors.
+	 */
+	public function force_clear_all_processes(): void {
+		as_unschedule_all_actions( self::PROCESS_SINGLE_BATCH_ACTION_NAME );
+		as_unschedule_all_actions( self::WATCHDOG_ACTION_NAME );
+
+		foreach ( $this->get_enqueued_processors() as $processor ) {
+			$this->clear_processor_state( $processor );
+		}
+
+		update_option( self::ENQUEUED_PROCESSORS_OPTION_NAME, array(), false );
+	}
+
+	/**
+	 * Log an error that happened while processing a batch.
+	 *
+	 * @param \Exception              $error Exception object to log.
+	 * @param WCS_Batch_Processor $batch_processor Batch processor instance.
+	 * @param array                   $batch Batch that was being processed.
+	 */
+	protected function log_error( \Exception $error, WCS_Batch_Processor $batch_processor, array $batch ): void {
+		$error_message = "Error processing batch for {$batch_processor->get_name()}: {$error->getMessage()}";
+		$error_context = array(
+			'exception' => $error,
+			'source'    => self::LOGS_CONTEXT,
+		);
+
+		// Log only first and last, as the entire batch may be too big.
+		if ( count( $batch ) > 0 ) {
+			$error_context = array_merge(
+				$error_context,
+				array(
+					'batch_start' => $batch[0],
+					'batch_end'   => end( $batch ),
+				)
+			);
+		}
+
+		/**
+		 * Filters the error message for a batch processing.
+		 *
+		 * @param string $error_message The error message that will be logged.
+		 * @param \Exception $error The exception that was thrown by the processor.
+		 * @param WCS_Batch_Processor $batch_processor The processor that threw the exception.
+		 * @param array $batch The batch that was being processed.
+		 * @param array $error_context Context to be passed to the logging function.
+		 * @return string The actual error message that will be logged.
+		 *
+		 * @since 8.0.0
+		 */
+		$error_message = apply_filters( 'wcs_batch_processing_log_message', $error_message, $error, $batch_processor, $batch, $error_context );
+
+		$this->logger->error( $error_message, $error_context );
+	}
+
+	/**
+	 * Determines whether a given processor is consistently failing based on how many recent consecutive failures it has had.
+	 *
+	 * @param WCS_Batch_Processor $batch_processor The processor that we want to check.
+	 * @return boolean TRUE if processor is consistently failing. FALSE otherwise.
+	 */
+	private function is_consistently_failing( WCS_Batch_Processor $batch_processor ): bool {
+		$process_details = $this->get_process_details( $batch_processor );
+		$max_attempts    = absint(
+			/**
+			 * Controls the failure threshold for batch processors. That is, the number of times we'll attempt to
+			 * process a batch that has resulted in a failure. Once above this threshold, the processor won't be
+			 * re-scheduled and will be removed from the queue.
+			 *
+			 * @since 8.0.0
+			 *
+			 * @param int $failure_threshold Maximum number of times for the processor to try processing a given batch.
+			 * @param WCS_Batch_Processor $batch_processor The processor instance.
+			 * @param array $process_details Array with batch processor state.
+			 */
+			apply_filters(
+				'wcs_batch_processing_max_attempts',
+				self::FAILING_PROCESS_MAX_ATTEMPTS_DEFAULT,
+				$batch_processor,
+				$process_details
+			)
+		);
+
+		return absint( $process_details['recent_failures'] ?? 0 ) >= max( $max_attempts, 1 );
+	}
+
+	/**
+	 * Creates log entry with details about a batch processor that is consistently failing.
+	 *
+	 * @param WCS_Batch_Processor $batch_processor The batch processor instance.
+	 * @param array                   $process_details Failing process details.
+	 */
+	private function log_consistent_failure( WCS_Batch_Processor $batch_processor, array $process_details ): void {
+		$this->logger->error(
+			"Batch processor {$batch_processor->get_name()} appears to be failing consistently: {$process_details['recent_failures']} unsuccessful attempt(s). No further attempts will be made.",
+			array(
+				'source'        => self::LOGS_CONTEXT,
+				'failures'      => $process_details['recent_failures'],
+				'first_failure' => $process_details['batch_first_failure'],
+				'last_failure'  => $process_details['batch_last_failure'],
+			)
+		);
+	}
+
+	/**
+	 * Hooked onto 'shutdown'. This cleanup routine checks enqueued processors and whether they are scheduled or not to
+	 * either re-eschedule them or remove them from the queue.
+	 * This prevents stale states where Action Scheduler won't schedule any more attempts but we still report the
+	 * processor as enqueued.
+	 *
+	 */
+	private function remove_or_retry_failed_processors(): void {
+		if ( ! did_action( 'wp_loaded' ) ) {
+			return;
+		}
+
+		$last_error = error_get_last();
+		if ( ! is_null( $last_error ) && in_array( $last_error['type'], array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ), true ) ) {
+			return;
+		}
+
+		// The most efficient way to check for an existing action is to use `as_has_scheduled_action`, but in unusual
+		// cases where another plugin has loaded a very old version of Action Scheduler, it may not be available to us.
+		$has_scheduled_action = function_exists( 'as_has_scheduled_action' ) ? 'as_has_scheduled_action' : 'as_next_scheduled_action';
+
+		if ( call_user_func( $has_scheduled_action, self::WATCHDOG_ACTION_NAME ) ) {
+			return;
+		}
+
+		$enqueued_processors    = $this->get_enqueued_processors();
+		$unscheduled_processors = array_diff( $enqueued_processors, array_filter( $enqueued_processors, array( $this, 'is_scheduled' ) ) );
+
+		foreach ( $unscheduled_processors as $processor ) {
+			try {
+				$instance = $this->get_processor_instance( $processor );
+			} catch ( \Exception $e ) {
+				continue;
+			}
+
+			$exception = new \Exception( 'Processor is enqueued but not scheduled. Background job was probably killed or marked as failed. Reattempting execution.' );
+			$this->update_processor_state( $instance, 0, $exception );
+			$this->log_error( $exception, $instance, array() );
+
+			if ( $this->is_consistently_failing( $instance ) ) {
+				$this->log_consistent_failure( $instance, $this->get_process_details( $instance ) );
+				$this->remove_processor( $processor );
+			} else {
+				$this->schedule_batch_processing( $processor, true );
+			}
+		}
+	}
+}

--- a/includes/class-wcs-core-autoloader.php
+++ b/includes/class-wcs-core-autoloader.php
@@ -150,7 +150,8 @@ class WCS_Core_Autoloader {
 	 */
 	protected function is_class_interface( $class ) {
 		static $interfaces = array(
-			'wcs_cache_updater' => true,
+			'wcs_cache_updater'   => true,
+			'wcs_batch_processor' => true,
 		);
 
 		return isset( $interfaces[ $class ] );

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -44,7 +44,7 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 	 * @return string Datetime of the last time the notification settings were updated.
 	 */
 	public function get_notification_settings_update_time() {
-		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time', 0 );
+		$notification_settings_update_timestamp = get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$update_time_setting_string, 0 );
 		if ( 0 === $notification_settings_update_timestamp ) {
 			return '';
 		}

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -5,7 +5,7 @@
  *
  * @package  WooCommerce Subscriptions
  * @category Class
- * @since    8.0.0
+ * @since    x.x.x
  */
 class WCS_Notifications_Batch_Processor implements WCS_Batch_Processor {
 

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -1,9 +1,13 @@
 <?php
 
-use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
-use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
-
-class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
+/**
+ * WooCommerce Subscriptions Notifications Batch Processor.
+ *
+ * @package  WooCommerce Subscriptions
+ * @category Class
+ * @since    8.0.0
+ */
+class WCS_Notifications_Batch_Processor implements WCS_Batch_Processor {
 
 	/**
 	 * Get a user-friendly name for this processor.
@@ -78,12 +82,12 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 				$wpdb->prepare(
 					"SELECT 
-								COUNT(*) 
-							FROM {$wpdb->prefix}wc_orders 
-							WHERE type='shop_subscription'
-							AND date_updated_gmt < %s
-							AND status IN ($placeholders)
-							",
+						COUNT(*) 
+					FROM {$wpdb->prefix}wc_orders 
+					WHERE type='shop_subscription'
+					AND date_updated_gmt < %s
+					AND status IN ($placeholders)
+					",
 					$this->get_notification_settings_update_time(),
 					...$allowed_statuses
 				)
@@ -94,12 +98,12 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 				$wpdb->prepare(
 					"SELECT 
-								COUNT(*) 
-							FROM {$wpdb->prefix}posts 
-							WHERE post_type='shop_subscription'
-							AND post_modified_gmt < %s
-							AND post_status IN ($placeholders)
-							",
+						COUNT(*) 
+					FROM {$wpdb->prefix}posts 
+					WHERE post_type='shop_subscription'
+					AND post_modified_gmt < %s
+					AND post_status IN ($placeholders)
+					",
 					$this->get_notification_settings_update_time(),
 					...$allowed_statuses
 				)
@@ -145,13 +149,13 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 				$wpdb->prepare(
 					"SELECT 
-								id
-							FROM {$wpdb->prefix}wc_orders 
-							WHERE type='shop_subscription'
-							AND date_updated_gmt < %s
-							AND status IN ($placeholders)
-							ORDER BY id ASC
-							LIMIT %d",
+						id
+					FROM {$wpdb->prefix}wc_orders 
+					WHERE type='shop_subscription'
+					AND date_updated_gmt < %s
+					AND status IN ($placeholders)
+					ORDER BY id ASC
+					LIMIT %d",
 					...$args
 				)
 			);
@@ -161,13 +165,13 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 				$wpdb->prepare(
 					"SELECT 
-								ID
-							FROM {$wpdb->prefix}posts 
-							WHERE post_type='shop_subscription'
-							AND post_modified_gmt < %s
-							AND post_status IN ($placeholders)
-							ORDER BY ID ASC
-							LIMIT %d",
+						ID
+					FROM {$wpdb->prefix}posts 
+					WHERE post_type='shop_subscription'
+					AND post_modified_gmt < %s
+					AND post_status IN ($placeholders)
+					ORDER BY ID ASC
+					LIMIT %d",
 					...$args
 				)
 			);
@@ -224,7 +228,7 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 	 * @return string Informative string to show after the tool is triggered in UI.
 	 */
 	public static function enqueue(): string {
-		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		$batch_processor = WCS_Batch_Processing_Controller::instance();
 		if ( $batch_processor->is_enqueued( self::class ) ) {
 			return __( 'Background process for updating subscritpion notifications already started, nothing done.', 'woocommerce-subscriptions' );
 		}
@@ -239,7 +243,7 @@ class WCS_Notifications_Batch_Processor implements BatchProcessorInterface {
 	 * @return string Informative string to show after the tool is triggered in UI.
 	 */
 	public static function dequeue(): string {
-		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		$batch_processor = WCS_Batch_Processing_Controller::instance();
 		if ( ! $batch_processor->is_enqueued( self::class ) ) {
 			return __( 'Background process for updating subscritpion notifications not started, nothing done.', 'woocommerce-subscriptions' );
 		}

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -48,7 +48,7 @@ class WCS_Notifications_Batch_Processor implements WCS_Batch_Processor {
 	 * @return string Datetime of the last time the notification settings were updated.
 	 */
 	public function get_notification_settings_update_time() {
-		$notification_settings_update_timestamp = get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$update_time_setting_string, 0 );
+		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time', 0 );
 		if ( 0 === $notification_settings_update_timestamp ) {
 			return '';
 		}

--- a/includes/interfaces/interface-wcs-batch-processor.php
+++ b/includes/interfaces/interface-wcs-batch-processor.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WCS_Batch_Processor Interface
+ *
+ * Interface for batch data processors. See the WCS_Batch_Processing_Controller class for usage details.
+ *
+ * @package  WooCommerce Subscriptions
+ * @version  8.0.0
+ * @since    8.0.0
+ */
+interface WCS_Batch_Processor {
+
+	/**
+	 * Get a user-friendly name for this processor.
+	 *
+	 * @return string Name of the processor.
+	 */
+	public function get_name() : string;
+
+	/**
+	 * Get a user-friendly description for this processor.
+	 *
+	 * @return string Description of what this processor does.
+	 */
+	public function get_description() : string;
+
+	/**
+	 * Get the total number of pending items that require processing.
+	 * Once an item is successfully processed by 'process_batch' it shouldn't be included in this count.
+	 *
+	 * Note that the once the processor is enqueued the batch processor controller will keep
+	 * invoking `get_next_batch_to_process` and `process_batch` repeatedly until this method returns zero.
+	 *
+	 * @return int Number of items pending processing.
+	 */
+	public function get_total_pending_count() : int;
+
+	/**
+	 * Returns the next batch of items that need to be processed.
+	 *
+	 * A batch item can be anything needed to identify the actual processing to be done,
+	 * but whenever possible items should be numbers (e.g. database record ids)
+	 * or at least strings, to ease troubleshooting and logging in case of problems.
+	 *
+	 * The size of the batch returned can be less than $size if there aren't that
+	 * many items pending processing (and it can be zero if there isn't anything to process),
+	 * but the size should always be consistent with what 'get_total_pending_count' returns
+	 * (i.e. the size of the returned batch shouldn't be larger than the pending items count).
+	 *
+	 * @param int $size Maximum size of the batch to be returned.
+	 *
+	 * @return array Batch of items to process, containing $size or less items.
+	 */
+	public function get_next_batch_to_process( int $size ) : array;
+
+	/**
+	 * Process data for the supplied batch.
+	 *
+	 * This method should be prepared to receive items that don't actually need processing
+	 * (because they have been processed before) and ignore them, but if at least
+	 * one of the batch items that actually need processing can't be processed, an exception should be thrown.
+	 *
+	 * Once an item has been processed it shouldn't be counted in 'get_total_pending_count'
+	 * nor included in 'get_next_batch_to_process' anymore (unless something happens that causes it
+	 * to actually require further processing).
+	 *
+	 * @throw \Exception Something went wrong while processing the batch.
+	 *
+	 * @param array $batch Batch to process, as returned by 'get_next_batch_to_process'.
+	 */
+	public function process_batch( array $batch ): void;
+
+	/**
+	 * Default (preferred) batch size to pass to 'get_next_batch_to_process'.
+	 * The controller will pass this size unless it's externally configured
+	 * to use a different size.
+	 *
+	 * @return int Default batch size.
+	 */
+	public function get_default_batch_size() : int;
+}

--- a/includes/interfaces/interface-wcs-batch-processor.php
+++ b/includes/interfaces/interface-wcs-batch-processor.php
@@ -5,8 +5,8 @@
  * Interface for batch data processors. See the WCS_Batch_Processing_Controller class for usage details.
  *
  * @package  WooCommerce Subscriptions
- * @version  8.0.0
- * @since    8.0.0
+ * @version  x.x.x
+ * @since    x.x.x
  */
 interface WCS_Batch_Processor {
 

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -5,6 +5,35 @@ use PHPUnit\Framework\TestCase;
 class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 
 	/**
+	 * Sanity check the controller first.
+	 *
+	 * @covers WCS_Notifications_Debug_Tool_Processor::process_batch
+	 *
+	 * @param array $data
+	 * @return bool
+	 */
+	public function test_batch_processesing_controller() {
+
+		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
+
+		$batch_processor = WCS_Batch_Processing_Controller::instance();
+		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
+
+		// Enqueue the processor.
+		$batch_processor->enqueue_processor( WCS_Notifications_Debug_Tool_Processor::class );
+
+		$this->assertTrue( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
+
+		// Process.
+		$reflection                              = new ReflectionClass( $batch_processor );
+		$process_next_batch_for_single_processor = $reflection->getMethod( 'process_next_batch_for_single_processor' );
+		$process_next_batch_for_single_processor->setAccessible( true );
+		$process_next_batch_for_single_processor->invoke( $batch_processor, WCS_Notifications_Debug_Tool_Processor::class );
+
+		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
+	}
+
+	/**
 	 * Test the "WCS_Notifications_Debug_Tool_Processor::process_batch()" method.
 	 *
 	 * @covers WCS_Notifications_Debug_Tool_Processor::process_batch

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -14,16 +14,6 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 	 */
 	public function test_process_batch_notifications() {
 
-		// Enable feature.
-		update_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'yes' );
-		update_option(
-			WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
-			[
-				'number' => '3',
-				'unit'   => 'days',
-			]
-		);
-
 		$batches   = $this->notification_subscription_data_provider();
 		$processor = new WCS_Notifications_Debug_Tool_Processor();
 

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -1,7 +1,5 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 
 	/**

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -4,13 +4,8 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 
 	/**
 	 * Sanity check the controller first.
-	 *
-	 * @covers WCS_Notifications_Debug_Tool_Processor::process_batch
-	 *
-	 * @param array $data
-	 * @return bool
 	 */
-	public function test_batch_processesing_controller() {
+	public function test_batch_processing_controller() {
 
 		$batch_processor = WCS_Batch_Processing_Controller::instance();
 		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
@@ -31,11 +26,6 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test the "WCS_Notifications_Debug_Tool_Processor::process_batch()" method.
-	 *
-	 * @covers WCS_Notifications_Debug_Tool_Processor::process_batch
-	 *
-	 * @param array $data
-	 * @return bool
 	 */
 	public function test_process_batch_notifications() {
 
@@ -45,7 +35,7 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 		foreach ( $batches as $batch ) {
 			$subscription = $batch['subscription'];
 			$action_name  = $batch['action_name'];
-			$action_args  = [ 'subscription_id' => $subscription->get_id() ];
+			$action_args  = \WC_Subscriptions_Core_Plugin::instance()->notifications_scheduler::get_action_args( $subscription );
 
 			$has_notification = false !== as_next_scheduled_action( $action_name, $action_args, 'wcs_customer_notifications' );
 			$this->assertTrue( $has_notification );
@@ -178,7 +168,7 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 
 		$simple_subscription->update_dates(
 			[
-				'next_payment' => '2034-09-20 08:08:08',
+				'next_payment' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
 			]
 		);
 
@@ -188,13 +178,13 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 		$free_trial_subscription = WCS_Helper_Subscription::create_subscription(
 			[
 				'status'     => 'active',
-				'start_date' => '2024-09-10 08:08:08',
+				'start_date' => gmdate( 'Y-m-d H:i:s' ),
 			]
 		);
 
 		$free_trial_subscription->update_dates(
 			[
-				'trial_end' => '2034-09-20 08:08:08',
+				'trial_end' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
 			]
 		);
 
@@ -204,13 +194,13 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 		$expiry_subscription = WCS_Helper_Subscription::create_subscription(
 			[
 				'status'     => 'active',
-				'start_date' => '2024-09-10 08:08:08',
+				'start_date' => gmdate( 'Y-m-d H:i:s' ),
 			]
 		);
 
 		$expiry_subscription->update_dates(
 			[
-				'end' => '2034-09-20 08:08:08',
+				'end' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
 			]
 		);
 

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -21,6 +21,7 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 		$process_next_batch_for_single_processor->setAccessible( true );
 		$process_next_batch_for_single_processor->invoke( $batch_processor, WCS_Notifications_Debug_Tool_Processor::class );
 
+		// Ensure that the processor is dequeued after processing done.
 		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
 	}
 

--- a/tests/unit/test-wcs-notifications-debug-tool.php
+++ b/tests/unit/test-wcs-notifications-debug-tool.php
@@ -12,8 +12,6 @@ class WCS_Subscription_Notifications_Debug_Tool_Test extends WP_UnitTestCase {
 	 */
 	public function test_batch_processesing_controller() {
 
-		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
-
 		$batch_processor = WCS_Batch_Processing_Controller::instance();
 		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Debug_Tool_Processor::class ) );
 

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -1,0 +1,104 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test should send notification.
+	 */
+	public function test_should_send_notification() {
+		add_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_false' );
+		$should = WC_Subscriptions_Email_Notifications::should_send_notification();
+		$this->assertFalse( $should );
+
+		$this->enable_notifications_globally();
+
+		$should = WC_Subscriptions_Email_Notifications::should_send_notification();
+		$this->assertTrue( $should );
+		remove_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_false' );
+	}
+
+	/**
+	 * Test the update time sync.
+	 */
+	public function test_update_time_sync() {
+		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time' );
+		$this->assertFalse( $notification_settings_update_timestamp );
+
+		// Update the timestamp.
+		$this->enable_notifications_globally();
+
+		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time' );
+		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
+		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp );
+	}
+
+	/**
+	 * Test subscription period too short.
+	 */
+	public function test_subscription_period_too_short() {
+		$subscription1 = WCS_Helper_Subscription::create_subscription(
+			[
+				'status'           => 'active',
+				'start_date'       => '2024-09-10 08:08:08',
+				'billing_period'   => 'day',
+				'billing_interval' => 1,
+			]
+		);
+
+		$too_short1 = WC_Subscriptions_Email_Notifications::subscription_period_too_short( $subscription1 );
+		$this->assertTrue( $too_short1 );
+
+		$subscription2 = WCS_Helper_Subscription::create_subscription(
+			[
+				'billing_period'   => 'day',
+				'billing_interval' => 2,
+			]
+		);
+
+		$too_short2 = WC_Subscriptions_Email_Notifications::subscription_period_too_short( $subscription2 );
+		$this->assertTrue( $too_short2 );
+
+		$subscription3 = WCS_Helper_Subscription::create_subscription(
+			[
+				'billing_period'   => 'day',
+				'billing_interval' => 3,
+			]
+		);
+
+		$too_short3 = WC_Subscriptions_Email_Notifications::subscription_period_too_short( $subscription3 );
+		$this->assertFalse( $too_short3 );
+	}
+
+	/**
+	 * Test subscription period too long.
+	 */
+	public function test_notifications_globally_enabled() {
+		$enabled = WC_Subscriptions_Email_Notifications::notifications_globally_enabled();
+		$this->assertFalse( $enabled );
+
+		$this->enable_notifications_globally();
+		$enabled = WC_Subscriptions_Email_Notifications::notifications_globally_enabled();
+		$this->assertTrue( $enabled );
+	}
+
+	/**
+	 * Helper to enable notifications globally.
+	 * TODO: We should create global helpers?
+	 *
+	 * @return void
+	 */
+	protected function enable_notifications_globally(
+		$default_value = [
+			'number' => '3',
+			'unit'   => 'days',
+		]
+	) {
+		update_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'yes' );
+		update_option(
+			WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
+			$default_value
+		);
+	}
+}

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -23,15 +23,28 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	 * Test the update time sync.
 	 */
 	public function test_update_time_sync() {
-		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time' );
+		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
 		$this->assertFalse( $notification_settings_update_timestamp );
 
 		// Update the timestamp.
 		$this->enable_notifications_globally();
 
-		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time' );
+		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
 		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
 		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp );
+
+		// Update the timestamp again.
+		$this->enable_notifications_globally(
+			[
+				'number' => '4',
+				'unit'   => 'days',
+			]
+		);
+
+		$notification_settings_update_timestamp2 = get_option( 'woocommerce_notification_settings_update_time' );
+		$this->assertTrue( is_numeric( $notification_settings_update_timestamp2 ) );
+		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp2 );
+		$this->assertGreaterThan( $notification_settings_update_timestamp, $notification_settings_update_timestamp2 );
 	}
 
 	/**

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -23,17 +23,12 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	 * Test the update time sync.
 	 */
 	public function test_update_time_sync() {
-		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
-		$this->assertFalse( $notification_settings_update_timestamp );
 
-		// Update the timestamp.
-		$this->enable_notifications_globally();
-
+		// Test installation provisioning.
 		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
 		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
-		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp );
 
-		// Update the timestamp again.
+		// Update the timestamp.
 		$this->enable_notifications_globally(
 			[
 				'number' => '4',
@@ -41,10 +36,9 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$notification_settings_update_timestamp2 = get_option( 'woocommerce_notification_settings_update_time' );
-		$this->assertTrue( is_numeric( $notification_settings_update_timestamp2 ) );
-		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp2 );
-		$this->assertGreaterThan( $notification_settings_update_timestamp, $notification_settings_update_timestamp2 );
+		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
+		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
+		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp );
 	}
 
 	/**
@@ -113,5 +107,14 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 			WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
 			$default_value
 		);
+	}
+
+	/**
+	 * Helper to enable notifications globally.
+	 *
+	 * @return void
+	 */
+	protected function disable_notifications_globally() {
+		update_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$switch_setting_string, 'no' );
 	}
 }

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -23,7 +23,7 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	public function test_update_time_sync() {
 
 		// Test installation provisioning.
-		$notification_settings_update_timestamp = get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$update_time_setting_string );
+		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time' );
 		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
 
 		// Update the timestamp.
@@ -34,7 +34,7 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$notification_settings_update_timestamp = get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$update_time_setting_string );
+		$notification_settings_update_timestamp = get_option( 'wcs_notification_settings_update_time' );
 		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
 		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp );
 	}

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -77,7 +77,7 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test subscription period too long.
+	 * Test global subscription notification switch.
 	 */
 	public function test_notifications_globally_enabled() {
 		$enabled = WC_Subscriptions_Email_Notifications::notifications_globally_enabled();

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -10,12 +10,12 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	public function test_should_send_notification() {
 		add_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_false' );
 		$should = WC_Subscriptions_Email_Notifications::should_send_notification();
-		$this->assertFalse( $should );
+		$this->assertTrue( $should );
 
-		$this->enable_notifications_globally();
+		$this->disable_notifications_globally();
 
 		$should = WC_Subscriptions_Email_Notifications::should_send_notification();
-		$this->assertTrue( $should );
+		$this->assertFalse( $should );
 		remove_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_false' );
 	}
 
@@ -25,7 +25,7 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	public function test_update_time_sync() {
 
 		// Test installation provisioning.
-		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
+		$notification_settings_update_timestamp = get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$update_time_setting_string );
 		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
 
 		// Update the timestamp.
@@ -36,7 +36,7 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$notification_settings_update_timestamp = get_option( 'woocommerce_notification_settings_update_time' );
+		$notification_settings_update_timestamp = get_option( WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$update_time_setting_string );
 		$this->assertTrue( is_numeric( $notification_settings_update_timestamp ) );
 		$this->assertLessThanOrEqual( time(), $notification_settings_update_timestamp );
 	}
@@ -83,11 +83,11 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	 */
 	public function test_notifications_globally_enabled() {
 		$enabled = WC_Subscriptions_Email_Notifications::notifications_globally_enabled();
-		$this->assertFalse( $enabled );
-
-		$this->enable_notifications_globally();
-		$enabled = WC_Subscriptions_Email_Notifications::notifications_globally_enabled();
 		$this->assertTrue( $enabled );
+
+		$this->disable_notifications_globally();
+		$enabled = WC_Subscriptions_Email_Notifications::notifications_globally_enabled();
+		$this->assertFalse( $enabled );
 	}
 
 	/**

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -1,7 +1,5 @@
 <?php
 
-use PHPUnit\Framework\TestCase;
-
 class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 
 	/**

--- a/tests/unit/test-wcs-notifications-processor.php
+++ b/tests/unit/test-wcs-notifications-processor.php
@@ -90,7 +90,7 @@ class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 		foreach ( $batches as $batch ) {
 			$subscription = $batch['subscription'];
 			$action_name  = $batch['action_name'];
-			$action_args  = [ 'subscription_id' => $subscription->get_id() ];
+			$action_args  = \WC_Subscriptions_Core_Plugin::instance()->notifications_scheduler::get_action_args( $subscription );
 
 			// First iteration doesn't have the notification scheduled, since the feature was disabled during the creation.
 			$has_notification = false !== as_next_scheduled_action( $action_name, $action_args, 'wcs_customer_notifications' );

--- a/tests/unit/test-wcs-notifications-processor.php
+++ b/tests/unit/test-wcs-notifications-processor.php
@@ -145,7 +145,7 @@ class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 
 		$simple_subscription->update_dates(
 			[
-				'next_payment' => '2034-09-20 08:08:08',
+				'next_payment' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
 			]
 		);
 
@@ -155,13 +155,13 @@ class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 		$free_trial_subscription = WCS_Helper_Subscription::create_subscription(
 			[
 				'status'     => 'active',
-				'start_date' => '2024-09-10 08:08:08',
+				'start_date' => gmdate( 'Y-m-d H:i:s' ),
 			]
 		);
 
 		$free_trial_subscription->update_dates(
 			[
-				'trial_end' => '2034-09-20 08:08:08',
+				'trial_end' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
 			]
 		);
 
@@ -171,13 +171,13 @@ class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 		$expiry_subscription = WCS_Helper_Subscription::create_subscription(
 			[
 				'status'     => 'active',
-				'start_date' => '2024-09-10 08:08:08',
+				'start_date' => gmdate( 'Y-m-d H:i:s' ),
 			]
 		);
 
 		$expiry_subscription->update_dates(
 			[
-				'end' => '2034-09-20 08:08:08',
+				'end' => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
 			]
 		);
 

--- a/tests/unit/test-wcs-notifications-processor.php
+++ b/tests/unit/test-wcs-notifications-processor.php
@@ -89,7 +89,7 @@ class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 		$batches   = $this->notification_subscription_data_provider();
 		$processor = new WCS_Notifications_Debug_Tool_Processor();
 
-		// Important: Give some time to diff the update timestamp with the post_modified fields.
+		// Important: Give some time to differentiate the update timestamp with the post_modified fields.
 		sleep( 1 );
 		$this->enable_notifications_globally();
 

--- a/tests/unit/test-wcs-notifications-processor.php
+++ b/tests/unit/test-wcs-notifications-processor.php
@@ -1,19 +1,17 @@
 <?php
 
-use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
-
 class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test processor queued when notifications are enabled.
 	 */
 	public function test_processor_queued() {
-		$batch_processor = wc_get_container()->get( BatchProcessingController::class );
+		$batch_processor = WCS_Batch_Processing_Controller::instance();
 
 		// Test initial state.
 		$this->assertTrue( $batch_processor->is_enqueued( WCS_Notifications_Batch_Processor::class ) );
 		// Run.
-		do_action( 'wc_run_batch_process', WCS_Notifications_Batch_Processor::class );
+		do_action( 'wcs_run_batch_process', WCS_Notifications_Batch_Processor::class );
 
 		// Check that is dequeued.
 		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Batch_Processor::class ) );
@@ -31,7 +29,7 @@ class WCS_Subscription_Notifications_Processor_Test extends WP_UnitTestCase {
 		$this->assertTrue( $batch_processor->is_enqueued( WCS_Notifications_Batch_Processor::class ) );
 
 		// Run.
-		do_action( 'wc_run_batch_process', WCS_Notifications_Batch_Processor::class );
+		do_action( 'wcs_run_batch_process', WCS_Notifications_Batch_Processor::class );
 
 		// Check that is dequeued.
 		$this->assertFalse( $batch_processor->is_enqueued( WCS_Notifications_Batch_Processor::class ) );


### PR DESCRIPTION
## Description

This pull request brings a hosted version of core's [BatchProcessingController](https://github.com/woocommerce/woocommerce/blob/37bb36994b08d417e34b9043fea0bf92a3f9c236/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php#L29) as `WCS_Batch_Processing_Controller` together with a new `WCS_Batch_Processor` interface. It also addressed required changes for the unit tests, adds more coverage, and fixes the provisioning for new installations.

### Reason for moving these interfaces

Before [this](https://github.com/woocommerce/woocommerce/pull/46975) fix was introduced (which was implemented in WC v9.0), the batch processing controller in Core could only work with "namespaced" processors. To avoid using polyfill classes, we decided to transfer the functionality to WCS for better stability. Plus, using internal-namespaced classes is considered an antipattern, so moving the functionality was the most direct solution.

## How to test this PR

Unit Tests 
+
Exploratory testing. Some suggested steps:
- Change the offset or enable it if it's disabled.
- Keep an eye on AS actions in the "Tools > Scheduled Actions" table.
- Observe any changes made to AS actions.
- Now, delete any notification-related AS actions.
- Go to "WooCommerce > Status > Tools" and click on the "Add notifications" tool.
- Keep an eye on the AS actions.
- Confirm that the expected AS actions are restored after the batcher has run.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
