### PR TITLE
Include the date type when calculating notification offset

### DIFF
--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -184,7 +184,7 @@ class WC_Subscriptions_Email_Notifications {
 	 *
 	 * @return bool
 	 */
-	public static function should_send_notification( $subscription ) {
+	public static function should_send_notification() {
 		$notification_enabled = true;
 
 		if ( WCS_Staging::is_duplicate_site() ) {
@@ -203,19 +203,7 @@ class WC_Subscriptions_Email_Notifications {
 			$notification_enabled = false;
 		}
 
-		/**
-		 * Enables/disables all customer subscription notifications.
-		 *
-		 * Values 'yes' or 'no' expected, since it works with WC_Settings_API.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param bool $notification_enabled
-		 * @param WC_Subscription $subscription
-		 *
-		 * @return bool
-		 */
-		return apply_filters( 'woocommerce_subscription_customer_email_notifications_enabled', $notification_enabled, $subscription );
+		return $notification_enabled;
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -210,9 +210,12 @@ class WC_Subscriptions_Email_Notifications {
 		 *
 		 * @since x.x.x
 		 *
-		 * @param string $notification_enabled
+		 * @param bool $notification_enabled
+		 * @param WC_Subscription $subscription
+		 *
+		 * @return bool
 		 */
-		return apply_filters( 'wcs_customer_email_notifications_enabled', $notification_enabled, $subscription );
+		return apply_filters( 'woocommerce_subscription_customer_email_notifications_enabled', $notification_enabled, $subscription );
 	}
 
 	/**

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -34,6 +34,27 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 	protected static $notifications_as_group = 'wcs_customer_notifications';
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$setting_option = get_option(
+			WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
+			[
+				'number' => 3,
+				'unit'   => 'days',
+			]
+		);
+		$this->set_time_offset( self::convert_offset_to_seconds( $setting_option ) );
+
+		add_action( 'woocommerce_before_subscription_object_save', [ $this, 'update_notifications' ], 10, 2 );
+
+		add_action( 'update_option_' . WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string, [ $this, 'set_time_offset_from_option' ], 5, 3 );
+		add_action( 'add_option_' . WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string, [ $this, 'set_time_offset_from_option' ], 5, 2 );
+	}
+
+	/**
 	 * Check if the subscription period is too short to send a renewal notification.
 	 *
 	 * @param $subscription
@@ -58,18 +79,23 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 	 * Generally, there is one offset for all subscriptions, but there's a filter.
 	 *
 	 * @param WC_Subscription $subscription
+	 * @param string $notification_type
 	 *
 	 * @return mixed|null
 	 */
-	public function get_time_offset( $subscription ) {
+	public function get_time_offset( $subscription, $notification_type ) {
 		/**
 		 * Offset between a subscription event and related notification.
 		 *
 		 * @since x.x.x
 		 *
-		 * @param int $time_offset
+		 * @param int $time_offset In seconds
+		 * @param WC_Subscription $subscription
+		 * @param string $notification_type Can be 'trial_end', 'next_payment' or 'end'.
+		 *
+		 * @return int
 		 */
-		return apply_filters( 'woocommerce_subscriptions_customer_notification_time_offset', $this->time_offset, $subscription );
+		return apply_filters( 'woocommerce_subscriptions_customer_notification_time_offset', $this->time_offset, $subscription, $notification_type );
 	}
 
 	/**
@@ -95,30 +121,12 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		$this->time_offset = self::convert_offset_to_seconds( $new_option_value );
 	}
 
-	public function __construct() {
-		parent::__construct();
-
-		$setting_option = get_option(
-			WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string,
-			[
-				'number' => 3,
-				'unit'   => 'days',
-			]
-		);
-		$this->set_time_offset( self::convert_offset_to_seconds( $setting_option ) );
-
-		add_action( 'woocommerce_before_subscription_object_save', [ $this, 'update_notifications' ], 10, 2 );
-
-		add_action( 'update_option_' . WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string, [ $this, 'set_time_offset_from_option' ], 5, 3 );
-		add_action( 'add_option_' . WC_Subscriptions_Admin::$option_prefix . WC_Subscriptions_Email_Notifications::$offset_setting_string, [ $this, 'set_time_offset_from_option' ], 5, 2 );
-	}
-
 	/**
 	 * Calculate time offset in seconds from the settings array.
 	 *
 	 * @param array $offset Format: [ 'number' => 3, 'unit' => 'days' ]
 	 *
-	 * @return float|int
+	 * @return int
 	 */
 	protected static function convert_offset_to_seconds( $offset ) {
 		$default_offset = 3 * DAY_IN_SECONDS;
@@ -141,6 +149,15 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		}
 	}
 
+	/**
+	 * Maybe schedule a notification.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param string $action
+	 * @param int $timestamp
+	 *
+	 * @return void
+	 */
 	protected function maybe_schedule_notification( $subscription, $action, $timestamp ) {
 		if ( ! WC_Subscriptions_Email_Notifications::notifications_globally_enabled() ) {
 			return;
@@ -172,18 +189,19 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		as_schedule_single_action( $timestamp, $action, $action_args, self::$notifications_as_group );
 	}
 
-	/*
+	/**
 	 * Subtract time offset from given datetime based on the settings and subscription properties and return resulting timestamp.
 	 *
 	 * @param string $datetime
 	 * @param WC_Subscription $subscription
+	 * @param string $notification_type Can be 'trial_end', 'next_payment' or 'end'.
 	 *
 	 * @return int
 	 */
-	protected function subtract_time_offset( $datetime, $subscription ) {
+	protected function subtract_time_offset( $datetime, $subscription, $notification_type ) {
 		$dt = new DateTime( $datetime, new DateTimeZone( 'UTC' ) );
 
-		return $dt->getTimestamp() - $this->get_time_offset( $subscription );
+		return $dt->getTimestamp() - $this->get_time_offset( $subscription, $notification_type );
 	}
 
 	/**
@@ -267,7 +285,7 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		$action_name = self::get_action_from_date_type( $notification_type );
 
 		$event_date = $subscription->get_date( $notification_type );
-		$timestamp  = $this->subtract_time_offset( $event_date, $subscription );
+		$timestamp  = $this->subtract_time_offset( $event_date, $subscription, $notification_type );
 
 		$this->maybe_schedule_notification(
 			$subscription,

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -95,7 +95,7 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		 *
 		 * @return int
 		 */
-		return apply_filters( 'woocommerce_subscriptions_customer_notification_time_offset', $this->time_offset, $subscription, $notification_type );
+		return apply_filters( 'woocommerce_subscription_customer_notification_time_offset', $this->time_offset, $subscription, $notification_type );
 	}
 
 	/**

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -77,7 +77,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 
 		if ( ! $this->is_enabled()
 			|| ! $this->get_recipient()
-			|| ! WC_Subscriptions_Email_Notifications::should_send_notification( $subscription )
+			|| ! WC_Subscriptions_Email_Notifications::should_send_notification()
 			|| WCS_Action_Scheduler_Customer_Notifications::is_subscription_period_too_short( $subscription )
 		) {
 			// TODO: add admin notice here if in admin

--- a/tests/unit/test-wcs-notifications-emails.php
+++ b/tests/unit/test-wcs-notifications-emails.php
@@ -6,15 +6,13 @@ class WCS_Subscription_Notifications_Emails_Test extends WP_UnitTestCase {
 	 * Test should send notification.
 	 */
 	public function test_should_send_notification() {
-		$subscription = WCS_Helper_Subscription::create_subscription();
-
 		add_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_false' );
-		$should = WC_Subscriptions_Email_Notifications::should_send_notification( $subscription );
+		$should = WC_Subscriptions_Email_Notifications::should_send_notification();
 		$this->assertTrue( $should );
 
 		$this->disable_notifications_globally();
 
-		$should = WC_Subscriptions_Email_Notifications::should_send_notification( $subscription );
+		$should = WC_Subscriptions_Email_Notifications::should_send_notification();
 		$this->assertFalse( $should );
 		remove_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_false' );
 	}


### PR DESCRIPTION
## Description

This pull request adds a date type for calculating the time offset when sending notifications. 

The goal is to allow merchants to define different offsets based on subscription properties and the type of current event (such as renewal, expiration, or end of free trial).

Here’s an example snippet:
```php
add_filter(
	'woocommerce_subscription_customer_notification_time_offset', 
	function( $offset_in_seconds, $subscription, $date_type ) {

		// If it's not a renewal notification, return the default offset.
		if ( 'next_payment' !== $date_type ) {
			return $offset_in_seconds;
		}

		$period   = $subscription->get_billing_period();
		$interval = $subscription->get_billing_interval();

		switch ( $period ) {
			case 'week':
				// Default.
				break;
			case 'month':
				// Default for less than 6 months.
				if ( $interval >= 6 ) {
					$offset_in_seconds = 1 * WEEK_IN_SECONDS;
				}
				break;
			case 'year':
				$offset_in_seconds = 1 * MONTH_IN_SECONDS;
				break;
		}

		return $offset_in_seconds;
	},
	10,
	3
);
```

Additionally, it renames some hooks for consistency.

## How to test this PR

Unit Tests.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
