### PR TITLE
Prevents fatal error from occurring when calling the `get_total_tax_refunded()` data store function.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Correctly updates a subscription status to `cancelled` during a payment failure call when the current status is `pending-cancel`.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.
 * Fix - Prevent deprecation notices after updating to WooCommerce 9.3.
+* Fix - Prevent PHP fatal error that occurs when calculating the total tax refunded on a subscription.
 * Dev - Only initialise the `WCS_WC_Admin_Manager` class on stores running WC 9.2 or older. This class handled integration with the Woo Navigation feature that was removed in WC 9.3.
 
 = 7.5.0 - 2024-09-12 =

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -247,7 +247,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 	public function get_total_tax_refunded( $subscription ) {
 		$total = 0;
 
-		foreach ( $subscription->get_related_orders() as $order ) {
+		foreach ( $subscription->get_related_orders( 'all' ) as $order ) {
 			$total += parent::get_total_tax_refunded( $order );
 		}
 

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -305,7 +305,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 
 		$total = 0;
 
-		foreach ( $subscription->get_related_orders() as $order ) {
+		foreach ( $subscription->get_related_orders( 'all' ) as $order ) {
 			$total += parent::get_total_tax_refunded( $order );
 		}
 


### PR DESCRIPTION
Fixes #697

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

I couldn't reproduce this fatal error locally, however, the reporter explains that they're experiencing the following fatal error when trying to change their subscriptions payment method:

```
[14-Oct-2024 03:46:10 UTC] PHP Fatal error:  Uncaught Error: Call to a member function get_id() on int in /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php:977
```

This error is caused by both of our subscriptions data store classes trying to fetch related orders using `$subscription->get_related_orders()` (which defaults to return order IDs), and then calls `get_total_tax_refunded( $order )` with an ID, instead of the expected `WC_Order` object.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> I tried reproducing this issue locally but couldn't figure it out.
> Basically you need taxes enabled, and tax settings set to display totals as inclusive and also as a single total instead of itemized: ![nuRhtS.png](https://github.com/user-attachments/assets/c6b16011-ce5a-4e0e-a114-9babc82c405b)
>
> Then in `WC_Subscriptions` we override WooCommerce's `get_formatted_order_total()` and never pass the `$tax_display` arg to `parent::get_formatted_order_total()` and so I can't figure out how we would ever be calling `$subscription->get_total_tax_refunded()` 🤔 

1. To reproduce this fatal error, I ran the following snippet of code:
```
$subscription       = wcs_get_subscription( 4960 );
$total_tax_refunded = $subscription->get_data_store()->get_total_tax_refunded( $subscription );
echo $total_tax_refunded;
```
2. On `trunk` this snippet will throw a PHP fatal error
3. On this branch, the correct total tax refunded will be calculated/returned.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)