### PR TITLE
Introduce filter for first renewal timestamp.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.7.0 - xxxx-xx-xx =
+* Dev - Introduce the filter `woocommerce_subscriptions_synced_first_renewal_payment_timestamp` to enable plugins to modify the first renewal date of synced subscriptions.
+
 = 7.6.0 - 2024-10-14 =
 * Fix - Correctly updates a subscription status to `cancelled` during a payment failure call when the current status is `pending-cancel`.
 * Fix - Clear the `cancelled_email_sent` meta when a subscription is reactivated to allow the customer to receive future cancellation emails.

--- a/includes/class-wc-subscriptions-synchroniser.php
+++ b/includes/class-wc-subscriptions-synchroniser.php
@@ -857,6 +857,7 @@ class WC_Subscriptions_Synchroniser {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
 	public static function products_first_renewal_payment_time( $first_renewal_timestamp, $product_id, $from_date, $timezone ) {
+		$unmodified_first_renewal_timestamp = $first_renewal_timestamp;
 
 		if ( self::is_product_synced( $product_id ) ) {
 
@@ -871,7 +872,18 @@ class WC_Subscriptions_Synchroniser {
 			}
 		}
 
-		return $first_renewal_timestamp;
+		/**
+		 * Filter the first renewal payment date string for a product.
+		 *
+		 * @since 7.7.0
+		 *
+		 * @param int    $first_renewal_timestamp            The timestamp of the first renewal payment date.
+		 * @param int    $product_id                         The product ID.
+		 * @param string $from_date                          The date to calculate the first payment from in GMT/UTC timezone.
+		 * @param string $timezone                           The timezone to use for the first payment date.
+		 * @param int    $unmodified_first_renewal_timestamp The unmodified timestamp of the first renewal payment date.
+		 */
+		return apply_filters( 'woocommerce_subscriptions_synced_first_renewal_payment_timestamp', $first_renewal_timestamp, $product_id, $from_date, $timezone, $unmodified_first_renewal_timestamp );
 	}
 
 	/**


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

Introduces the filter `woocommerce_subscriptions_synced_first_renewal_payment_timestamp` within the method `WC_Subscriptions_Synchroniser::products_first_renewal_payment_time()`.

This filter allows plugins modifying the start date of syncronised subscriptions to modify the first renewal date too. At present the first renewal date is affected by the current time due to the `self::is_today()` condition. For plugins delaying the start date of a synced subscription, this can result in the first renewal being set before the start date, triggering a fatal error due to the logical fallacy of renewing a subscription before it begins.

Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4677

**How can it break?**

Without interaction from other plugins, the code is pretty safe. If another plugin makes use of the filter and incorrectly calculates the first renewal date it will cause problems but I don't think it's a big concern or a situation in which Subs can protect developers from their own mistakes.


## How to test this PR

1. Enable the synced subs feature, not pro-rated, do not charge
2. Create a synced sub product:
   - Simple Subscription
   - Monthly Cycle
   - Renews on the 15th 
3. Add the following as an mu-plugin:
   ```php
   add_filter( 'woocommerce_subscriptions_synced_first_renewal_payment_timestamp', function( $timestamp ) {
   	return $timestamp - DAY_IN_SECONDS;
   } );
   ```
4. Purchase the product
5. Observe the first payment is on the 14th.
6. Delete the mu-plugin created above to avoid confusion later.


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes https://github.com/woocommerce/woocommerce-subscriptions/issues/4677
- [ ] Will this PR affect WooCommerce Payments? no
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
