### PR TITLE
Add support for signup fee coupons during subscription switches

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.9.0 - xxxx-xx-xx =
+* Add - Support use of sign up fee coupons during subscription switches.
 * Fix - Prevent payment gateways that complete Change Payment requests asynchronously from blocking future attempts to update payment methods for all subscriptions.
 
 = 7.8.0 - 2024-12-16 =

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -219,10 +219,14 @@ class WC_Subscriptions_Coupon {
 				}
 			}
 
-			// Compute the sign-up fee. If it's a switch, we need to get the signup fee less
-			// recurring payment upgrade/downgrade costs.
+			// Compute the true sign-up fee. If it's a subscription upgrade, we need to get the fee
+			// before extra charges, e.g. prorated recurring payment, were applied.
 			if ( $is_switch ) {
-				$sign_up_fee = (int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
+				$is_downgrade = isset( $cart_item['subscription_switch']['upgraded_or_downgraded'] ) &&
+										'downgraded' === $cart_item['subscription_switch']['upgraded_or_downgraded'];
+				$sign_up_fee  = $is_downgrade ?
+										WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ) :
+										(int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
 			} else {
 				$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
 			}

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -222,10 +222,10 @@ class WC_Subscriptions_Coupon {
 			// Compute the original sign-up fee. If it's a switch, we need to get the signup fee less
 			// upgrade costs.
 			if ( $is_switch ) {
-				$sign_up_fee_prorated = (int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
-				$price_prorated       = (int) $cart_item['data']->get_meta( '_subscription_price_prorated' );
+				$sign_up_fee_prorated = (float) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
+				$price_prorated       = (float) $cart_item['data']->get_meta( '_subscription_price_prorated' );
 
-				if ( 0 === $sign_up_fee_prorated && 0 === $price_prorated ) {
+				if ( 0.0 === $sign_up_fee_prorated && 0.0 === $price_prorated ) {
 					// No prorated recurring fees, i.e. no extra upgrade costs, so we can use the original sign-up fee.
 					$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
 				} else {

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -219,10 +219,18 @@ class WC_Subscriptions_Coupon {
 				}
 			}
 
-			// Compute the sign-up fee. If it's a switch, we need to get the signup fee less
-			// recurring payment upgrade/downgrade costs.
+			// Compute the original sign-up fee. If it's a switch, we need to get the signup fee less
+			// upgrade costs.
 			if ( $is_switch ) {
-				$sign_up_fee = (int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
+				$sign_up_fee_prorated = (int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
+				$price_prorated       = (int) $cart_item['data']->get_meta( '_subscription_price_prorated' );
+
+				if ( 0 === $sign_up_fee_prorated && 0 === $price_prorated ) {
+					// No prorated recurring fees, i.e. no extra upgrade costs, so we can use the original sign-up fee.
+					$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
+				} else {
+					$sign_up_fee = $sign_up_fee_prorated;
+				}
 			} else {
 				$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
 			}

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -219,17 +219,18 @@ class WC_Subscriptions_Coupon {
 				}
 			}
 
-			// Compute the original sign-up fee. If it's a switch, we need to get the signup fee less
-			// upgrade costs.
+			// Compute the true sign-up fee.
+			// If it's a switch, we need to get the signup fee less upgrade costs.
 			if ( $is_switch ) {
-				$sign_up_fee_prorated = (float) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
-				$price_prorated       = (float) $cart_item['data']->get_meta( '_subscription_price_prorated' );
+				// When sign-up fees are prorated, this meta will store the prorated amount:
+				// the original sign-up fee less what's already paid. When recurring fees are prorated,
+				// this meta contains the sign-up fee before extra fees are applied.
+				$is_sign_up_fee_prorated = (float) $cart_item['data']->meta_exists( '_subscription_sign_up_fee_prorated' );
 
-				if ( 0.0 === $sign_up_fee_prorated && 0.0 === $price_prorated ) {
-					// No prorated recurring fees, i.e. no extra upgrade costs, so we can use the original sign-up fee.
-					$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
+				if ( $is_sign_up_fee_prorated ) {
+					$sign_up_fee = (float) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
 				} else {
-					$sign_up_fee = $sign_up_fee_prorated;
+					$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
 				}
 			} else {
 				$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -219,14 +219,10 @@ class WC_Subscriptions_Coupon {
 				}
 			}
 
-			// Compute the true sign-up fee. If it's a subscription upgrade, we need to get the fee
-			// before extra charges, e.g. prorated recurring payment, were applied.
+			// Compute the sign-up fee. If it's a switch, we need to get the signup fee less
+			// recurring payment upgrade/downgrade costs.
 			if ( $is_switch ) {
-				$is_downgrade = isset( $cart_item['subscription_switch']['upgraded_or_downgraded'] ) &&
-										'downgraded' === $cart_item['subscription_switch']['upgraded_or_downgraded'];
-				$sign_up_fee  = $is_downgrade ?
-										WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ) :
-										(int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
+				$sign_up_fee = (int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
 			} else {
 				$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
 			}

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -219,8 +219,16 @@ class WC_Subscriptions_Coupon {
 				}
 			}
 
-			// Apply sign-up discounts. Exclude switch cart items because their initial amount is entirely sign-up fees but should be treated as initial amounts
-			if ( ! $is_switch && WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ) > 0 ) {
+			// Compute the sign-up fee. If it's a switch, we need to get the signup fee less
+			// recurring payment upgrade/downgrade costs.
+			if ( $is_switch ) {
+				$sign_up_fee = (int) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );
+			} else {
+				$sign_up_fee = WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] );
+			}
+
+			// Apply sign-up discounts
+			if ( $sign_up_fee > 0 ) {
 
 				if ( 'sign_up_fee' == $coupon_type ) {
 					$apply_initial_coupon = true;
@@ -236,7 +244,7 @@ class WC_Subscriptions_Coupon {
 						$cart_item['data'],
 						array(
 							'qty'   => 1,
-							'price' => WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ),
+							'price' => $sign_up_fee,
 						)
 					);
 				} else {
@@ -244,7 +252,7 @@ class WC_Subscriptions_Coupon {
 						$cart_item['data'],
 						array(
 							'qty'   => 1,
-							'price' => WC_Subscriptions_Product::get_sign_up_fee( $cart_item['data'] ),
+							'price' => $sign_up_fee,
 						)
 					);
 				}
@@ -253,7 +261,7 @@ class WC_Subscriptions_Coupon {
 				if ( in_array( $coupon_type, array( 'sign_up_fee', 'sign_up_fee_percent' ) ) ) {
 					$discounting_amount = $signup_fee;
 				} else {
-					$discounting_amount -= $signup_fee;
+					$discounting_amount = max( 0, $discounting_amount - $signup_fee );
 				}
 			}
 

--- a/includes/class-wc-subscriptions-coupon.php
+++ b/includes/class-wc-subscriptions-coupon.php
@@ -225,7 +225,7 @@ class WC_Subscriptions_Coupon {
 				// When sign-up fees are prorated, this meta will store the prorated amount:
 				// the original sign-up fee less what's already paid. When recurring fees are prorated,
 				// this meta contains the sign-up fee before extra fees are applied.
-				$is_sign_up_fee_prorated = (float) $cart_item['data']->meta_exists( '_subscription_sign_up_fee_prorated' );
+				$is_sign_up_fee_prorated = $cart_item['data']->meta_exists( '_subscription_sign_up_fee_prorated' );
 
 				if ( $is_sign_up_fee_prorated ) {
 					$sign_up_fee = (float) $cart_item['data']->get_meta( '_subscription_sign_up_fee_prorated' );

--- a/tests/unit/test-class-wc-subscriptions-coupon.php
+++ b/tests/unit/test-class-wc-subscriptions-coupon.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Class: WC_Subscription_Payment_Count_Test
+ */
+class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
+
+	private $cart;
+
+	private $simple_subscription_product;
+	private $variable_subscription_product;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->cart = WC()->cart;
+
+		// Create a simple subscription product.
+		$simple = WCS_Helper_Product::create_simple_subscription_product(
+			[
+				'price'               => 25,
+				'subscription_period' => 'month',
+			]
+		);
+		$simple->update_meta_data( '_subscription_sign_up_fee', 10 );
+		$simple->update_meta_data( '_subscription_trial_length', 0 );
+		$this->simple_subscription_product = $simple;
+
+		// Create a variable subscription product.
+		$variable = WCS_Helper_Product::create_variable_subscription_product(
+			[
+				'subscription_period' => 'month',
+			]
+		);
+		$variable->update_meta_data( '_subscription_sign_up_fee', 10 );
+		$variable->update_meta_data( '_subscription_trial_length', 0 );
+		$this->variable_subscription_product = $variable;
+	}
+
+	public function tear_down() {
+		$this->cart->empty_cart();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests for the WC_Subscriptions_Coupon::get_discount_amount_for_cart_item method,
+	 * specifically for sign-up fee and sign-up fee percent coupons.
+	 */
+	public function test_get_discount_amount_for_cart_item_sign_up_fee_coupons() {
+		$coupon_sign_up_fee_percent = new WC_Coupon();
+		$coupon_sign_up_fee_percent->set_amount( 10 );
+		$coupon_sign_up_fee_percent->set_discount_type( 'sign_up_fee_percent' );
+
+		$coupon_sign_up_fee = new WC_Coupon();
+		$coupon_sign_up_fee->set_amount( 2 );
+		$coupon_sign_up_fee->set_discount_type( 'sign_up_fee' );
+
+		$coupon_sign_up_fee_large = new WC_Coupon();
+		$coupon_sign_up_fee_large->set_amount( 100 );
+		$coupon_sign_up_fee_large->set_discount_type( 'sign_up_fee' );
+
+		$discount           = 0;
+		$discounting_amount = 30;
+		$single             = true;
+
+		// Not a subscription switch
+		$cart_item = array(
+			'data'                => $this->simple_subscription_product,
+			'quantity'            => 1,
+			'subscription_switch' => false,
+		);
+		$this->cart->empty_cart();
+		$this->cart->add_to_cart( $cart_item['data']->get_id() );
+
+		$this->assertEquals(
+			1,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_percent
+			)
+		);
+
+		$this->assertEquals(
+			2,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee
+			)
+		);
+
+		// Subscription switch, with extra upgrade costs. Discount should be
+		// applied to the sign-up fee before other costs.
+		$cart_item = array(
+			'data'                => $this->variable_subscription_product,
+			'quantity'            => 1,
+			'subscription_switch' => [
+				'subscription_id' => 123,
+			],
+		);
+		$this->cart->empty_cart();
+		$this->cart->add_to_cart( $cart_item['data']->get_id() );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 30 );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 10 );
+		$this->assertEquals(
+			1,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_percent
+			)
+		);
+
+		$this->assertEquals(
+			2,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee
+			)
+		);
+
+		$this->assertEquals(
+			10, // Discount should never be more than the sign-up fee
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_large
+			)
+		);
+
+		// Subscription switch -- no sign up fee, no discount
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 0 );
+		$this->assertEquals(
+			0,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_percent
+			)
+		);
+
+		$this->assertEquals(
+			0,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee
+			)
+		);
+
+		$this->assertEquals(
+			0,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_large
+			)
+		);
+	}
+
+
+	/**
+	 * Tests for the WC_Subscriptions_Coupon::get_discount_amount_for_cart_item method,
+	 * specifically for recurring fee and recurring fee percent coupons.
+	 */
+	public function test_get_discount_amount_for_cart_item_recurring_fee_coupons() {
+		$coupon_recurring_percent = new WC_Coupon();
+		$coupon_recurring_percent->set_amount( 10 );
+		$coupon_recurring_percent->set_discount_type( 'recurring_percent' );
+
+		$coupon_recurring_fee = new WC_Coupon();
+		$coupon_recurring_fee->set_amount( 5 );
+		$coupon_recurring_fee->set_discount_type( 'recurring_fee' );
+
+		$coupon_recurring_fee_large = new WC_Coupon();
+		$coupon_recurring_fee_large->set_amount( 100 );
+		$coupon_recurring_fee_large->set_discount_type( 'recurring_fee' );
+
+		$discount           = 0;
+		$discounting_amount = 30;
+		$single             = true;
+
+		// Not a subscription switch
+		$cart_item = array(
+			'data'                => $this->simple_subscription_product,
+			'quantity'            => 1,
+			'subscription_switch' => false,
+		);
+		$this->cart->empty_cart();
+		$this->cart->add_to_cart( $cart_item['data']->get_id() );
+
+		// 10% off recurring fee (20.00)
+		$this->assertEquals(
+			2,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_recurring_percent
+			)
+		);
+
+		// 5.00 off recurring fee (20.00)
+		$this->assertEquals(
+			5,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_recurring_fee
+			)
+		);
+
+		// 100.00 off recurring fee (20.00)
+		$this->assertEquals(
+			20, // Discount should never be more than the recurring fee
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_recurring_fee_large
+			)
+		);
+
+		// Subscription switch
+		$cart_item = array(
+			'data'                => $this->variable_subscription_product,
+			'quantity'            => 1,
+			'subscription_switch' => [
+				'subscription_id' => 123,
+			],
+		);
+		$this->cart->empty_cart();
+		$this->cart->add_to_cart( $cart_item['data']->get_id() );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 30 );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 10 );
+		$this->assertEquals(
+			2,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_recurring_percent
+			)
+		);
+
+		$this->assertEquals(
+			5,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_recurring_fee
+			)
+		);
+	}
+}

--- a/tests/unit/test-class-wc-subscriptions-coupon.php
+++ b/tests/unit/test-class-wc-subscriptions-coupon.php
@@ -100,7 +100,8 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 			'data'                => $this->variable_subscription_product,
 			'quantity'            => 1,
 			'subscription_switch' => [
-				'subscription_id' => 123,
+				'subscription_id'        => 123,
+				'upgraded_or_downgraded' => 'upgraded',
 			],
 		);
 		$this->cart->empty_cart();
@@ -172,6 +173,22 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 				$discounting_amount,
 				$single,
 				$coupon_sign_up_fee_large
+			)
+		);
+
+		// Subscription switch -- downgrade
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 10 );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 0 );
+		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 0 );
+		$cart_item['subscription_switch']['upgraded_or_downgraded'] = 'downgraded';
+		$this->assertEquals(
+			1,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_percent
 			)
 		);
 	}
@@ -248,7 +265,8 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 			'data'                => $this->variable_subscription_product,
 			'quantity'            => 1,
 			'subscription_switch' => [
-				'subscription_id' => 123,
+				'subscription_id'        => 123,
+				'upgraded_or_downgraded' => 'upgraded',
 			],
 		);
 		$this->cart->empty_cart();

--- a/tests/unit/test-class-wc-subscriptions-coupon.php
+++ b/tests/unit/test-class-wc-subscriptions-coupon.php
@@ -107,6 +107,7 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 		$this->cart->add_to_cart( $cart_item['data']->get_id() );
 		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 30 );
 		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 10 );
+		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 20 );
 		$this->assertEquals(
 			1,
 			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
@@ -141,7 +142,9 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 		);
 
 		// Subscription switch -- no sign up fee, no discount
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 20 );
 		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 0 );
+		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 20 );
 		$this->assertEquals(
 			0,
 			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
@@ -172,6 +175,22 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 				$discounting_amount,
 				$single,
 				$coupon_sign_up_fee_large
+			)
+		);
+
+		// Subscription switch -- no prorated fees, e.g. downgrade
+		$discounting_amount = 10;
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 10 );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 0 );
+		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 0 );
+		$this->assertEquals(
+			1,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_sign_up_fee_percent
 			)
 		);
 	}
@@ -255,6 +274,7 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 		$this->cart->add_to_cart( $cart_item['data']->get_id() );
 		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 30 );
 		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 10 );
+		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 20 );
 		$this->assertEquals(
 			2,
 			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
@@ -274,6 +294,22 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 				$discounting_amount,
 				$single,
 				$coupon_recurring_fee
+			)
+		);
+
+		// Subscription switch -- no prorated fees, e.g. downgrade
+		$discounting_amount = 10;
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 10 );
+		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 0 );
+		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 0 );
+		$this->assertEquals(
+			0,
+			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
+				$cart_item,
+				$discount,
+				$discounting_amount,
+				$single,
+				$coupon_recurring_percent
 			)
 		);
 	}

--- a/tests/unit/test-class-wc-subscriptions-coupon.php
+++ b/tests/unit/test-class-wc-subscriptions-coupon.php
@@ -100,8 +100,7 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 			'data'                => $this->variable_subscription_product,
 			'quantity'            => 1,
 			'subscription_switch' => [
-				'subscription_id'        => 123,
-				'upgraded_or_downgraded' => 'upgraded',
+				'subscription_id' => 123,
 			],
 		);
 		$this->cart->empty_cart();
@@ -173,22 +172,6 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 				$discounting_amount,
 				$single,
 				$coupon_sign_up_fee_large
-			)
-		);
-
-		// Subscription switch -- downgrade
-		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee', 10 );
-		$cart_item['data']->update_meta_data( '_subscription_sign_up_fee_prorated', 0 );
-		$cart_item['data']->update_meta_data( '_subscription_price_prorated', 0 );
-		$cart_item['subscription_switch']['upgraded_or_downgraded'] = 'downgraded';
-		$this->assertEquals(
-			1,
-			WC_Subscriptions_Coupon::get_discount_amount_for_cart_item(
-				$cart_item,
-				$discount,
-				$discounting_amount,
-				$single,
-				$coupon_sign_up_fee_percent
 			)
 		);
 	}
@@ -265,8 +248,7 @@ class WC_Subscriptions_Coupon_Test extends WP_UnitTestCase {
 			'data'                => $this->variable_subscription_product,
 			'quantity'            => 1,
 			'subscription_switch' => [
-				'subscription_id'        => 123,
-				'upgraded_or_downgraded' => 'upgraded',
+				'subscription_id' => 123,
 			],
 		);
 		$this->cart->empty_cart();


### PR DESCRIPTION
Fixes #726 

## Description
This PR adds support for signup fee coupon during subscription switches. It computes for the actual signup fee amount and applies the discount to that amount.

## How to test this PR
1. Go to WooCommerce > Settings > Subscriptions > Switching, and
   - Enable `Allow Switching: Between Subscription Variations`.
   - For Prorate Recurring Payment: `For Upgrades and Downgrades of All Subscription Products`
   - For Prorate Signup Fee: `Never (charge the full signup fee)`
3. Go to Marketing > Coupons and create a coupon: a signup fee % discount for 20%.
4. Create a Variable Subscription product:
   - Under Attributes, add "Membership Tier" with "Regular|Premium" as values, and check `Used for variations` before saving.
   - Under Variations, create:
      - Regular: 80.00/month, with 5.00 signup fee
      - Premium: 100.00/month, with 5.00 signup fee
5. As a shopper, purchase the "Regular" variation.
6. Go to My Account > Subscriptions > View, and click "Upgrade or Downgrade". Upgrade to "Premium" and go to checkout.
7. Add the signup fee % discount coupon.
8. Verify that the "Order Summary Signup Fee" shows 25.00, but the discount amount is only 1.00 (20% of 5.00, the signup fee prior to upgrade costs).
9. Test for different combinations of `Prorate Recurring Payment` and `Prorate Signup Fee`: no matter the combination, the discount amount should never be more than 1.00.
10. Test using different coupon types:
    - signup fee coupon, e.g. 10.00: discount should always be 5.00 or less
    - recurring fee/recurring fee percent coupon: discount should be applied to upgrade cost excluding signup fee. 
11. Test a subscription downgrade.


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
