### PR TITLE
Update the notifications-related admin notice's copy

### DIFF
--- a/includes/admin/class-wcs-admin-notice.php
+++ b/includes/admin/class-wcs-admin-notice.php
@@ -191,7 +191,7 @@ class WCS_Admin_Notice {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
 	 */
 	public function print_dismiss_url() {
-		echo esc_attr( $this->dismiss_url );
+		echo esc_url( $this->dismiss_url );
 	}
 
 	/* Getters */

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -259,6 +259,7 @@ class WC_Subscriptions_Email_Notifications {
 	 * @return array Subscriptions settings.
 	 */
 	public static function add_settings( $settings ) {
+
 		$notification_settings = [
 			[
 				'name' => __( 'Customer Notifications', 'woocommerce-subscriptions' ),
@@ -334,7 +335,7 @@ class WC_Subscriptions_Email_Notifications {
 
 		$admin_notice   = new WCS_Admin_Notice( 'notice', array(), wp_nonce_url( add_query_arg( $action, 'dismiss' ), $action, $nonce ) );
 		$notice_title   = __( 'WooCommerce Subscriptions: Introducing customer email notifications!', 'woocommerce-subscriptions' );
-		$notice_content = __( 'You can now send email notifications for subscription renewals, expirations, and free trials. Go to the settings page to configure when your customers receive these important updates.', 'woocommerce-subscriptions' );
+		$notice_content = __( 'You can now send email notifications for subscription renewals, expirations, and free trials. Go to the "Customer Notifications" settings section to configure when your customers receive these important updates.', 'woocommerce-subscriptions' );
 		$html_content   = sprintf( '<p class="main"><strong>%1$s</strong></p><p>%2$s</p>', $notice_title, $notice_content );
 		$admin_notice->set_html_content( $html_content );
 		$admin_notice->set_actions(

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -311,6 +311,11 @@ class WC_Subscriptions_Email_Notifications {
 			return;
 		}
 
+		// Prevent showing the notice on the Subscriptions settings page.
+		if ( isset( $_GET['page'], $_GET['tab'] ) && 'wc-settings' === $_GET['page'] && 'subscriptions' === $_GET['tab'] ) {
+			return;
+		}
+
 		$option_name = 'wcs_hide_customer_notifications_notice';
 		$nonce       = '_wcsnonce';
 		$action      = 'wcs_hide_customer_notifications_notice_action';
@@ -327,22 +332,22 @@ class WC_Subscriptions_Email_Notifications {
 			return;
 		}
 
-		$admin_notice = new WCS_Admin_Notice( 'notice' );
-		$admin_notice->set_simple_content(
-			esc_html__(
-				'New customer email reminders for renewals, expirations, and free trials are now available! Enable and configure these features in WooCommerce > Settings > Subscriptions to control when your customers receive important updates.',
-				'woocommerce-subscriptions'
-			)
-		);
+		$admin_notice   = new WCS_Admin_Notice( 'notice', array(), wp_nonce_url( add_query_arg( $action, 'dismiss' ), $action, $nonce ) );
+		$notice_title   = __( 'WooCommerce Subscriptions: Introducing customer email notifications!', 'woocommerce-subscriptions' );
+		$notice_content = __( 'You can now send email notifications for subscription renewals, expirations, and free trials. Go to the settings page to configure when your customers receive these important updates.', 'woocommerce-subscriptions' );
+		$html_content   = sprintf( '<p class="main"><strong>%1$s</strong></p><p>%2$s</p>', $notice_title, $notice_content );
+		$admin_notice->set_html_content( $html_content );
 		$admin_notice->set_actions(
 			array(
 				array(
-					'name' => 'Manage Settings',
-					'url'  => admin_url( 'admin.php?page=wc-settings&tab=subscriptions' ),
+					'name'  => __( 'Manage settings', 'woocommerce-subscriptions' ),
+					'url'   => admin_url( 'admin.php?page=wc-settings&tab=subscriptions' ),
+					'class' => 'button button-primary',
 				),
 				array(
-					'name' => 'Dismiss',
-					'url'  => wp_nonce_url( add_query_arg( $action, 'dismiss' ), $action, $nonce ),
+					'name'  => __( 'Learn more', 'woocommerce-subscriptions' ),
+					'url'   => 'https://woocommerce.com/document/subscriptions/subscriptions-notifications/',
+					'class' => 'button',
 				),
 			)
 		);

--- a/templates/admin/html-admin-notice.php
+++ b/templates/admin/html-admin-notice.php
@@ -24,6 +24,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php endif; ?>
 
 	<?php if ( $notice->is_dismissible() ) : ?>
-		<a href="<?php echo esc_url( $notice->print_dismiss_url() ); ?>" type="button" class="notice-dismiss" style="text-decoration: none;"></a>
+		<a href="<?php $notice->print_dismiss_url(); ?>" type="button" class="notice-dismiss" style="text-decoration: none;"></a>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
## Description

This PR improves the wording of the admin notice for the notifications feature.

## Screenshot
![Screenshot 2024-11-01 at 5 12 45 PM](https://github.com/user-attachments/assets/a028bfb2-8dee-4fe1-ba72-8c47b4139c9a)


## How to test this PR

N/A
This changes the copy of existing functionality.

If the notice was previously dismissed, remove the option via`delete_option('wcs_hide_customer_notifications_notice')` and disable the notifications to display the notice on a store with existing notifications.



## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
