### PR TITLE
Suspend subscription only when failing renewal is most recent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.8.0 - xxxx-xx-xx =
+* Fix - Prevent failing non-recent renewal order from suspending the subscription and marking the most recent renewal order as failed.
 * Fix - Use block theme-styled buttons for subscription and related-orders actions on My Account pages.
 * Fix - Subscription totals not properly updating when customers remove items via the My Account > View Subscription page on some stores with caching enabled.
 * Fix - Resolved unexpected errors during the renewal process when a subscription contains metadata with key "id".

--- a/includes/class-wc-subscriptions-renewal-order.php
+++ b/includes/class-wc-subscriptions-renewal-order.php
@@ -139,7 +139,8 @@ class WC_Subscriptions_Renewal_Order {
 				if ( $is_failed_renewal_order ) {
 					do_action( 'woocommerce_subscriptions_paid_for_failed_renewal_order', wc_get_order( $order_id ), $subscription );
 				}
-			} elseif ( 'failed' == $orders_new_status ) {
+			} elseif ( 'failed' === $orders_new_status && wcs_is_order_last_renewal_of_subscription( $order, $subscription ) ) {
+				// We will suspend the subscription if the latest renewal order fails.
 				$subscription->payment_failed();
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3556

## Description
In https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3556, when the merchant loses a dispute for one of a subscription's renewals, the disputed renewal order is set to `failed`, the subscription is set to `on-hold`, and the most recent renewal order, which may or may not be the same as the disputed order, is also set to `failed`.

This PR changes the behavior such that we only want to update the status of the affected renewal order, and only put the subscription on hold if the failing renewal is the most recent renewal.

This is similar to #625, which fixes successful renewals and subscription activation.

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR
We want to simulate a case where a subscription renewal (that is not the most recent renewal) is disputed and the merchant lost the dispute.

1. Make sure your Stripe webhooks are working properly.
2. Since we are simulating a dispute using a special CC number, the dispute webhook might fire unrealistically too soon, before the charge info is associated with the order. Add a `sleep(5);` on the first line of [`WC_Stripe_Webhook_Handler::process_webhook_dispute()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/b919ed35db707a0c9396ce29e07e570dc3f0b11c/includes/class-wc-stripe-webhook-handler.php#L337).
3. Purchase a subscription using `4242424242424242`.
4. In My Account > Subscriptions, verify the subscription is set to auto-renew as expected, and change the payment method to `4000000000000259`, a special dispute CC number.
5. In WooCommerce > Subscriptions > Edit Subscription, process a renewal for the subscription.
6. Wait for a few seconds and verify the dispute kicked in, and the renewal order has been put on hold.
7. In My Account > Subscriptions, change the payment method back to `4242424242424242`.
8. **Refresh the Edit Subscription page to load the updated payment method (important)**,  and then process a couple of renewals for the subscription.
   - These renewals should succeed, with no dispute.
9. In your Stripe dashboard, accept the dispute for the renewal in Step 5. (There should only be one dispute.)
10. In `develop`, the disputed order and the most recent order gets set to `failed`, and the subscription itself is set to `on-hold`.
11. In this branch, only the disputed order gets set to `failed`, and the subscription remains active.


| Before | After |
|--------|-------|
| <img width="823" alt="Screenshot 2024-12-13 at 10 54 08 AM" src="https://github.com/user-attachments/assets/021d54c6-2f94-4cca-b7c9-23f427a0f808" /> | <img width="823" alt="Screenshot 2024-12-13 at 10 53 45 AM" src="https://github.com/user-attachments/assets/f5659f57-22b8-4720-ac05-3c2f9ad9a8c5" /> |







## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes
- [ ] Will this PR affect WooCommerce Payments? no
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
