### PR TITLE
Improve the performance of checking if a customer can purchase a limited product

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.7.0 - xxxx-xx-xx =
+* Tweak - Replaced wcs_get_subscriptions() call with a more performance-friendly method when checking limited subscription product availability.
+
 = 7.6.0 - 2024-10-14 =
 * Fix - Correctly updates a subscription status to `cancelled` during a payment failure call when the current status is `pending-cancel`.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.

--- a/includes/wcs-limit-functions.php
+++ b/includes/wcs-limit-functions.php
@@ -60,13 +60,13 @@ function wcs_is_product_limited_for_user( $product, $user_id = 0 ) {
 		// If the product is limited for any status, there exists a chance that the customer has cancelled subscriptions which cannot be resubscribed to as they have no completed payments.
 		if ( 'any' === $product_limitation && $is_limited_for_user ) {
 			$is_limited_for_user = false;
-			$user_subscriptions  = wcs_get_subscriptions( array(
-				'subscriptions_per_page' => -1,
-				'customer_id'            => $user_id,
-				'product_id'             => $product->get_id(),
-			) );
 
-			foreach ( $user_subscriptions as $subscription ) {
+			foreach ( wcs_get_users_subscriptions( $user_id ) as $subscription ) {
+				// Skip if the subscription is not for the product we are checking.
+				if ( $subscription->has_product( $product->get_id() ) ) {
+					continue;
+				}
+
 				if ( ! $subscription->has_status( 'cancelled' ) || 0 !== $subscription->get_payment_count() ) {
 					$is_limited_for_user = true;
 					break;

--- a/includes/wcs-limit-functions.php
+++ b/includes/wcs-limit-functions.php
@@ -63,7 +63,7 @@ function wcs_is_product_limited_for_user( $product, $user_id = 0 ) {
 
 			foreach ( wcs_get_users_subscriptions( $user_id ) as $subscription ) {
 				// Skip if the subscription is not for the product we are checking.
-				if ( $subscription->has_product( $product->get_id() ) ) {
+				if ( ! $subscription->has_product( $product->get_id() ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
## Description

It's a known issue that the `wcs_get_subscriptions_for_product()` function is not performance friendly. Unfortunately, by the nature of the database structure, that kind of query is going to be slow. As such, we should avoid using it on large sites (as illustrated by [this example](https://github.com/Automattic/woocommerce-subscriptions-core/blob/6.5.0/includes/admin/class-wc-subscriptions-admin.php#L882) where we don't call it on a large site).

If you call `wcs_get_subscriptions()` function with the `product_id` or `variation_id` args, it also calls `wcs_get_subscriptions_for_product()`. So therefore, calling `wcs_get_subscriptions()` with those args should also be avoided. 

**This PR replaces one of those `wcs_get_subscriptions()` calls with the more performance friendly approach.**

### Why is this more performant? 

User subscriptions (fetched via `wcs_get_users_subscriptions()`) are cached in the `WCS_Customer_Store` and so pulling a specific user's subscriptions is a single user meta read. 

Whereas, querying for all subscriptions with a specific product is a direct database query like this one:

```sql
SELECT DISTINCT order_items.order_id FROM wp_woocommerce_order_items as order_items LEFT JOIN wp_woocommerce_order_itemmeta AS itemmeta ON order_items.order_item_id = itemmeta.order_item_id LEFT JOIN wp_posts AS orders ON order_items.order_id = orders.ID WHERE orders.post_type = 'shop_subscription' AND itemmeta.meta_key IN ( '_variation_id', '_product_id' ) AND order_items.order_item_type = 'line_item' AND itemmeta.meta_value IN ( '628' ) ORDER BY order_items.order_id
```

Given the joins in this query are on large tables (like the itemmeta table and posts), this query is very slow.

Getting a cached list of user subscriptions and filtering out the irrelevant ones in PHP is a lot faster.

In my tests on a smallish (350 subscription) test site, this improved the performance from 7.135875 to 1.237625 milliseconds. Not at all scientific but it's a big improvement.

## How to test this PR

0. Verify that the logic of this function is equivalent. 
1. Create a subscription product limited to any status. 

<p align="center">
<img width="1379" alt="Screenshot 2024-10-18 at 11 24 52 am" src="https://github.com/user-attachments/assets/205d1bd9-0f8a-4ab1-9f14-2fbed011a268">
</p> 

3. Purchase the product.
4. Go to the subscription product and confirm it's not purchasable.

**TESTING THE LOGIC**

1. Trash any subscription to that limited product. 
2. Add the product to your cart again.
3. Fail the sign up using a generic failure card (eg `4000000000000002`)
4. Go to the subscription on the my account page and cancel the on-hold/failed subscription.
5. Go to the product page and confirm it is purchasable. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
