### PR TITLE
Correctly style My Account > Subscriptions actions as buttons when using a block theme

### DIFF
--- a/assets/css/view-subscription.css
+++ b/assets/css/view-subscription.css
@@ -7,6 +7,11 @@
 	}
 }
 
+.subscription_details .button {
+	display: inline-block;
+	margin-bottom: 0.5em;
+}
+
 .subscription-auto-renew-toggle {
 	margin-left: 5px;
 	margin-bottom: 2px;

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.8.0 - xxxx-xx-xx =
+* Fix - Use block theme-styled buttons for subscription and related-orders actions on My Account pages.
+
 = 7.7.1 - 2024-11-13 =
 * Fix - Only show the individual subscription information in customer notification emails, not all subscriptions purchased in the initial order.
 * Fix - Resolved issues with Customer Notification emails not being sent due to unsupported emoji used in the default email subject.

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -50,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php echo wp_kses_post( $subscription->get_formatted_order_total() ); ?>
 			</td>
 			<td class="subscription-actions order-actions woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-actions woocommerce-orders-table__cell-order-actions">
-				<a href="<?php echo esc_url( $subscription->get_view_order_url() ) ?>" class="woocommerce-button button view"><?php echo esc_html_x( 'View', 'view a subscription', 'woocommerce-subscriptions' ); ?></a>
+				<a href="<?php echo esc_url( $subscription->get_view_order_url() ) ?>" class="woocommerce-button button view<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html_x( 'View', 'view a subscription', 'woocommerce-subscriptions' ); ?></a>
 				<?php do_action( 'woocommerce_my_subscriptions_actions', $subscription ); ?>
 			</td>
 		</tr>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -89,7 +89,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 					if ( $actions ) {
 						foreach ( $actions as $key => $action ) {
-							echo wp_kses_post( '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button button ' . sanitize_html_class( $key ) . '">' . esc_html( $action['name'] ) . '</a>' );
+							echo wp_kses_post( '<a href="' . esc_url( $action['url'] ) . '" class="woocommerce-button button ' . sanitize_html_class( $key ) . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '">' . esc_html( $action['name'] ) . '</a>' );
 						}
 					}
 					?>

--- a/templates/myaccount/subscription-details.php
+++ b/templates/myaccount/subscription-details.php
@@ -81,11 +81,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<td><?php esc_html_e( 'Actions', 'woocommerce-subscriptions' ); ?></td>
 				<td>
 					<?php foreach ( $actions as $key => $action ) : ?>
-						<?php $classes = [ 'button', sanitize_html_class( $key ) ]; ?>
-						<?php $classes[] = isset( $action['block_ui'] ) && $action['block_ui'] ? 'wcs_block_ui_on_click' : '' ?>
+						<?php
+						$classes   = [ 'woocommerce-button', 'button', sanitize_html_class( $key ) ];
+						$classes[] = isset( $action['block_ui'] ) && $action['block_ui'] ? 'wcs_block_ui_on_click' : '';
+
+						if ( wc_wp_theme_get_element_class_name( 'button' ) ) {
+							$classes[] = wc_wp_theme_get_element_class_name( 'button' );
+						}
+						?>
 						<a
 							href="<?php echo esc_url( $action['url'] ); ?>"
-							class="<?php echo trim( implode( ' ', $classes ) ); ?>"
+							class="<?php echo esc_attr( trim( implode( ' ', $classes ) ) ); ?>"
 						>
 							<?php echo esc_html( $action['name'] ); ?>
 						</a>


### PR DESCRIPTION
Fixes 4748-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Stores using block themes will cause subscription action buttons to be displayed as links instead of the expected buttons. The issue with this is the links are tightly grouped making it confusing to understand that these are actually individual links.

This PR brings back the button styles when switching to a block theme for:
- The list of subscription actions on the single view subscription page (i.e "Cancel", "Change payment" etc)
- The "View" links on the related order table
- The "View" links on the subscriptions list

**View Subscription Actions**

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a8bd32b0-39b4-4545-8a2c-b7600804625a) | ![image](https://github.com/user-attachments/assets/6f27cc3f-be2c-432e-88e9-f9447df5d835) |

**Related Orders Actions**

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2f14d600-197d-48ca-bbbf-72341ed9a3dc) | ![image](https://github.com/user-attachments/assets/8a3d7341-b4c5-4913-bf19-9c6ab772d30a) |

**Subscriptions List**

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b1b1f302-6169-470b-86c0-2ac6f39327ff)| ![image](https://github.com/user-attachments/assets/ca158b97-b707-4eb6-8292-a5f98ada8e62) |

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. While on `trunk` enable the `Twenty Twenty Four` theme and visit your My Account Page
2. When viewing My Account subscription pages, notice that the buttons are being displayed as links
3. Checkout this branch and confirm the links are now displayed properly as buttons.
4. Switch to a non-block theme like Storefront and confirm no changes.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
