### PR TITLE
Tests for possible fatal errors when getting order

### DIFF
--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1307,15 +1307,19 @@ class WCS_Cart_Renewal {
 			return;
 		}
 
-		$cart_fees = $cart->get_fees();
+		$renewal_order = $this->get_order();
+
+		if ( ! $renewal_order ) {
+			return;
+		}
 
 		// Fees are naturally recurring if they have been applied to the renewal order. Generate a key (name + amount) for each fee applied to the order.
 		$renewal_order_fees = array();
-		if ($this->get_order()){ // fatal error casued by the foreach, if get_order returns false
-			foreach ( $this->get_order()->get_fees() as $item_id => $fee_line_item ) {
-				$renewal_order_fees[ $item_id ] = $fee_line_item->get_name() . wc_format_decimal( $fee_line_item->get_total() );
-			}
-	        }
+		$cart_fees          = $cart->get_fees();
+
+		foreach ( $renewal_order->get_fees() as $item_id => $fee_line_item ) {
+			$renewal_order_fees[ $item_id ] = $fee_line_item->get_name() . wc_format_decimal( $fee_line_item->get_total() );
+		}
 
 		// WC doesn't have a method for removing fees individually so we clear them and re-add them where applicable.
 		if ( is_callable( array( $cart, 'fees_api' ) ) ) { // WC 3.2 +

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1311,9 +1311,11 @@ class WCS_Cart_Renewal {
 
 		// Fees are naturally recurring if they have been applied to the renewal order. Generate a key (name + amount) for each fee applied to the order.
 		$renewal_order_fees = array();
-		foreach ( $this->get_order()->get_fees() as $item_id => $fee_line_item ) {
-			$renewal_order_fees[ $item_id ] = $fee_line_item->get_name() . wc_format_decimal( $fee_line_item->get_total() );
-		}
+		if ($this->get_order()){ // fatal error casued by the foreach, if get_order returns false
+			foreach ( $this->get_order()->get_fees() as $item_id => $fee_line_item ) {
+				$renewal_order_fees[ $item_id ] = $fee_line_item->get_name() . wc_format_decimal( $fee_line_item->get_total() );
+			}
+	        }
 
 		// WC doesn't have a method for removing fees individually so we clear them and re-add them where applicable.
 		if ( is_callable( array( $cart, 'fees_api' ) ) ) { // WC 3.2 +

--- a/includes/wcs-renewal-functions.php
+++ b/includes/wcs-renewal-functions.php
@@ -108,10 +108,11 @@ function wcs_cart_contains_failed_renewal_order_payment() {
 	$cart_item        = wcs_cart_contains_renewal();
 
 	if ( false !== $cart_item && isset( $cart_item['subscription_renewal']['renewal_order_id'] ) ) {
-		$renewal_order           = wc_get_order( $cart_item['subscription_renewal']['renewal_order_id'] );
-		if ($renewal_order){ //test for fatal error if wc_get_order doesn't return an order object
+		$renewal_order = wc_get_order( $cart_item['subscription_renewal']['renewal_order_id'] );
+
+		if ( $renewal_order ) {
 			$is_failed_renewal_order = apply_filters( 'woocommerce_subscriptions_is_failed_renewal_order', $renewal_order->has_status( 'failed' ), $cart_item['subscription_renewal']['renewal_order_id'], $renewal_order->get_status() );
-	
+
 			if ( $is_failed_renewal_order ) {
 				$contains_renewal = $cart_item;
 			}

--- a/includes/wcs-renewal-functions.php
+++ b/includes/wcs-renewal-functions.php
@@ -109,10 +109,12 @@ function wcs_cart_contains_failed_renewal_order_payment() {
 
 	if ( false !== $cart_item && isset( $cart_item['subscription_renewal']['renewal_order_id'] ) ) {
 		$renewal_order           = wc_get_order( $cart_item['subscription_renewal']['renewal_order_id'] );
-		$is_failed_renewal_order = apply_filters( 'woocommerce_subscriptions_is_failed_renewal_order', $renewal_order->has_status( 'failed' ), $cart_item['subscription_renewal']['renewal_order_id'], $renewal_order->get_status() );
-
-		if ( $is_failed_renewal_order ) {
-			$contains_renewal = $cart_item;
+		if ($renewal_order){ //test for fatal error if wc_get_order doesn't return an order object
+			$is_failed_renewal_order = apply_filters( 'woocommerce_subscriptions_is_failed_renewal_order', $renewal_order->has_status( 'failed' ), $cart_item['subscription_renewal']['renewal_order_id'], $renewal_order->get_status() );
+	
+			if ( $is_failed_renewal_order ) {
+				$contains_renewal = $cart_item;
+			}
 		}
 	}
 


### PR DESCRIPTION
Submitting PR per support request

## Description

Encountered in the wild, I found an issue where fatal PHP errors could be thrown from class-wcs-cart-renewal on line 1314 and wcs-renewal-functions on line 112. 
This resulted in one customer in particular encountering a fatal error on all page requests immediately after logging in.


PHP Fatal error:  Uncaught Error: Call to a member function get_fees() on bool in
/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/class-wcs-cart-renewal.php:1314

PHP Fatal error:  Uncaught Error: Call to a member function has_status() on bool in
/wp-content/plugins/woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/wcs-renewal-functions.php:112


The submitted change checks that an order is preset before attempting to call methods that would result in a 500 error if the order is false.


## How to test this PR

How to replicate the apparent issue with a past order isn't known but suspect it was due to a manual deletion or cancellation of a past subscription via the admin. 

Tested the patch live on the site which had this problem by signing in as that user, used the site as normal, no other issues found. 
