### PR TITLE
In our customer notification emails, only display the subscription that is about to renew or expire, don't show all subscriptions purchased in the parent order.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.7.1 - 2024-xx-xx =
+* Fix - Only show the individual subscription information in customer notification emails, not all subscriptions purchased in the initial order.
+
 = 7.7.0 - 2024-11-13 =
 * Add - New Customer Notification feature: sends reminder emails for upcoming subscription renewals, trials ending, and subscription expirations.
 * Fix - Prevent adding products to the cart if a subscription renewal is already present.

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -295,6 +295,32 @@ class WC_Subscriptions_Email {
 	}
 
 	/**
+	 * Show the subscription details table.
+	 *
+	 * @param WC_Subscription $subscription The subscription.
+	 * @param WC_Order|null   $order        The order related to the subscription - defaults to parent order.
+	 * @param bool            $sent_to_admin Whether the email is sent to admin - defaults to false
+	 * @param bool            $plain_text Whether the email should use plain text templates - defaults to false
+	 * @param WC_Email        $email
+	 */
+	public static function subscription_details( $subscriptions, $order = null, $sent_to_admin = false, $plain_text = false, $skip_my_account_link = false ) {
+		$template_base = WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' );
+		$template      = ( $plain_text ) ? 'emails/plain/subscription-info.php' : 'emails/subscription-info.php';
+
+		wc_get_template(
+			$template,
+			array(
+				'order'                => ! $order ? $subscription->get_parent() : $order,
+				'subscriptions'        => is_array( $subscriptions ) ? $subscriptions : [ $subscriptions ],
+				'is_admin_email'       => $sent_to_admin,
+				'skip_my_account_link' => $skip_my_account_link,
+			),
+			'',
+			$template_base
+		);
+	}
+
+	/**
 	 * Detach WC transactional emails from a specific hook.
 	 *
 	 * @param string Optional. The action hook or filter to detach WC core's transactional emails from. Defaults to the current filter.

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -297,11 +297,11 @@ class WC_Subscriptions_Email {
 	/**
 	 * Show the subscription details table.
 	 *
-	 * @param WC_Subscription $subscription The subscription.
-	 * @param WC_Order|null   $order        The order related to the subscription - defaults to parent order.
-	 * @param bool            $sent_to_admin Whether the email is sent to admin - defaults to false
-	 * @param bool            $plain_text Whether the email should use plain text templates - defaults to false
-	 * @param WC_Email        $email
+	 * @param WC_Subscription[] $subscriptions        List of subscriptions. Also accepts a single subscription.
+	 * @param WC_Order|null     $order                The order related to the subscription - defaults to parent order.
+	 * @param bool              $sent_to_admin        Whether the email is sent to admin - defaults to false.
+	 * @param bool              $plain_text           Whether the email should use plain text templates - defaults to false.
+	 * @param bool              $skip_my_account_link Whether to skip displaying the My Account link - defaults to false.
 	 */
 	public static function subscription_details( $subscriptions, $order = null, $sent_to_admin = false, $plain_text = false, $skip_my_account_link = false ) {
 		$template = ( $plain_text ) ? 'emails/plain/subscription-info.php' : 'emails/subscription-info.php';

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -304,8 +304,7 @@ class WC_Subscriptions_Email {
 	 * @param WC_Email        $email
 	 */
 	public static function subscription_details( $subscriptions, $order = null, $sent_to_admin = false, $plain_text = false, $skip_my_account_link = false ) {
-		$template_base = WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' );
-		$template      = ( $plain_text ) ? 'emails/plain/subscription-info.php' : 'emails/subscription-info.php';
+		$template = ( $plain_text ) ? 'emails/plain/subscription-info.php' : 'emails/subscription-info.php';
 
 		wc_get_template(
 			$template,
@@ -316,7 +315,7 @@ class WC_Subscriptions_Email {
 				'skip_my_account_link' => $skip_my_account_link,
 			),
 			'',
-			$template_base
+			WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
 		);
 	}
 

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -57,7 +57,6 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
-
 ?>
 	<p>
 		<small>

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -56,7 +56,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text, true );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
+
 ?>
 	<p>
 		<small>

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -69,7 +69,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text, true );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -56,7 +56,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text, true );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -97,7 +97,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/templates/emails/customer-notification-manual-trial-ending.php
+++ b/templates/emails/customer-notification-manual-trial-ending.php
@@ -51,7 +51,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -40,7 +40,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 echo "\n";
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text, true );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
 esc_html_e( 'You can manage this subscription from your account dashboard: ', 'woocommerce-subscriptions' );
 echo esc_url( wc_get_page_permalink( 'myaccount' ) );

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -46,7 +46,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text, true );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -40,7 +40,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text, true );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
 /**
  * Show user-defined additional content - this is set in each email's settings.

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -61,7 +61,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 

--- a/templates/emails/plain/customer-notification-manual-trial-ending.php
+++ b/templates/emails/plain/customer-notification-manual-trial-ending.php
@@ -38,7 +38,7 @@ echo esc_html(
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
 // Show subscription details.
-\WC_Subscriptions_Order::add_sub_info_email( $order, $sent_to_admin, $plain_text );
+\WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 


### PR DESCRIPTION
Fixes #721

## Description

While testing the new Customer Notification feature I noticed that in the table under "Subscription Information", it contained all of my subscriptions that I purchased in the parent/initial order.

For example, I purchased a weekly and an "every 2 days" subscription in the same order, and then processed the "upcoming renewal order" email for just the weekly subscription. When I viewed the email it the subscriptions table contained both of my subscriptions which is not correct:

![image](https://github.com/user-attachments/assets/568cb5b0-7a28-4b3f-afb8-c54b78e7f0eb)

We don't really have a function available which displays a single subscription info table, therefore this PR introduces a new function to fill this gap. The new `WC_Subscriptions_Email::subscription_details()` function added in this PR is similar to our existing `WC_Subscriptions_Email::order_details()` function and can be used to load the `subscriptions-info.php` template for single or multiple subscriptions.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> To test customer notifications you will need to either:
> 1. Add `return true;` at the top of [`should_send_reminder_email()` ](https://github.com/Automattic/woocommerce-subscriptions-core/blob/f311fe765206ee47b9986bbca2d04dbaccc80889/includes/emails/class-wcs-email-customer-notification.php#L269), or
> 2. Add `define( 'WP_ENVIRONMENT_TYPE', 'production' );` to your `wp-config.php` file
>
> You will also need a way to test receiving an email. For testing locally, I just use the `WP Mail Logging` plugin.

1. Go to **WooCommerce > Settings > Subscriptions** and enable the new Customer Notifications feature
2. Add a weekly and monthly subscription product to your cart and go successfully through the checkout
3. While on `trunk`, go to the Edit Subscription page for the weekly Subscription and use the actions to run "Send upcoming renewal notification".
4. View the email and notice that both subscriptions are listed under "Subscription Information" the upcoming renewal email :x:
5. Switch to this branch and confirm only the relevant subscription is listed in the email

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
