### PR TITLE
Add debug tool copy when notifications are disabled

### DIFF
--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -297,7 +297,7 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 					'%1$s<br/><strong class="red">%2$s</strong> %3$s <a href="%4$s">%5$s</a>',
 					__( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
 					__( 'Note:', 'woocommerce-subscriptions' ),
-					__( 'Notifications are currently turned off. To activate them, check the "Enable customer renewal reminder notification emails." option (via Settings > Subscriptions > Customer Notifications).', 'woocommerce-subscriptions' ),
+					__( 'Notifications are currently turned off. To activate them, check the "Enable customer renewal reminder notification emails." option (via WooCommerce > Settings > Subscriptions > Customer Notifications).', 'woocommerce-subscriptions' ),
 					esc_url( admin_url( 'admin.php?page=wc-settings&tab=subscriptions' ) ),
 					__( 'Manage settings.', 'woocommerce-subscriptions' ),
 				),

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -290,10 +290,10 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 		if ( ! WC_Subscriptions_Email_Notifications::notifications_globally_enabled() ) {
 
 			$tools['start_add_subscription_notifications'] = array(
-				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
-				'disabled' => true,
-				'desc'     => sprintf(
+				'name'             => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
+				'button'           => __( 'Add notifications', 'woocommerce-subscriptions' ),
+				'disabled'         => true,
+				'desc'             => sprintf(
 					'%1$s<br/><strong class="red">%2$s</strong> %3$s <a href="%4$s">%5$s</a>',
 					__( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
 					__( 'Note:', 'woocommerce-subscriptions' ),
@@ -301,6 +301,7 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 					esc_url( admin_url( 'admin.php?page=wc-settings&tab=subscriptions' ) ),
 					__( 'Manage settings.', 'woocommerce-subscriptions' ),
 				),
+				'requires_refresh' => true,
 			);
 			return $tools;
 		}
@@ -311,19 +312,21 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 
 			$pending_count                                = $this->get_total_pending_count();
 			$tools['stop_add_subscription_notifications'] = array(
-				'name'     => __( 'Stop adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'   => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
-				'desc'     =>
+				'name'             => __( 'Stop adding subscription notifications', 'woocommerce-subscriptions' ),
+				'button'           => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
+				'desc'             =>
 					/* translators: %1$d=count of total entries needing conversion */
 					sprintf( __( 'Stopping this will halt the background process that adds notifications to pending, active, and on-hold subscriptions. %1$d subscriptions remain to be processed.', 'woocommerce-subscriptions' ), $pending_count ),
-				'callback' => array( $this, 'dequeue' ),
+				'callback'         => array( $this, 'dequeue' ),
+				'requires_refresh' => true,
 			);
 		} else {
 			$tools['start_add_subscription_notifications'] = array(
-				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
-				'desc'     => __( 'This tool will regenerate notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
-				'callback' => array( $this, 'enqueue' ),
+				'name'             => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
+				'button'           => __( 'Add notifications', 'woocommerce-subscriptions' ),
+				'desc'             => __( 'This tool will regenerate notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
+				'callback'         => array( $this, 'enqueue' ),
+				'requires_refresh' => true,
 			);
 		}
 

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -306,26 +306,23 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 		}
 
 		$batch_processor = WCS_Batch_Processing_Controller::instance();
-		$pending_count   = $this->get_total_pending_count();
-		$state           = $this->get_tool_state();
-		$total_done      = isset( $state['last_offset'] ) ? (int) $state['last_offset'] : 0;
 
 		if ( $batch_processor->is_enqueued( self::class ) ) {
+
+			$pending_count                                = $this->get_total_pending_count();
 			$tools['stop_add_subscription_notifications'] = array(
 				'name'     => __( 'Stop adding subscription notifications', 'woocommerce-subscriptions' ),
 				'button'   => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
 				'desc'     =>
-				/* translators: %1$d=count of total entries needing conversion */
-					sprintf( __( 'Stopping this will halt the background process that adds notifications to pending, active, and on-hold subscriptions. %1$d of %2$d subscriptions remain to be processed.', 'woocommerce-subscriptions' ), $pending_count, ( $pending_count + $total_done ) ),
+					/* translators: %1$d=count of total entries needing conversion */
+					sprintf( __( 'Stopping this will halt the background process that adds notifications to pending, active, and on-hold subscriptions. %1$d subscriptions remain to be processed.', 'woocommerce-subscriptions' ), $pending_count ),
 				'callback' => array( $this, 'dequeue' ),
 			);
 		} else {
 			$tools['start_add_subscription_notifications'] = array(
 				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
 				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
-				'desc'     =>
-				/* translators: %d=count of entries pending conversion */
-					sprintf( __( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler. Currently, there are %d subscriptions to process.', 'woocommerce-subscriptions' ), $pending_count ),
+				'desc'     => __( 'This tool will regenerate notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
 				'callback' => array( $this, 'enqueue' ),
 			);
 		}

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -288,11 +288,19 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 	public function handle_woocommerce_debug_tools( array $tools ): array {
 
 		if ( ! WC_Subscriptions_Email_Notifications::notifications_globally_enabled() ) {
+
 			$tools['start_add_subscription_notifications'] = array(
 				'name'     => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
 				'button'   => __( 'Add notifications', 'woocommerce-subscriptions' ),
 				'disabled' => true,
-				'desc'     => __( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler. Notifications are currently disabled.', 'woocommerce-subscriptions' ),
+				'desc'     => sprintf(
+					'%1$s<br/><strong class="red">%2$s</strong> %3$s <a href="%4$s">%5$s</a>',
+					__( 'This tool will add notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
+					__( 'Note:', 'woocommerce-subscriptions' ),
+					__( 'Notifications are currently turned off. To activate them, check the "Enable customer renewal reminder notification emails." option (via Settings > Subscriptions > Customer Notifications).', 'woocommerce-subscriptions' ),
+					esc_url( admin_url( 'admin.php?page=wc-settings&tab=subscriptions' ) ),
+					__( 'Manage settings.', 'woocommerce-subscriptions' ),
+				),
 			);
 			return $tools;
 		}

--- a/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
+++ b/includes/admin/debug-tools/class-wcs-notifications-debug-tool-processor.php
@@ -290,8 +290,8 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 		if ( ! WC_Subscriptions_Email_Notifications::notifications_globally_enabled() ) {
 
 			$tools['start_add_subscription_notifications'] = array(
-				'name'             => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'           => __( 'Add notifications', 'woocommerce-subscriptions' ),
+				'name'             => __( 'Regenerate subscription notifications', 'woocommerce-subscriptions' ),
+				'button'           => __( 'Regenerate notifications', 'woocommerce-subscriptions' ),
 				'disabled'         => true,
 				'desc'             => sprintf(
 					'%1$s<br/><strong class="red">%2$s</strong> %3$s <a href="%4$s">%5$s</a>',
@@ -312,8 +312,8 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 
 			$pending_count                                = $this->get_total_pending_count();
 			$tools['stop_add_subscription_notifications'] = array(
-				'name'             => __( 'Stop adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'           => __( 'Stop adding notifications', 'woocommerce-subscriptions' ),
+				'name'             => __( 'Regenerate subscription notifications', 'woocommerce-subscriptions' ),
+				'button'           => __( 'Stop regenerating notifications', 'woocommerce-subscriptions' ),
 				'desc'             =>
 					/* translators: %1$d=count of total entries needing conversion */
 					sprintf( __( 'Stopping this will halt the background process that adds notifications to pending, active, and on-hold subscriptions. %1$d subscriptions remain to be processed.', 'woocommerce-subscriptions' ), $pending_count ),
@@ -322,8 +322,8 @@ class WCS_Notifications_Debug_Tool_Processor implements WCS_Batch_Processor {
 			);
 		} else {
 			$tools['start_add_subscription_notifications'] = array(
-				'name'             => __( 'Start adding subscription notifications', 'woocommerce-subscriptions' ),
-				'button'           => __( 'Add notifications', 'woocommerce-subscriptions' ),
+				'name'             => __( 'Regenerate subscription notifications', 'woocommerce-subscriptions' ),
+				'button'           => __( 'Regenerate notifications', 'woocommerce-subscriptions' ),
 				'desc'             => __( 'This tool will regenerate notifications to pending, active, and on-hold subscriptions. These updates will occur gradually in the background using Action Scheduler.', 'woocommerce-subscriptions' ),
 				'callback'         => array( $this, 'enqueue' ),
 				'requires_refresh' => true,


### PR DESCRIPTION
## Description

This PR adds a more descriptive copy to the debug tool's UI when the notifications are disabled. 

Expected UI:
![Screenshot 2024-10-21 at 5 09 21 PM](https://github.com/user-attachments/assets/ad4f7c43-0a14-4be0-9784-881b6d338be0)

## How to test this PR

1. Ensure that notifications are disabled.
2. Visit the "WooCommerce > Status" page and navigate to the "Tools" tab. 
3. Notice the new text and the CTA to edit the settings.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
