### PR TITLE
Github workflows: manually install svn

### DIFF
--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   phpcs:
     name:    PHP Code Sniffer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name:    PHP Linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -71,7 +71,7 @@ jobs:
           bash bin/run-ci-tests.sh
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       WC_VERSION: 7.7.0  # the min supported version as per L-2 policy
       WP_VERSION: 'latest'
@@ -92,7 +92,7 @@ jobs:
       - run: bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       WC_VERSION: 'beta'
       WP_VERSION: 'latest'

--- a/.github/workflows/php-lint-test.yml
+++ b/.github/workflows/php-lint-test.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   phpcs:
     name:    PHP Code Sniffer
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -27,12 +27,14 @@ jobs:
           php-version: '7.3' # needs >=7.3 for SARB
           tools:       composer
           coverage:    none
+      - name: Install SVN
+        run: sudo apt-get install -y subversion
       # install dependencies and run phpcs
       - run: composer self-update 2.0.6 && composer install --no-progress && composer phpcs
 
   lint:
     name:    PHP Linting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -41,12 +43,14 @@ jobs:
         with:
           php-version: '7.3'
           coverage:    none
+      - name: Install SVN
+        run: sudo apt-get install -y subversion
       # run CI checks
       - run: find . \( -path ./vendor \) -prune -o \( -name '*.php' \) -exec php -lf {} \;| (! grep -v "No syntax errors detected" )
 
   test:
     name:    PHP testing
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -64,14 +68,16 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools:       composer
+          tools: composer
+      - name: Install SVN
+        run: sudo apt-get install -y subversion
       # run CI checks
       - run: |
           echo "bash bin/run-ci-tests.sh"
           bash bin/run-ci-tests.sh
   compatibility-oldest:
     name: Run unit tests on Oldest supported version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       WC_VERSION: 7.7.0  # the min supported version as per L-2 policy
       WP_VERSION: 'latest'
@@ -88,11 +94,13 @@ jobs:
         with:
           php-version: '7.3'
           tools: composer
+      - name: Install SVN
+        run: sudo apt-get install -y subversion
       # run CI checks
       - run: bash bin/run-ci-tests.sh
   compatibility-beta:
     name: Run unit tests on beta WC
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       WC_VERSION: 'beta'
       WP_VERSION: 'latest'
@@ -108,6 +116,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools:       composer
+          tools: composer
+      - name: Install SVN
+        run: sudo apt-get install -y subversion
       # run CI checks
       - run: bash bin/run-ci-tests.sh


### PR DESCRIPTION
## Description
Recent workflow runs have been failing with `bin/install-wp-tests.sh: line 141: svn: command not found`, as the latest Ubuntu version no longer has `svn` pre-installed.

In this PR, we add a step to manually install `subversion` before running our tests.

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR
Verify Github workflows succeed.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply): does not apply
- [x] Will this PR affect WooCommerce Subscriptions? no
- [x] Will this PR affect WooCommerce Payments? no
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
