### PR TITLE
Updates link on order thank-you page to take customers to My Account > Subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 7.8.0 - xxxx-xx-xx =
+* Update - Changed the link on the order thank-you page to take customers directly to their "My Account > Subscriptions" page.
+
 = 7.7.1 - 2024-11-13 =
 * Fix - Only show the individual subscription information in customer notification emails, not all subscriptions purchased in the initial order.
 * Fix - Resolved issues with Customer Notification emails not being sent due to unsupported emoji used in the default email subject.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -339,7 +339,7 @@ class WC_Subscriptions_Order {
 			$subscriptions                = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'any' ) );
 			$subscription_count           = count( $subscriptions );
 			$thank_you_message            = '';
-			$my_account_subscriptions_url = get_permalink( wc_get_page_id( 'myaccount' ) );
+			$my_account_subscriptions_url = wc_get_endpoint_url( 'subscriptions', '', wc_get_page_permalink( 'myaccount' ) );
 
 			if ( $subscription_count ) {
 				foreach ( $subscriptions as $subscription ) {

--- a/includes/class-wcs-query.php
+++ b/includes/class-wcs-query.php
@@ -152,7 +152,7 @@ class WCS_Query extends WC_Query {
 	 * @return string
 	 */
 	public function maybe_redirect_to_only_subscription( $url, $endpoint ) {
-		if ( $this->query_vars['subscriptions'] === $endpoint && is_account_page() ) {
+		if ( $this->query_vars['subscriptions'] === $endpoint && ( is_account_page() || is_order_received_page() ) ) {
 			$subscriptions = wcs_get_users_subscriptions();
 
 			if ( is_array( $subscriptions ) && 1 === count( $subscriptions ) && apply_filters( 'wcs_my_account_redirect_to_single_subscription', true ) ) {


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Requested in slack here: p1731689382911189-slack-C07CBV7SKPH

After purchasing a subscription product, we tell customers to view their subscription status from their account page. Clicking the link currently takes you to the main myaccount page and then you have to navigate to subscriptions from there.

![image](https://github.com/user-attachments/assets/6f9b72ed-37a3-4727-b4e0-157430ba3279)

This PR updates this link to take the customers directly to their `my-account/subscriptions` page to view their subscription.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Purchase a subscription product
2. On the Order Received page, click on link in "View the status of your subscription in **your account**"
3. While on this branch, confirm you're redirected to the View subscriptions page:
![image](https://github.com/user-attachments/assets/e8c121a4-09bc-4a68-b768-0bd35532292c)


## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)