### PR TITLE
Improve the performance of fetching subscriptions by product where the query is limited to customers or orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.7.0 - xxxx-xx-xx =
+* Update - Improved performance of wcs_get_subscription() when querying by product and customer or order.
+
 = 7.6.0 - 2024-10-14 =
 * Fix - Correctly updates a subscription status to `cancelled` during a payment failure call when the current status is `pending-cancel`.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.

--- a/includes/class-wc-subscription-product-query-controller.php
+++ b/includes/class-wc-subscription-product-query-controller.php
@@ -58,9 +58,11 @@ class WC_Subscription_Product_Query_Controller {
 	 */
 	public function should_filter_query_results() {
 		$can_filter_results = false;
+		$order_id           = $this->query_vars['order_id'] ?? 0;
+		$customer_id        = $this->query_vars['customer_id'] ?? 0;
 
 		// If we're querying by order ID or customer ID, we can filter the results by product ID after the query has been run.
-		if ( isset( $this->query_vars['order_id'] ) || isset( $this->query_vars['customer_id'] ) ) {
+		if ( ! empty( $order_id ) || ! empty( $customer_id ) ) {
 			$can_filter_results = apply_filters( 'wcs_should_filter_subscriptions_results_by_product_id', true, $this->query_vars );
 		}
 

--- a/includes/class-wc-subscription-product-query-controller.php
+++ b/includes/class-wc-subscription-product-query-controller.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Subscription Product Query Controller
+ *
+ * This class is used by wcs_get_subscriptions() to determine if the query should be filtered by product ID or variation ID after the query has been run.
+ *
+ * Querying subscriptions by product or variation ID is an expensive database operation. This class provides methods to determine if a wcs_get_subscriptions()
+ * set of args would be better served by filtering the query results by product ID or variation ID after the query has been run, rather than querying for
+ * subscriptions by products.
+ *
+ * If the wcs_get_subscriptions() args are already limited by customer ID or order ID we know that the results will be sufficiently limited. In these cases, we can
+ * filter the results by product ID or variation ID after the query has been run.
+ *
+ * @package WooCommerce Subscriptions
+ * @subpackage Component
+ * @since 6.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Subscription_Product_Query class.
+ */
+class WC_Subscription_Product_Query_Controller {
+
+	/**
+	 * The wcs_get_subscriptions() query variables.
+	 *
+	 * @var array
+	 */
+	private $query_vars = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $query_vars The wcs_get_subscriptions() query variables.
+	 */
+	public function __construct( $query_vars ) {
+		$this->query_vars = $query_vars;
+	}
+
+	/**
+	 * Determines if the query is for a specific product or variation.
+	 *
+	 * @return bool True if the query is for a specific product or variation, otherwise false.
+	 */
+	public function has_product_query() {
+		return ( 0 !== $this->query_vars['product_id'] && is_numeric( $this->query_vars['product_id'] ) ) || ( 0 !== $this->query_vars['variation_id'] && is_numeric( $this->query_vars['variation_id'] ) );
+	}
+
+	/**
+	 * Determines if the wcs_get_subscription() query should filter the results by product ID or variation ID after the query has been run.
+	 *
+	 * If the wcs_get_subscriptions() query is substantially limited (eg to a customer or order) we know that the results will be small. In these cases, we can
+	 * filter the results by product ID or variation ID after the query has been run for better performance.
+	 *
+	 * @return bool True if the subscriptions should be queried by product ID, otherwise false.
+	 */
+	public function should_filter_query_results() {
+		$can_filter_results = false;
+
+		// If we're querying by order ID or customer ID, we can filter the results by product ID after the query has been run.
+		if ( isset( $this->query_vars['order_id'] ) || isset( $this->query_vars['customer_id'] ) ) {
+			$can_filter_results = true;
+		}
+
+		return apply_filters( 'wcs_can_filter_subscriptions_results_by_product_id', $can_filter_results, $this->query_vars );
+	}
+
+	/**
+	 * Filters the subscription query results by product ID or variation ID.
+	 *
+	 * @param WC_Subscriptions[] $subscriptions
+	 * @return WC_Subscriptions[] The filtered subscriptions.
+	 */
+	public function filter_subscriptions( $subscriptions ) {
+		$filtered_subscriptions = [];
+		$product_id             = $this->query_vars['product_id'] ?? 0;
+		$variation_id           = $this->query_vars['variation_id'] ?? 0;
+
+		if ( empty( $product_id ) && empty( $variation_id ) ) {
+			return $subscriptions;
+		}
+
+		// Filter the subscriptions by product ID or variation ID.
+		foreach ( $subscriptions as $subscription_id => $subscription ) {
+			if (
+				( $variation_id && $subscription->has_product( $variation_id ) ) ||
+				( $product_id && $subscription->has_product( $product_id ) )
+			) {
+				$filtered_subscriptions[ $subscription_id ] = $subscription;
+			}
+		}
+
+		return $filtered_subscriptions;
+	}
+
+	/**
+	 * Applies pagination to the subscriptions array.
+	 *
+	 * @param WC_Subscriptions[] $subscriptions
+	 * @return WC_Subscriptions[] The subscriptions array with pagination applied.
+	 */
+	public function paginate_results( $subscriptions ) {
+		$per_page = $this->query_vars['subscriptions_per_page'];
+		$page     = $this->query_vars['paged'];
+		$offset   = $this->query_vars['offset'];
+
+		// If the limit is -1, return all subscriptions.
+		if ( -1 === $per_page ) {
+			return $subscriptions;
+		}
+
+		if ( $offset ) {
+			$start_index = $offset;
+		} else {
+			// Calculate the starting index for the slice.
+			$start_index = ( $page - 1 ) * $per_page;
+		}
+
+		// Slice the subscriptions array to get the required items.
+		return array_slice( $subscriptions, $start_index, $per_page, true );
+	}
+}

--- a/includes/class-wc-subscription-product-query-controller.php
+++ b/includes/class-wc-subscription-product-query-controller.php
@@ -61,10 +61,10 @@ class WC_Subscription_Product_Query_Controller {
 
 		// If we're querying by order ID or customer ID, we can filter the results by product ID after the query has been run.
 		if ( isset( $this->query_vars['order_id'] ) || isset( $this->query_vars['customer_id'] ) ) {
-			$can_filter_results = true;
+			$can_filter_results = apply_filters( 'wcs_should_filter_subscriptions_results_by_product_id', true, $this->query_vars );
 		}
 
-		return apply_filters( 'wcs_can_filter_subscriptions_results_by_product_id', $can_filter_results, $this->query_vars );
+		return $can_filter_results;
 	}
 
 	/**

--- a/includes/class-wc-subscription-query-controller.php
+++ b/includes/class-wc-subscription-query-controller.php
@@ -1,8 +1,11 @@
 <?php
 /**
- * Subscription Product Query Controller
+ * Subscription Query Controller
  *
- * This class is used by wcs_get_subscriptions() to determine if the query should be filtered by product ID or variation ID after the query has been run.
+ * This class is used to assist the wcs_get_subscriptions() query for something.
+ * It currently supports 1 feature to determine if the query should be filtered by product ID or variation ID after the query has been run.
+ *
+ * QUERYING SUBSCRIPTIONS BY PRODUCT
  *
  * Querying subscriptions by product or variation ID is an expensive database operation. This class provides methods to determine if a wcs_get_subscriptions()
  * set of args would be better served by filtering the query results by product ID or variation ID after the query has been run, rather than querying for
@@ -19,9 +22,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Subscription_Product_Query class.
+ * WC_Subscription_Query_Controller class.
  */
-class WC_Subscription_Product_Query_Controller {
+class WC_Subscription_Query_Controller {
 
 	/**
 	 * The wcs_get_subscriptions() query variables.

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -458,7 +458,7 @@ function wcs_get_subscriptions( $args ) {
 		'status'     => $args['subscription_status'],
 		'limit'      => $args['subscriptions_per_page'],
 		'page'       => $args['paged'],
-		'offset'     => $args['offset'],
+		'offset'     => $args['offset'] > 0 ? $args['offset'] : null,
 		'order'      => $args['order'],
 		'return'     => 'ids',
 		// just in case we need to filter or order by meta values later

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -519,7 +519,9 @@ function wcs_get_subscriptions( $args ) {
 		if ( $product_query_handler->should_filter_query_results() ) {
 			// We will filter the results and apply any paging, limit and offset after the query has been run.
 			unset( $args['product_id'], $args['variation_id'], $query_args['limit'], $query_args['paged'], $query_args['offset'] );
-			$query_args['limit'] = -1; // We need to get all subscriptions to filter them.
+
+			// We need to get all subscriptions otherwise the limit could be filled with subscriptions that don't contain the product.
+			$query_args['limit'] = -1;
 		} else {
 			$subscriptions_for_product = wcs_get_subscriptions_for_product( array( $args['product_id'], $args['variation_id'] ) );
 			$query_args                = WCS_Admin_Post_Types::set_post__in_query_var( $query_args, $subscriptions_for_product );

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -512,11 +512,11 @@ function wcs_get_subscriptions( $args ) {
 	// It's more efficient to filter the results by product ID or variation ID rather than querying for via a "post__in" clause.
 	// This can only work where we know that the results will be sufficiently limited by the other query args. ie when we're querying by customer_id or order_id.
 	// We store the filters in a separate array so that we can apply them after the query has been run.
-	$product_query_handler = new WC_Subscription_Product_Query_Controller( $args );
+	$query_controller = new WC_Subscription_Query_Controller( $args );
 
 	// We need to restrict subscriptions to those which contain a certain product/variation.
-	if ( $product_query_handler->has_product_query() ) {
-		if ( $product_query_handler->should_filter_query_results() ) {
+	if ( $query_controller->has_product_query() ) {
+		if ( $query_controller->should_filter_query_results() ) {
 			// We will filter the results and apply any paging, limit and offset after the query has been run.
 			unset( $args['product_id'], $args['variation_id'], $query_args['limit'], $query_args['paged'], $query_args['offset'] );
 
@@ -546,9 +546,9 @@ function wcs_get_subscriptions( $args ) {
 	}
 
 	// If we didn't query the database for subscriptions to a product, filter the results now.
-	if ( $product_query_handler->has_product_query() && $product_query_handler->should_filter_query_results() ) {
-		$subscriptions = $product_query_handler->filter_subscriptions( $subscriptions );
-		$subscriptions = $product_query_handler->paginate_results( $subscriptions );
+	if ( $query_controller->has_product_query() && $query_controller->should_filter_query_results() ) {
+		$subscriptions = $query_controller->filter_subscriptions( $subscriptions );
+		$subscriptions = $query_controller->paginate_results( $subscriptions );
 	}
 
 	return apply_filters( 'woocommerce_got_subscriptions', $subscriptions, $args );


### PR DESCRIPTION
## Description

Querying subscriptions for specific products is an expensive database operation. When you combine it with other query requirements (eg subscription status, customer etc) it actually leads to 2 database queries. 1 to get the subscriptions with the product, and 2 to fetch subscriptions by the other query args where the results from the first query are included in the `post_in` arg.

This can lead to big issues on large sites.

1. The list of results in the `post_in` can be so large, the query is cut off based on query character limits.
2. The query to fetch that list, can take a long time given the joins necessary to fetch subscriptions with a specific product.  

This PR improves the performance of `wcs_get_subscription()` calls which are querying for a product where the query is also limited to a specific customer or order. 

### Why is this more performant?
When querying for subscriptions for a specific customer, the list of subscriptions is likely to be a substantial subset of the total subscriptions on the store. ie a customer may have 1 or 2 or even in extreme cases 10s of subscriptions. Looping over 10 subscriptions and checking if they include a product is a lot more performant than trying to find all subscriptions to that product which is likely to include 100s or 1000s of results.

The same goes for orders. If the `wcs_get_subscription()` query is limited to a specific order, than it's even more likely that the list of possible subscriptions is small. Most orders would contain 1 subscription. In more extreme cases, maybe 2 or 3. 

Looping over those subscriptions and limiting it to a product is a lot more performant than finding all subscriptions to the product (possibly 1000s).

Querying for all subscriptions with a specific product is a direct database query like this one:

```sql
SELECT DISTINCT order_items.order_id FROM wp_woocommerce_order_items as order_items LEFT JOIN wp_woocommerce_order_itemmeta AS itemmeta ON order_items.order_item_id = itemmeta.order_item_id LEFT JOIN wp_posts AS orders ON order_items.order_id = orders.ID WHERE orders.post_type = 'shop_subscription' AND itemmeta.meta_key IN ( '_variation_id', '_product_id' ) AND order_items.order_item_type = 'line_item' AND itemmeta.meta_value IN ( '628' ) ORDER BY order_items.order_id
```

Given the joins in this query are on large tables (like the itemmeta table and posts), this query is very slow.

## How to test this PR

1. The only way to test this is really via custom code because in WC Subscriptions we don't really ever make use of this combination of args (get subscriptions by customer/order and product).

```php 
$args = array(
	'customer_id' => 64,
	'product_id'  => 5069,
	//'variation_id'  => 5069,
	//'subscriptions_per_page' => 5,
	//'paged'       => 2,
	//'offset'      => 7,
	'return'      => 'ids',
);

add_filter( 'wcs_should_filter_subscriptions_results_by_product_id', '__return_true' );
$s = microtime( true );
error_log( 'new: ' . print_r( array_keys( wcs_get_subscriptions( $args ) ), true ) );
error_log( 'new: ' . ( ( microtime( true ) - $s ) * 1000 ) );

add_filter( 'wcs_should_filter_subscriptions_results_by_product_id', '__return_false' );
$s = microtime( true );
error_log( 'old: ' . print_r( array_keys( wcs_get_subscriptions( $args ) ), true ) );
error_log( 'old: ' . ( ( microtime( true ) - $s ) * 1000 ) );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
