### PR TITLE
Add hooks before and after the subscription info table email

### DIFF
--- a/templates/emails/plain/subscription-info.php
+++ b/templates/emails/plain/subscription-info.php
@@ -4,7 +4,7 @@
  *
  * @author  Brent Shepherd / Chuck Mac
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.4
+ * @version 1.1.0 - Migrated from WooCommerce Subscriptions v3.0.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +16,8 @@ if ( empty( $subscriptions ) ) {
 
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
+
+do_action( 'wcs_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );
 
 echo "\n\n" . __( 'Subscription information', 'woocommerce-subscriptions' ) . "\n\n";
 foreach ( $subscriptions as $subscription ) {
@@ -61,3 +63,5 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 		)
 	);
 }
+
+do_action( 'wcs_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -17,7 +17,7 @@ if ( empty( $subscriptions ) ) {
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
 
-do_action( 'wcs_email_before_subscription_info', $subscription, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );
+do_action( 'wcs_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );
 
 ?>
 <div style="margin-bottom: 40px;">
@@ -79,4 +79,4 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 </div>
 <?php
 
-do_action( 'wcs_email_after_subscription_info', $subscription, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );
+do_action( 'wcs_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -4,7 +4,7 @@
  *
  * @author  Brent Shepherd / Chuck Mac
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.4
+ * @version 1.1.0 - Migrated from WooCommerce Subscriptions v3.0.4
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -16,6 +16,9 @@ if ( empty( $subscriptions ) ) {
 
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
+
+do_action( 'wcs_email_before_subscription_info', $subscription, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );
+
 ?>
 <div style="margin-bottom: 40px;">
 <h2><?php esc_html_e( 'Subscription information', 'woocommerce-subscriptions' ); ?></h2>
@@ -74,4 +77,6 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 }
 ?>
 </div>
+<?php
 
+do_action( 'wcs_email_after_subscription_info', $subscription, $order, $has_automatic_renewal, $is_parent_order, $sent_to_admin, $plain_text );


### PR DESCRIPTION
Updates #752 

## Description

As mentioned on the issue:

> Depending on the subscription business, the information on the "Subscription information" email template might not be enough for the customer to understand why is he getting this email.
> 
> (...)
> 
> I have two suggestions:
> 
> - Load the order details email template after the subscription information table
> - Add hooks before and after the subscription information table so that developers can decide what else to add

This PR implements the second suggestion.

## How to test this PR

Hook into `wcs_email_before_subscription_info` or `wcs_email_after_subscription_info` and add any content you want to the subscription information template on emails.

## Product impact

- [x] Will this PR affect WooCommerce Subscriptions?
