### PR TITLE
Manually clear subscription object from cache after removing order items via My Account > View Subscription page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.8.0 - xxxx-xx-xx =
 * Fix - Use block theme-styled buttons for subscription and related-orders actions on My Account pages.
+* Fix - Subscription totals not properly updating when customers remove items via the My Account > View Subscription page on some stores with caching enabled.
 * Update - Changed the link on the order thank-you page to take customers directly to their "My Account > Subscriptions" page.
 
 = 7.7.1 - 2024-11-13 =

--- a/includes/class-wcs-remove-item.php
+++ b/includes/class-wcs-remove-item.php
@@ -143,6 +143,10 @@ class WCS_Remove_Item {
 				}
 			}
 
+			// Clear cache after updating subscription items.
+			clean_post_cache( $subscription->get_id() );
+			wc_delete_shop_order_transients( $subscription );
+
 			/**
 			 * In WooCommerce 3.0 the subscription object and its items override the database with their current content,
 			 * so we lost the changes we just did with `wc_update_order_item`. Re-reading the object fixes this problem.


### PR DESCRIPTION
Fixes 4736-gh-woocommerce/woocommerce-subscriptions

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

On sites with caching enabled, there's an issue where after removing an order item from the My Account > View Subscription page, the subscription totals are not being calculated using the latest order item updates.

I wasn't able to reproduce the original issue locally, however after creating a Jurassic Ninja test site with Drop-in Cache Plugins enabled I was able to reproduce:
![image](https://github.com/user-attachments/assets/18a94ffc-56b4-4957-9a31-6f63b962987a)

Given this, fixing the issue required clearing the subscription from cache before fetching a new instance of it.

To remove the order item we call `wcs_update_order_item_type()` which already clears the subscription order items cache (i.e. `wp_cache_delete( 'order-items-' . $order_or_subscription_id, 'orders' )` ), but this wasn't enough it seems.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a fresh JN test site with Drop-in Cache Plugins enabled (the default option)
2. Create two subscription products $15/monthly and $20/monthly
3. Purchase these two subscriptions together through the same checkout 
4. On the My Account > View Subscription page, click on the :x: next to the line item to remove it ![image](https://github.com/user-attachments/assets/3aa0ac0e-e2de-442c-984a-b966deb773db)
6. While on `trunk` you will noticed the line item totals were not updated ![image](https://github.com/user-attachments/assets/1e7a6890-2655-4d84-94e5-16c59938f6fc)
7. While using these changes (will need to build zip and upload it to the JN test site)

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
