### PR TITLE
Update subscription buttons to support block theme styles

### DIFF
--- a/templates/checkout/form-change-payment-method.php
+++ b/templates/checkout/form-change-payment-method.php
@@ -111,7 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<?php
 			echo wp_kses(
-				apply_filters( 'woocommerce_change_payment_button_html', '<input type="submit" class="button alt" id="place_order" value="' . esc_attr( $pay_order_button_text ) . '" data-value="' . esc_attr( $pay_order_button_text ) . '" />' ),
+				apply_filters( 'woocommerce_change_payment_button_html', '<input type="submit" class="button alt' . esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ) . '" id="place_order" value="' . esc_attr( $pay_order_button_text ) . '" data-value="' . esc_attr( $pay_order_button_text ) . '" />' ),
 				array(
 					'input' => array(
 						'type'       => array(),

--- a/templates/myaccount/related-subscriptions.php
+++ b/templates/myaccount/related-subscriptions.php
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php echo wp_kses_post( $subscription->get_formatted_order_total() ); ?>
 				</td>
 				<td class="subscription-actions order-actions woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-actions woocommerce-orders-table__cell-order-actions">
-					<a href="<?php echo esc_url( $subscription->get_view_order_url() ) ?>" class="woocommerce-button button view"><?php echo esc_html_x( 'View', 'view a subscription', 'woocommerce-subscriptions' ); ?></a>
+					<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" class="woocommerce-button button view<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html_x( 'View', 'view a subscription', 'woocommerce-subscriptions' ); ?></a>
 				</td>
 			</tr>
 		<?php endforeach; ?>

--- a/templates/single-product/add-to-cart/subscription.php
+++ b/templates/single-product/add-to-cart/subscription.php
@@ -26,7 +26,7 @@ if ( $product->is_in_stock() ) : ?>
 	<?php if ( ! $product->is_purchasable() && 0 !== $user_id && 'no' !== wcs_get_product_limitation( $product ) && wcs_is_product_limited_for_user( $product, $user_id ) ) : ?>
 		<?php $resubscribe_link = wcs_get_users_resubscribe_link_for_product( $product->get_id() ); ?>
 		<?php if ( ! empty( $resubscribe_link ) && 'any' === wcs_get_product_limitation( $product ) && wcs_user_has_subscription( $user_id, $product->get_id(), wcs_get_product_limitation( $product ) ) && ! wcs_user_has_subscription( $user_id, $product->get_id(), 'active' ) && ! wcs_user_has_subscription( $user_id, $product->get_id(), 'on-hold' ) ) : // customer has an inactive subscription, maybe offer the renewal button. ?>
-			<a href="<?php echo esc_url( $resubscribe_link ); ?>" class="button product-resubscribe-link"><?php esc_html_e( 'Resubscribe', 'woocommerce-subscriptions' ); ?></a>
+			<a href="<?php echo esc_url( $resubscribe_link ); ?>" class="button product-resubscribe-link<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php esc_html_e( 'Resubscribe', 'woocommerce-subscriptions' ); ?></a>
 		<?php else : ?>
 			<p class="limited-subscription-notice notice"><?php esc_html_e( 'You have an active subscription to this product already.', 'woocommerce-subscriptions' ); ?></p>
 		<?php endif; ?>

--- a/templates/single-product/add-to-cart/variable-subscription.php
+++ b/templates/single-product/add-to-cart/variable-subscription.php
@@ -25,7 +25,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 		<?php if ( ! $product->is_purchasable() && 0 !== $user_id && 'no' !== wcs_get_product_limitation( $product ) && wcs_is_product_limited_for_user( $product, $user_id ) ) : ?>
 			<?php $resubscribe_link = wcs_get_users_resubscribe_link_for_product( $product->get_id() ); ?>
 			<?php if ( ! empty( $resubscribe_link ) && 'any' === wcs_get_product_limitation( $product ) && wcs_user_has_subscription( $user_id, $product->get_id(), wcs_get_product_limitation( $product ) ) && ! wcs_user_has_subscription( $user_id, $product->get_id(), 'active' ) && ! wcs_user_has_subscription( $user_id, $product->get_id(), 'on-hold' ) ) : // customer has an inactive subscription, maybe offer the renewal button. ?>
-				<a href="<?php echo esc_url( $resubscribe_link ); ?>" class="woocommerce-button button product-resubscribe-link"><?php esc_html_e( 'Resubscribe', 'woocommerce-subscriptions' ); ?></a>
+				<a href="<?php echo esc_url( $resubscribe_link ); ?>" class="woocommerce-button button product-resubscribe-link<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php esc_html_e( 'Resubscribe', 'woocommerce-subscriptions' ); ?></a>
 			<?php else : ?>
 				<p class="limited-subscription-notice notice"><?php esc_html_e( 'You have an active subscription to this product already.', 'woocommerce-subscriptions' ); ?></p>
 			<?php endif; ?>


### PR DESCRIPTION
## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

More instances of: 4748-gh-woocommerce/woocommerce-subscriptions

In a [recent PR](https://github.com/Automattic/woocommerce-subscriptions-core/pull/727) I fixed some of these already however, I found more instances where subscription-related buttons were styled incorrectly on block themes. Specifically on the change payment payment page and the related subscriptions table displayed on the order thank-you page.

### Change payment method

| `trunk` 🙈  | This branch |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f344dfda-9fb6-47d7-99e8-26434e137edc) | ![image](https://github.com/user-attachments/assets/fcc74a2a-0829-45fb-a2ad-034405fb02fb) | 

### Related Subscriptions table

| `trunk` | This branch |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/827273cf-74d9-4e2b-a9ec-cef691f4e0bf) | ![image](https://github.com/user-attachments/assets/55d5b088-40fa-49ac-b045-aeafc584b66e) | 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch to a block theme (i.e. default Twenty twenty four theme)
2. Purchase a subscription product
3. While on the order thank-you page, confirm you see a button in the related subscriptions table
4. Visit the My Account > Subscriptions > View Subscription page
5. Click on the "Change payment" action, while on the change payment form, confirm the "Change Payment method" is properly styled.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
