### PR TITLE
Do not unset package contents for Shipping Subscriptions with free trials

### DIFF
--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -650,12 +650,6 @@ class WC_Subscriptions_Cart {
 
 		if ( 'none' === self::$calculation_type ) {
 			foreach ( $packages as $index => $package ) {
-				foreach ( $package['contents'] as $cart_item_key => $cart_item ) {
-					if ( WC_Subscriptions_Product::get_trial_length( $cart_item['data'] ) > 0 ) {
-						unset( $packages[ $index ]['contents'][ $cart_item_key ] );
-					}
-				}
-
 				if ( empty( $packages[ $index ]['contents'] ) ) {
 					unset( $packages[ $index ] );
 				}

--- a/includes/class-wc-subscriptions-cart.php
+++ b/includes/class-wc-subscriptions-cart.php
@@ -650,6 +650,12 @@ class WC_Subscriptions_Cart {
 
 		if ( 'none' === self::$calculation_type ) {
 			foreach ( $packages as $index => $package ) {
+				foreach ( $package['contents'] as $cart_item_key => $cart_item ) {
+					if ( WC_Subscriptions_Product::get_trial_length( $cart_item['data'] ) > 0 && apply_filters( 'wcs_unset_package_contents', '__return_true' ) ) {
+						unset( $packages[ $index ]['contents'][ $cart_item_key ] );
+					}
+				}
+
 				if ( empty( $packages[ $index ]['contents'] ) ) {
 					unset( $packages[ $index ] );
 				}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/9771

## Description

Enables shipping options for variable subscriptions with free trial.

## How to test this PR

To be tested along with https://github.com/Automattic/woocommerce-payments/pull/9955
