### PR TITLE
Prevent our WC_Subscriptions_Data_Copier from being able to update the ID of an order or subscription

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.8.0 - xxxx-xx-xx =
 * Fix - Use block theme-styled buttons for subscription and related-orders actions on My Account pages.
+* Fix - Resolved unexpected errors during the renewal process when a subscription contains metadata with key "id".
 * Update - Changed the link on the order thank-you page to take customers directly to their "My Account > Subscriptions" page.
 
 = 7.7.1 - 2024-11-13 =

--- a/includes/class-wc-subscriptions-data-copier.php
+++ b/includes/class-wc-subscriptions-data-copier.php
@@ -41,6 +41,7 @@ class WC_Subscriptions_Data_Copier {
 		'_trial_period',
 		'_created_via',
 		'_order_stock_reduced',
+		'id',
 	];
 
 	/**


### PR DESCRIPTION
Slack thread: p1726775258906899-slack-C7U3Y3VMY

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

While investigating an issue on a merchants site, @kaushikasomaiya and @nicdwilson discovered an unexpected bug with our data copier class when the `$from_object` contains the 'id' meta. In short, this results in our data copier unexpectedly calling `$to_object->set_id()` and setting a new ID of the `to_object`. 🙈

In this particular support ticket, a subscription contained metadata with key 'id' and the value set to the ID of itself. When this subscription processed a renewal order, the metadata from the subscription was copied to the new renewal order resulting in the renewal order's ID being set to the subscription's ID.

Not only is this bad enough, it also then caused subsequent code to run like:

```
$order_item_id = wc_add_order_item( $new_order->get_id(), array(
	'order_item_name' => $item_name,
	'order_item_type' => $item->get_type(),
) );
```

This caused the subscription to add/duplicate the order items, instead of adding them to the renewal order.

---

Typically, we would require third-party extensions to hook onto `wc_subscriptions_{copy_type}_data` and tell us which data should not be copied, however, given the severity and impact that this particular meta can cause, and also not knowing which plugin/custom code added this 'id' field, it make sense for us to add this to the list of default meta to not copy.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Disable HPOS on your store (with HPOS enabled it results in the subscription disappearing entirely 💥)
2. Purchase a new subscription with just one product
3. Manually add metadata 'id' with the value being the ID of the subscription itself, i.e.
```
update_post_meta( 123, 'id', 123 );
```
4. Process a renewal order for this subscription using the subscription actions on the Edit Subscription page.
5. On `trunk` you will likely get a fatal error on refresh or a memory leak issue.
6. Navigate back to your **WooCommerce > Subscriptions** list table and notice that the subscription is on-hold and it now contains two order items (duplicated the order items).
![image](https://github.com/user-attachments/assets/5c09a07a-23c7-46f2-a621-f5b339a8b3f3)
7. Check out this branch and run the same tests again to confirm this issue has been fixed.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)