### PR TITLE
Change variation's single_add_to_cart_text() 

### DIFF
--- a/includes/class-wc-product-subscription-variation.php
+++ b/includes/class-wc-product-subscription-variation.php
@@ -110,7 +110,7 @@ class WC_Product_Subscription_Variation extends WC_Product_Variation {
 	 * @return string
 	 */
 	public function single_add_to_cart_text() {
-		return apply_filters( 'woocommerce_product_single_add_to_cart_text', self::add_to_cart_text(), $this );
+		return apply_filters( 'woocommerce_product_single_add_to_cart_text', WC_Subscriptions_Product::get_add_to_cart_text(), $this );
 	}
 
 	/**


### PR DESCRIPTION
to use `WC_Subscriptions_Product::get_add_to_cart_text()` as default value. This avoids the `woocommerce_product_add_to_cart_text` filter. Closes #741.
