### PR TITLE
Fix missing doc to order_type argument on wcs_get_subscriptions_for_order function

### DIFF
--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *    'product_id' The post ID of a WC_Product_Subscription, WC_Product_Variable_Subscription or WC_Product_Subscription_Variation object
  *    'order_id' The post ID of a shop_order post/WC_Order object which was used to create the subscription
  *    'subscription_status' Any valid subscription status. Can be 'any', 'active', 'cancelled', 'on-hold', 'expired', 'pending' or 'trash'. Defaults to 'any'.
- *    'order_type' Get subscriptions for the any order type in this array. Can include 'any', 'parent', 'renewal' or 'switch', defaults to parent.
+ *    'order_type' Get subscriptions for the any order type in this array. Can include 'any', 'parent', 'renewal', 'resubscribe' or 'switch', defaults to 'parent'.
  * @return WC_Subscription[] Subscription details in post_id => WC_Subscription form.
  * @since  1.0.0 - Migrated from WooCommerce Subscriptions v2.0
  */


### PR DESCRIPTION
## Description

It is possible to use `resubscribe` as `order_type` argument on the function `wcs_get_subscriptions_for_order`. It is used by [`wcs_get_subscriptions_for_resubscribe_order`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/13977b5084a37030282342d828e91c141ba64d9a/includes/wcs-resubscribe-functions.php#L141), but the type is not present in the argument documentation.

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

No code to test.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
