### PR TITLE
Align the notification offset settings fields

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -877,6 +877,10 @@ span.product-type.variable-subscription::before {
 	width: 400px;
 	margin-bottom: 1em;
 }
+table.form-table input#woocommerce_subscriptions_customer_notifications_offset {
+	/* Aligns with .woocommerce table.form-table select */
+	line-height: 32px;
+}
 
 /* Reports Page */
 .woocommerce-reports-wide .postbox .chart-legend li a {


### PR DESCRIPTION
## Description

A simple fix to properly align the setting fields.

### Before
![Screenshot 2024-10-21 at 4 40 04 PM](https://github.com/user-attachments/assets/04ac72d7-1b83-4dce-953f-2011ff3b5a7f)

### After 
![Screenshot 2024-10-21 at 4 39 51 PM](https://github.com/user-attachments/assets/a7bbc29c-78c6-4a07-b457-455684b9d515)

## How to test this PR

1. Go to "WooCommerce > Settings > Subscriptions" and find the "Customer Notifications" section.
2. Make sure the option "Enable customer renewal reminder notification emails" is checked.
3. Check for the inconsistencies in the alignment of the fields.
4. Apply this patch and build the project. *1
5. Verify that everything works as expected.

_*1: I had to run `NODE_OPTIONS=--openssl-legacy-provider npm run build`_

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
