### PR TITLE
Fixes notices being displayed on WordPress 6.7 due to loading translations too early.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.8.0 - xxxx-xx-xx =
 * Fix - Use block theme-styled buttons for subscription and related-orders actions on My Account pages.
+* Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early.
 * Update - Changed the link on the order thank-you page to take customers directly to their "My Account > Subscriptions" page.
 
 = 7.7.1 - 2024-11-13 =

--- a/includes/data-stores/class-wcs-customer-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-customer-store-cached-cpt.php
@@ -70,13 +70,20 @@ class WCS_Customer_Store_Cached_CPT extends WCS_Customer_Store_CPT implements WC
 
 		$this->object_data_cache_manager->init();
 
+		add_action( 'init', array( $this, 'register_debug_tools' ) );
+
 		// When a user is first added, make sure the subscription cache is empty because it can not have any data yet, and we want to avoid running the query needlessly
 		add_filter( 'user_register', array( $this, 'set_empty_cache' ) );
 
 		// When the post for a subscription is change, make sure the corresponding cache is updated
 		add_action( 'wcs_update_post_meta_caches', array( $this, 'maybe_update_for_post_meta_change' ), 10, 5 );
 		add_action( 'wcs_delete_all_post_meta_caches', array( $this, 'maybe_delete_all_for_post_meta_change' ), 10, 1 );
+	}
 
+	/**
+	 * Register debug tools for managing the cache.
+	 */
+	public function register_debug_tools() {
 		WCS_Debug_Tool_Factory::add_cache_tool( 'generator', __( 'Generate Customer Subscription Cache', 'woocommerce-subscriptions' ), __( 'This will generate the persistent cache for linking users with subscriptions. The caches will be generated overtime in the background (via Action Scheduler).', 'woocommerce-subscriptions' ), self::instance() );
 		WCS_Debug_Tool_Factory::add_cache_tool( 'eraser', __( 'Delete Customer Subscription Cache', 'woocommerce-subscriptions' ), __( 'This will clear the persistent cache of all of subscriptions stored against users in your store. Expect slower performance of checkout, renewal and other subscription related functions after taking this action. The caches will be regenerated overtime as queries to find a given user\'s subscriptions are run.', 'woocommerce-subscriptions' ), self::instance() );
 	}

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -92,6 +92,8 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 
 		$this->object_data_cache_manager->init();
 
+		add_action( 'init', array( $this, 'register_debug_tools' ) );
+
 		// When a subscription is being read from the database, don't load cached related order meta data into subscriptions.
 		add_filter( 'wcs_subscription_data_store_props_to_ignore', array( $this, 'add_related_order_cache_props' ), 10, 2 );
 
@@ -104,7 +106,12 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 
 		// When copying meta from a subscription to a renewal order, don't copy cache related order meta keys.
 		add_filter( 'wc_subscriptions_renewal_order_data', array( $this, 'remove_related_order_cache_keys' ), 10, 1 );
+	}
 
+	/**
+	 * Register debug tools for managing the cache.
+	 */
+	public function register_debug_tools() {
 		WCS_Debug_Tool_Factory::add_cache_tool( 'generator', __( 'Generate Related Order Cache', 'woocommerce-subscriptions' ), __( 'This will generate the persistent cache of all renewal, switch, resubscribe and other order types for all subscriptions in your store. The caches will be generated overtime in the background (via Action Scheduler).', 'woocommerce-subscriptions' ), self::instance() );
 		WCS_Debug_Tool_Factory::add_cache_tool( 'eraser', __( 'Delete Related Order Cache', 'woocommerce-subscriptions' ), __( 'This will clear the persistent cache of all renewal, switch, resubscribe and other order types for all subscriptions in your store. Expect slower performance of checkout, renewal and other subscription related functions after taking this action. The caches will be regenerated overtime as related order queries are run.', 'woocommerce-subscriptions' ), self::instance() );
 	}

--- a/includes/privacy/class-wcs-privacy.php
+++ b/includes/privacy/class-wcs-privacy.php
@@ -37,7 +37,16 @@ class WCS_Privacy extends WC_Abstract_Privacy {
 			self::$background_process = new WCS_Privacy_Background_Updater();
 		}
 
-		parent::__construct( __( 'WooCommerce Subscriptions', 'woocommerce-subscriptions' ) );
+		parent::__construct();
+
+		add_action( 'init', array( $this, 'register_erasers_exporters' ) );
+	}
+
+	/**
+	 * Register erasers and exporters.
+	 */
+	public function register_erasers_exporters() {
+		$this->name = __( 'WooCommerce Subscriptions', 'woocommerce-subscriptions' );
 
 		// Add our exporters and erasers.
 		$this->add_exporter( 'woocommerce-subscriptions-data', __( 'Subscriptions Data', 'woocommerce-subscriptions' ), array( 'WCS_Privacy_Exporters', 'subscription_data_exporter' ) );

--- a/includes/wcs-compatibility-functions.php
+++ b/includes/wcs-compatibility-functions.php
@@ -603,11 +603,7 @@ function wcs_is_wc_feature_enabled( $feature_name ) {
  * @return bool
  */
 function wcs_is_custom_order_tables_usage_enabled() {
-	if ( ! class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' ) || ! wcs_is_wc_feature_enabled( 'custom_order_tables' ) ) {
-		return false;
-	}
-
-	return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+	return class_exists( '\Automattic\WooCommerce\Utilities\OrderUtil' ) && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
 }
 
 /**


### PR DESCRIPTION
Fixes 4747-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

WordPress 6.7 introduced changes that throws a "doing it wrong" error when translations are loaded before init.
See full change: https://core.trac.wordpress.org/changeset/59127\

Subscription stores that have updated to WordPress 6.7 and are using translations (i.e. language is set to something other than US English) will see the following notices:

![image](https://github.com/user-attachments/assets/b0296c95-12c7-4d54-8979-1eca249b4218)

There are a couple of areas of code causing this error to be displayed:

#### 1. Calling `wcs_is_custom_order_tables_usage_enabled()` before the `init` hook.

Across subscriptions, we typically call this function on `woocommerce_loaded` and then attach different hooks depending on whether HPOS is enabled or disabled.

The reason this causes issues is because this function calls `FeaturesUtil::feature_is_enabled()`, which gets a list of enabled features and their descriptions which are translatable.

To fix this, rather than updating all of our `wcs_is_custom_order_tables_usage_enabled()` uses to trigger later, I decided to update `wcs_is_custom_order_tables_usage_enabled()` to no longer call `FeaturesUtil::feature_is_enabled()`. Discussed here with SWW team: pdqkbG-4Q2-p2#comment-2255

#### 2. Calling `__( 'some text', 'woocommerce-subscriptions' );` before `init` hook

There were only a few instances across Subscriptions where we were calling `__()` too early. I fixed these by moving them to trigger on `init` instead of in the classes `__construct()` or immediately after. There were only 3 instances of this that needed updating:
 - `WCS_Customer_Store_Cached_CPT` - Adding WC Debug tools
 - `WCS_Related_Order_Store_Cached_CPT` - Adding WC Debug tools
 - `WCS_Privacy` - Registering subscription privacy exporter/erasers

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Testing changes to `wcs_is_custom_order_tables_usage_enabled()`

1. With HPOS enabled, purchase a subscription product through the checkout
2. Trash the parent order of this new subscription
3. Confirm the subscription is also trashed
4. Disable HPOS and run the tests again to confirm the correct hooks are being added.

#### Testing moving `__()` to be triggered later

1. Go to **WooCommerce > Status > Tools**
2. Confirm the following caching tools exist:
   1. Generate Related Order Cache
   2. Delete Related Order Cache
   3. Generate Customer Subscription Cache
   4. Delete Customer Subscription Cache

#### Confirm `_doing_it_wrong()` errors are not displayed

1. Update to WooCommerce 9.4 and WordPress 6.7
2. Go to your Edit User Profile page and set your language to Español ![image](https://github.com/user-attachments/assets/e0d64fdf-a9c7-4d69-8d4e-bd4455d1ee79)
3. Save your settings and reload any WP Admin page
4. Confirm there's no errors.
5. Switch to `trunk` to confirm the errors are displayed.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)