### PR TITLE
Add dismissible admin notice to promote notifications feature

### DIFF
--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -40,6 +40,9 @@ class WC_Subscriptions_Email_Notifications {
 		// Add settings UI.
 		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_settings' ], 20 );
 
+		// Add admin notice.
+		add_action( 'admin_notices', [ __CLASS__, 'maybe_add_admin_notice' ] );
+
 		add_action( 'update_option_' . WC_Subscriptions_Admin::$option_prefix . self::$offset_setting_string, [ 'WC_Subscriptions_Email_Notifications', 'set_notification_settings_update_time' ], 10, 3 );
 		add_action( 'update_option_' . WC_Subscriptions_Admin::$option_prefix . self::$switch_setting_string, [ 'WC_Subscriptions_Email_Notifications', 'set_notification_settings_update_time' ], 10, 3 );
 		add_action( 'add_option_' . WC_Subscriptions_Admin::$option_prefix . self::$offset_setting_string, [ 'WC_Subscriptions_Email_Notifications', 'set_notification_settings_update_time' ], 10, 2 );
@@ -305,5 +308,54 @@ class WC_Subscriptions_Email_Notifications {
 
 		WC_Subscriptions_Admin::insert_setting_after( $settings, WC_Subscriptions_Admin::$option_prefix . '_miscellaneous', $notification_settings, 'multiple_settings', 'sectionend' );
 		return $settings;
+	}
+
+	/**
+	 * Maybe add an admin notice to inform the store manager about the existance of the notifications feature.
+	 */
+	public static function maybe_add_admin_notice() {
+
+		// If the notifications feature is enabled, don't show the notice.
+		if ( self::notifications_globally_enabled() ) {
+			return;
+		}
+
+		$option_name = 'wcs_hide_customer_notifications_notice';
+		$nonce       = '_wcsnonce';
+		$action      = 'wcs_hide_customer_notifications_notice_action';
+
+		// First, check if the notice is being dismissed.
+		$nonce_argument = sanitize_text_field( wp_unslash( $_GET[ $nonce ] ?? '' ) );
+		if ( isset( $_GET[ $action ], $nonce_argument ) && wp_verify_nonce( $nonce_argument, $action ) ) {
+			update_option( $option_name, 'yes' );
+			wp_safe_redirect( remove_query_arg( [ $action, $nonce ] ) );
+			return;
+		}
+
+		if ( 'yes' === get_option( $option_name ) ) {
+			return;
+		}
+
+		$admin_notice = new WCS_Admin_Notice( 'notice' );
+		$admin_notice->set_simple_content(
+			esc_html__(
+				'New customer email reminders for renewals, expirations, and free trials are now available! Enable and configure these features in WooCommerce > Settings > Susbcriptions to control when your customers receive important updates.',
+				'woocommerce-subscriptions'
+			)
+		);
+		$admin_notice->set_actions(
+			array(
+				array(
+					'name' => 'Manage Settings',
+					'url'  => admin_url( 'admin.php?page=wc-settings&tab=subscriptions' ),
+				),
+				array(
+					'name' => 'Dismiss',
+					'url'  => wp_nonce_url( add_query_arg( $action, 'dismiss' ), $action, $nonce ),
+				),
+			)
+		);
+
+		$admin_notice->display();
 	}
 }

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -339,7 +339,7 @@ class WC_Subscriptions_Email_Notifications {
 		$admin_notice = new WCS_Admin_Notice( 'notice' );
 		$admin_notice->set_simple_content(
 			esc_html__(
-				'New customer email reminders for renewals, expirations, and free trials are now available! Enable and configure these features in WooCommerce > Settings > Susbcriptions to control when your customers receive important updates.',
+				'New customer email reminders for renewals, expirations, and free trials are now available! Enable and configure these features in WooCommerce > Settings > Subscriptions to control when your customers receive important updates.',
 				'woocommerce-subscriptions'
 			)
 		);


### PR DESCRIPTION
## Description

This PR introduces a new dismissible admin notice that appears when notification reminders are not enabled in a store. The notice includes two actions:
- One to navigate to the Subscription Settings
- One to permanently dismiss the notice

## How to Test This PR

1. Apply the patch.
2. Visit the admin page to verify that no notice appears when the notifications feature is enabled.
3. Go to WooCommerce > Settings > Subscriptions and disable the notifications feature.
4. Observe the notice that appears at the top of the page.
5. Check that the "Manage Settings" call-to-action (CTA) correctly directs you to the settings page.
7. Enable the feature and confirm that the notice reappears.
8. Disable the feature again and confirm that the notice is no longer visible.
9. Click the "Dismiss" button and ensure that the notice does not appear again.

## Screenshots
![Screenshot 2024-10-22 at 5 44 08 PM](https://github.com/user-attachments/assets/f4bcca60-985b-4147-a1d6-1c6e1004feb2)

## Copy Feedback

The text currently states:
```
New customer email reminders for renewals, expirations, and free trials are now available! Enable and configure these features in WooCommerce > Settings > Susbcriptions to control when your customers receive important updates.
```

Any ideas for improvement?

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
