### PR TITLE
Fix pre-renewal email subjects containing incorrect plural formatting

### DIFF
--- a/includes/emails/class-wcs-email-customer-notification-auto-renewal.php
+++ b/includes/emails/class-wcs-email-customer-notification-auto-renewal.php
@@ -29,8 +29,8 @@ class WCS_Email_Customer_Notification_Auto_Renewal extends WCS_Email_Customer_No
 
 		$this->subject = sprintf(
 			// translators: %1$s: number of days until renewal, %2$s: customer's first name.
-			_x( 'Your subscription automatically renews in %1$s days, %2$s ♻️', 'default email subject for subscription\'s automatic renewal notice', 'woocommerce-subscriptions' ),
-			'{days_until_renewal}',
+			_x( 'Your subscription automatically renews in %1$s, %2$s ♻️', 'default email subject for subscription\'s automatic renewal notice', 'woocommerce-subscriptions' ),
+			'{time_until_renewal}',
 			'{customers_first_name}'
 		);
 

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -16,7 +16,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 		$this->placeholders = array_merge(
 			[
 				'{customers_first_name}' => '',
-				'{days_until_renewal}'   => '',
+				'{time_until_renewal}'   => '',
 			],
 			$this->placeholders
 		);
@@ -125,7 +125,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 
 		try {
 			$this->placeholders['{customers_first_name}'] = $subscription->get_billing_first_name();
-			$this->placeholders['{days_until_renewal}']   = $this->get_time_until_date( $subscription, 'next_payment' );
+			$this->placeholders['{time_until_renewal}']   = $this->get_time_until_date( $subscription, 'next_payment' );
 
 			$result = $this->send( $this->get_recipient(), $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
 
@@ -169,7 +169,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 				'subscription'                => $subscription,
 				'order'                       => $subscription->get_parent(),
 				'email_heading'               => $this->get_heading(),
-				'subscription_days_til_event' => $this->get_time_until_date( $subscription, $this->get_relevant_date_type() ),
+				'subscription_time_til_event' => $this->get_time_until_date( $subscription, $this->get_relevant_date_type() ),
 				'subscription_event_date'     => $this->get_formatted_date( $subscription, $this->get_relevant_date_type() ),
 				'url_for_renewal'             => $url_for_renewal,
 				'can_renew_early'             => $can_renew_early,
@@ -215,7 +215,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 				'subscription'                => $subscription,
 				'order'                       => $subscription->get_parent(),
 				'email_heading'               => $this->get_heading(),
-				'subscription_days_til_event' => $this->get_time_until_date( $subscription, $this->get_relevant_date_type() ),
+				'subscription_time_til_event' => $this->get_time_until_date( $subscription, $this->get_relevant_date_type() ),
 				'subscription_event_date'     => $this->get_formatted_date( $subscription, $this->get_relevant_date_type() ),
 				'url_for_renewal'             => $url_for_renewal,
 				'can_renew_early'             => $can_renew_early,
@@ -248,16 +248,17 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	 */
 	public function get_time_until_date( $subscription, $date_type ) {
 		$next_event = $subscription->get_date( $date_type );
+
 		if ( ! $next_event ) {
 			return '';
 		}
 
 		$next_event_dt = new DateTime( $next_event, new DateTimeZone( 'UTC' ) );
 		$now           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+
 		// Add some buffer, otherwise it will claim that only 2 full days are left when in reality it's 2 days, 23 hours and 59 minutes.
 		$now->modify( '+1 hour' );
-		$interval = $next_event_dt->diff( $now );
-		return $interval->days;
+		return human_time_diff( $now->getTimestamp(), $next_event_dt->getTimestamp() );
 	}
 
 	/**

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -256,8 +256,12 @@ class WCS_Email_Customer_Notification extends WC_Email {
 		$next_event_dt = new DateTime( $next_event, new DateTimeZone( 'UTC' ) );
 		$now           = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 
+		// Both dates to midnight so we only compare days, not hours.
+		$next_event_dt->setTime( 0, 0 );
+		$now->setTime( 0, 0 );
+
 		// Add some buffer, otherwise it will claim that only 2 full days are left when in reality it's 2 days, 23 hours and 59 minutes.
-		$now->modify( '+1 hour' );
+		$now->modify( '-1 hour' );
 		return human_time_diff( $now->getTimestamp(), $next_event_dt->getTimestamp() );
 	}
 

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -33,14 +33,12 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		<?php
 		echo wp_kses(
 			sprintf(
-				// translators: %1$s: number of days until expiry, %2$s: date in local format.
-				_n(
-					'Your subscription will <strong>automatically renew</strong> in %1$s day — that’s <strong>%2$s</strong>.',
-					'Your subscription will <strong>automatically renew</strong> in %1$s days — that’s <strong>%2$s</strong>.',
-					(int) $subscription_days_til_event,
+					// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+				__(
+					'Your subscription will <strong>automatically renew</strong> in %1$s — that’s <strong>%2$s</strong>.',
 					'woocommerce-subscriptions'
 				),
-				(int) $subscription_days_til_event,
+				$subscription_time_til_event,
 				$subscription_event_date
 			),
 			[ 'strong' => [] ]
@@ -65,7 +63,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 			<?php
 			echo wp_kses_post(
 				sprintf(
-							// translators: %s: link to subscription detail in the customer's dashboard.
+					// translators: %s: link to subscription detail in the customer's dashboard.
 					__( 'You can manage this subscription from your %s', 'woocommerce-subscriptions' ),
 					'<a href="' . esc_url( $subscription->get_view_order_url() ) . '">' . esc_html__( 'account dashboard', 'woocommerce-subscriptions' ) . '</a>',
 				)

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -33,14 +33,12 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		<?php
 		echo wp_kses(
 			sprintf(
-				// translators: %1$s: number of days until expiry, %2$s: date in local format.
-				_n(
-					'Your paid subscription begins when your free trial expires in %1$s day — that’s <strong>%2$s</strong>.',
-					'Your paid subscription begins when your free trial expires in %1$s days — that’s <strong>%2$s</strong>.',
-					(int) $subscription_days_til_event,
+				// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+				__(
+					'Your paid subscription begins when your free trial expires in %1$s — that’s <strong>%2$s</strong>.',
 					'woocommerce-subscriptions'
 				),
-				(int) $subscription_days_til_event,
+				$subscription_time_til_event,
 				$subscription_event_date
 			),
 			[ 'strong' => [] ]

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -33,14 +33,12 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		<?php
 		echo wp_kses(
 			sprintf(
-				// translators: %1$s: number of days until expiry, %2$s: date in local format.
-				_n(
-					'Your subscription expires in %1$s day — that’s <strong>%2$s</strong>.',
-					'Your subscription expires in %1$s days — that’s <strong>%2$s</strong>.',
-					(int) $subscription_days_til_event,
+				// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+				__(
+					'Your subscription expires in %1$s — that’s <strong>%2$s</strong>.',
 					'woocommerce-subscriptions'
 				),
-				(int) $subscription_days_til_event,
+				$subscription_time_til_event,
 				$subscription_event_date
 			),
 			[ 'strong' => [] ]

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -33,14 +33,12 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		<?php
 		echo wp_kses(
 			sprintf(
-				// translators: %1$s: number of days until expiry, %2$s: date in local format.
-				_n(
-					'Your subscription is up for renewal in %1$s day — that’s <strong>%2$s</strong>.',
-					'Your subscription is up for renewal in %1$s days — that’s <strong>%2$s</strong>.',
-					(int) $subscription_days_til_event,
+				// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+				__(
+					'Your subscription is up for renewal in %1$s — that’s <strong>%2$s</strong>.',
 					'woocommerce-subscriptions'
 				),
-				(int) $subscription_days_til_event,
+				$subscription_time_til_event,
 				$subscription_event_date
 			),
 			[ 'strong' => [] ]

--- a/templates/emails/customer-notification-manual-trial-ending.php
+++ b/templates/emails/customer-notification-manual-trial-ending.php
@@ -33,15 +33,13 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		<?php
 			echo wp_kses(
 				sprintf(
-					// translators: %1$s: number of days until expiry, %2$s: date in local format.
-					_n(
-						'Your free trial expires in %1$s day — that’s <strong>%2$s</strong>.',
-						'Your free trial expires in %1$s days — that’s <strong>%2$s</strong>.',
-						(int) $subscription_days_til_event,
+					// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+					__(
+						'Your free trial expires in %1$s — that’s <strong>%2$s</strong>.',
 						'woocommerce-subscriptions'
 					),
-					(int) $subscription_days_til_event,
-					$subscription_event_date,
+					$subscription_time_til_event,
+					$subscription_event_date
 				),
 				[ 'strong' => [] ]
 			);

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -25,14 +25,12 @@ echo "\n\n";
 
 echo esc_html(
 	sprintf(
-		// translators: %1$s: number of days until expiry, %2$s: date in local format.
-		_n(
-			'Your subscription will automatically renew in %1$s day — that’s %2$s.',
-			'Your subscription will automatically renew in %1$s days — that’s %2$s.',
-			(int) $subscription_days_til_event,
+		// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+		__(
+			'Your subscription will automatically renew in %1$s — that’s %2$s.',
 			'woocommerce-subscriptions'
 		),
-		(int) $subscription_days_til_event,
+		$subscription_time_til_event,
 		$subscription_event_date
 	)
 );

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -25,14 +25,12 @@ echo "\n\n";
 
 echo esc_html(
 	sprintf(
-		// translators: %1$s: number of days until expiry, %2$s: date in local format.
-		_n(
-			'Your paid subscription begins when your free trial expires in %1$s day — that’s %2$s.',
-			'Your paid subscription begins when your free trial expires in %1$s days — that’s %2$s.',
-			(int) $subscription_days_til_event,
+		// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+		__(
+			'Your paid subscription begins when your free trial expires in %1$s — that’s %2$s.',
 			'woocommerce-subscriptions'
 		),
-		(int) $subscription_days_til_event,
+		$subscription_time_til_event,
 		$subscription_event_date
 	)
 );

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -25,14 +25,12 @@ echo "\n\n";
 
 echo esc_html(
 	sprintf(
-		// translators: %1$s: number of days until expiry, %2$s: date in local format.
-		_n(
-			'Your subscription expires in %1$s day — that’s %2$s.',
-			'Your subscription expires in %1$s days — that’s %2$s.',
-			(int) $subscription_days_til_event,
+		// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+		__(
+			'Your subscription expires in %1$s — that’s %2$s.',
 			'woocommerce-subscriptions'
 		),
-		(int) $subscription_days_til_event,
+		$subscription_time_til_event,
 		$subscription_event_date
 	)
 );

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -25,14 +25,12 @@ echo "\n\n";
 
 echo esc_html(
 	sprintf(
-		// translators: %1$s: number of days until expiry, %2$s: date in local format.
-		_n(
-			'Your subscription is up for renewal in %1$s day — that’s %2$s.',
-			'Your subscription is up for renewal in %1$s days — that’s %2$s.',
-			(int) $subscription_days_til_event,
+		// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+		__(
+			'Your subscription is up for renewal in %1$s — that’s %2$s.',
 			'woocommerce-subscriptions'
 		),
-		(int) $subscription_days_til_event,
+		$subscription_time_til_event,
 		$subscription_event_date
 	)
 );

--- a/templates/emails/plain/customer-notification-manual-trial-ending.php
+++ b/templates/emails/plain/customer-notification-manual-trial-ending.php
@@ -25,14 +25,12 @@ echo "\n\n";
 
 echo esc_html(
 	sprintf(
-		// translators: %1$s: number of days until expiry, %2$s: date in local format.
-		_n(
-			'Your free trial expires in %1$s day — that’s %2$s.',
-			'Your free trial expires in %1$s days — that’s %2$s.',
-			(int) $subscription_days_til_event,
+		// translators: %1$s: human readable time difference (eg 3 days, 1 day), %2$s: date in local format.
+		__(
+			'Your free trial expires in %1$s — that’s %2$s.',
 			'woocommerce-subscriptions'
 		),
-		(int) $subscription_days_til_event,
+		$subscription_time_til_event,
 		$subscription_event_date
 	)
 );


### PR DESCRIPTION
Contributes to https://github.com/woocommerce/woocommerce-subscriptions/issues/4737, together with https://github.com/Automattic/woocommerce-subscriptions-core/pull/710 fixes it.

## Description

This PR: 

1. Updates the **Automatic renewal notice** email subject so it includes the correct pluralisation of the time period until the renewal occurs. eg prior to this PR it would say in 1 days instead of 1 days.
2. Updates all the email templates to use a `human_time_diff()` value instead of always the number of days. eg if you have your pre-renewal emails to be sent 2 weeks prior to renewal (most likely only really long billing terms), it will now say in 2 weeks rather than in 14 days. 

> [!note] 
> \* I've updated the `get_time_until_date()` to now use the core [`human_time_diff()` ](https://developer.wordpress.org/reference/functions/human_time_diff/) function. There are a number of places where this is done in both Subscriptions and WooCommerce core in a similar way to include a comprehensible time difference within a sentence. By doing this for the email subject, I figured it also made sense to do something similar to the email bodies which also include a time period in days. 
  

Let me know what you think of this approach @peterfabian. 
## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to …
4. Click on …

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
