### PR TITLE
[WooCommerce 9.6] Preview Email support for subscription emails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,10 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 7.9.0 - xxxx-xx-xx =
+* Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.
 * Fix - Prevent payment gateways that complete Change Payment requests asynchronously from blocking future attempts to update payment methods for all subscriptions.
+* Fix - Resolved an issue that could lead to undefined variable when attempting to send a customer notification email with no order.
+* Dev - Use the subscription's customer ID during the `wcs_can_user_renew_early()` function call when sending customer notification emails.
 
 = 7.8.0 - 2024-12-16 =
 * Fix - Prevent failing non-recent renewal order from suspending the subscription and marking the most recent renewal order as failed.

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Prevent payment gateways that complete Change Payment requests asynchronously from blocking future attempts to update payment methods for all subscriptions.
 * Fix - Resolved an issue that could lead to undefined variable when attempting to send a customer notification email with no order.
 * Dev - Use the subscription's customer ID during the `wcs_can_user_renew_early()` function call when sending customer notification emails.
+* Dev - Fix PHP deprecated warnings caused by calling esc_url with null.
 
 = 7.8.0 - 2024-12-16 =
 * Fix - Prevent failing non-recent renewal order from suspending the subscription and marking the most recent renewal order as failed.

--- a/includes/class-wc-subscriptions-core-plugin.php
+++ b/includes/class-wc-subscriptions-core-plugin.php
@@ -200,6 +200,7 @@ class WC_Subscriptions_Core_Plugin {
 		WCS_My_Account_Payment_Methods::init();
 		WCS_My_Account_Auto_Renew_Toggle::init();
 		new WCS_Deprecated_Filter_Hooks();
+		new WC_Subscriptions_Email_Preview();
 
 		// On some loads the WC_Query doesn't exist. To avoid a fatal, only load the WCS_Query class when it exists.
 		if ( class_exists( 'WC_Query' ) ) {

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -21,6 +21,19 @@ class WC_Subscriptions_Email_Notifications {
 	public static $switch_setting_string = '_customer_notifications_enabled';
 
 	/**
+	 * List of subscription notification email classes.
+	 *
+	 * @var array
+	 */
+	public static $email_classes = [
+		'WCS_Email_Customer_Notification_Manual_Trial_Expiration' => true,
+		'WCS_Email_Customer_Notification_Auto_Trial_Expiration' => true,
+		'WCS_Email_Customer_Notification_Manual_Renewal' => true,
+		'WCS_Email_Customer_Notification_Auto_Renewal'   => true,
+		'WCS_Email_Customer_Notification_Subscription_Expiration' => true,
+	];
+
+	/**
 	 * Init.
 	 */
 	public static function init() {
@@ -107,12 +120,9 @@ class WC_Subscriptions_Email_Notifications {
 	 * Add Subscriptions notifications' email classes.
 	 */
 	public static function add_emails( $email_classes ) {
-
-		$email_classes['WCS_Email_Customer_Notification_Auto_Trial_Expiration']   = new WCS_Email_Customer_Notification_Auto_Trial_Expiration();
-		$email_classes['WCS_Email_Customer_Notification_Manual_Trial_Expiration'] = new WCS_Email_Customer_Notification_Manual_Trial_Expiration();
-		$email_classes['WCS_Email_Customer_Notification_Subscription_Expiration'] = new WCS_Email_Customer_Notification_Subscription_Expiration();
-		$email_classes['WCS_Email_Customer_Notification_Manual_Renewal']          = new WCS_Email_Customer_Notification_Manual_Renewal();
-		$email_classes['WCS_Email_Customer_Notification_Auto_Renewal']            = new WCS_Email_Customer_Notification_Auto_Renewal();
+		foreach ( self::$email_classes as $email_class => $_ ) {
+			$email_classes[ $email_class ] = new $email_class();
+		}
 
 		return $email_classes;
 	}

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -12,6 +12,24 @@
 class WC_Subscriptions_Email {
 
 	/**
+	 * List of all core subscription email classes.
+	 *
+	 * @var array
+	 */
+	public static $email_classes = [
+		'WCS_Email_New_Renewal_Order'              => true,
+		'WCS_Email_New_Switch_Order'               => true,
+		'WCS_Email_Processing_Renewal_Order'       => true,
+		'WCS_Email_Completed_Renewal_Order'        => true,
+		'WCS_Email_Customer_On_Hold_Renewal_Order' => true,
+		'WCS_Email_Completed_Switch_Order'         => true,
+		'WCS_Email_Customer_Renewal_Invoice'       => true,
+		'WCS_Email_Cancelled_Subscription'         => true,
+		'WCS_Email_Expired_Subscription'           => true,
+		'WCS_Email_On_Hold_Subscription'           => true,
+	];
+
+	/**
 	 * Bootstraps the class and hooks required actions & filters.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v1.0
@@ -36,16 +54,9 @@ class WC_Subscriptions_Email {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v1.4
 	 */
 	public static function add_emails( $email_classes ) {
-		$email_classes['WCS_Email_New_Renewal_Order']              = new WCS_Email_New_Renewal_Order();
-		$email_classes['WCS_Email_New_Switch_Order']               = new WCS_Email_New_Switch_Order();
-		$email_classes['WCS_Email_Processing_Renewal_Order']       = new WCS_Email_Processing_Renewal_Order();
-		$email_classes['WCS_Email_Completed_Renewal_Order']        = new WCS_Email_Completed_Renewal_Order();
-		$email_classes['WCS_Email_Customer_On_Hold_Renewal_Order'] = new WCS_Email_Customer_On_Hold_Renewal_Order();
-		$email_classes['WCS_Email_Completed_Switch_Order']         = new WCS_Email_Completed_Switch_Order();
-		$email_classes['WCS_Email_Customer_Renewal_Invoice']       = new WCS_Email_Customer_Renewal_Invoice();
-		$email_classes['WCS_Email_Cancelled_Subscription']         = new WCS_Email_Cancelled_Subscription();
-		$email_classes['WCS_Email_Expired_Subscription']           = new WCS_Email_Expired_Subscription();
-		$email_classes['WCS_Email_On_Hold_Subscription']           = new WCS_Email_On_Hold_Subscription();
+		foreach ( self::$email_classes as $email_class => $_ ) {
+			$email_classes[ $email_class ] = new $email_class();
+		}
 
 		return $email_classes;
 	}

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -326,7 +326,7 @@ class WC_Subscriptions_Email {
 		wc_get_template(
 			$template,
 			array(
-				'order'                => $order ?? null,
+				'order'                => $order,
 				'subscriptions'        => $subscriptions,
 				'is_admin_email'       => $sent_to_admin,
 				'skip_my_account_link' => $skip_my_account_link,

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -317,11 +317,17 @@ class WC_Subscriptions_Email {
 	public static function subscription_details( $subscriptions, $order = null, $sent_to_admin = false, $plain_text = false, $skip_my_account_link = false ) {
 		$template = ( $plain_text ) ? 'emails/plain/subscription-info.php' : 'emails/subscription-info.php';
 
+		if ( ! is_array( $subscriptions ) ) {
+			$subscriptions = [ $subscriptions ];
+		}
+
+		$order = ! $order && ! empty( $subscriptions ) ? reset( $subscriptions )->get_parent() : $order;
+
 		wc_get_template(
 			$template,
 			array(
-				'order'                => ! $order ? $subscription->get_parent() : $order,
-				'subscriptions'        => is_array( $subscriptions ) ? $subscriptions : [ $subscriptions ],
+				'order'                => $order ?? null,
+				'subscriptions'        => $subscriptions,
 				'is_admin_email'       => $sent_to_admin,
 				'skip_my_account_link' => $skip_my_account_link,
 			),

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -26,11 +26,11 @@ class WC_Subscriptions_Email_Preview {
 	 * @return WC_Email
 	 */
 	public function prepare_email_for_preview( $email ) {
-		if ( ! $this->is_subscription_email( $email ) ) {
+		$this->email_type = get_class( $email );
+
+		if ( ! $this->is_subscription_email() ) {
 			return $email;
 		}
-
-		$this->email_type = get_class( $email );
 
 		$this->set_up_filters();
 
@@ -140,15 +140,12 @@ class WC_Subscriptions_Email_Preview {
 	}
 
 	/**
-	 * Check if an email is a subscription email.
-	 *
-	 * @param WC_Email $email The email class being previewed.
+	 * Check if the email being previewed is a subscription email.
 	 *
 	 * @return bool
 	 */
-	private function is_subscription_email( $email ) {
-		$class = get_class( $email );
-		return isset( WC_Subscriptions_Email::$email_classes[ $class ] ) || isset( WC_Subscriptions_Email_Notifications::$email_classes[ $class ] );
+	private function is_subscription_email() {
+		return isset( WC_Subscriptions_Email::$email_classes[ $this->email_type ] ) || isset( WC_Subscriptions_Email_Notifications::$email_classes[ $this->email_type ] );
 	}
 
 	/**

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Subscriptions Email Preview Class
+ */
+class WC_Subscriptions_Email_Preview {
+
+	/**
+	 * The email being previewed
+	 *
+	 * @var string
+	 */
+	private $email_type;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_prepare_email_for_preview', [ $this, 'prepare_email_for_preview' ] );
+	}
+
+	/**
+	 * Prepare subscription email dummy data for preview.
+	 *
+	 * @param WC_Email $email The email object.
+	 *
+	 * @return WC_Email
+	 */
+	public function prepare_email_for_preview( $email ) {
+		if ( ! $this->is_subscription_email( $email ) ) {
+			return $email;
+		}
+
+		$this->email_type = get_class( $email );
+
+		$this->set_up_filters();
+
+		switch ( $this->email_type ) {
+			case 'WCS_Email_New_Switch_Order':
+			case 'WCS_Email_Completed_Switch_Order':
+				$email->subscriptions = [ $this->get_dummy_subscription() ];
+				break;
+			case 'WCS_Email_Cancelled_Subscription':
+			case 'WCS_Email_Expired_Subscription':
+			case 'WCS_Email_On_Hold_Subscription':
+			case 'WCS_Email_Customer_Notification_Auto_Trial_Expiration':
+			case 'WCS_Email_Customer_Notification_Manual_Trial_Expiration':
+			case 'WCS_Email_Customer_Notification_Subscription_Expiration':
+			case 'WCS_Email_Customer_Notification_Manual_Renewal':
+			case 'WCS_Email_Customer_Notification_Auto_Renewal':
+				$email->set_object( $this->get_dummy_subscription() );
+				break;
+		}
+
+		add_filter( 'woocommerce_mail_content', [ $this, 'clean_up_filters' ] );
+
+		return $email;
+	}
+
+	/**
+	 * Get a dummy subscription for use in preview emails.
+	 *
+	 * @return WC_Subscription
+	 */
+	private function get_dummy_subscription() {
+		$subscription = new WC_Subscription();
+		$product      = $this->get_dummy_product();
+
+		$subscription->add_product( $product, 2 );
+		$subscription->set_id( 12346 );
+		$subscription->set_customer_id( 1 );
+		$subscription->set_date_created( gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ) );
+		$subscription->set_currency( 'USD' );
+		$subscription->set_total( 100 );
+		$subscription->set_billing_period( 'month' );
+		$subscription->set_billing_interval( 1 );
+		$subscription->set_start_date( gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ) );
+		$subscription->set_trial_end_date( gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) ) );
+		$subscription->set_next_payment_date( gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) ) );
+		$subscription->set_end_date( gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ) );
+
+		$address = self::get_dummy_address();
+
+		$subscription->set_billing_address( $address );
+		$subscription->set_shipping_address( $address );
+
+		/**
+		 * Filter the dummy subscription object used in email previews.
+		 *
+		 * @param WC_Subscription $subscription The dummy subscription object.
+		 * @param string          $email_type   The email type being previewed.
+		 */
+		return apply_filters( 'woocommerce_subscriptions_email_preview_dummy_subscription', $subscription, $this->email_type );
+	}
+
+	/**
+	 * Get a dummy product for use when previewing subscription emails.
+	 *
+	 * @return WC_Product
+	 */
+	private function get_dummy_product() {
+		$product = new WC_Product();
+		$product->set_name( 'Dummy Subscription' );
+		$product->set_price( 25 );
+
+		/**
+		 * Filter the dummy subscription product object used in email previews.
+		 *
+		 * @param WC_Product $product The dummy product object.
+		 * @param string     $email_type The email type being previewed.
+		 */
+		return apply_filters( 'woocommerce_subscriptions_email_preview_dummy_product', $product, $this->email_type );
+	}
+
+	/**
+	 * Get a dummy address used when previewing subscription emails.
+	 *
+	 * @return array
+	 */
+	private function get_dummy_address() {
+		$address = [
+			'first_name' => 'John',
+			'last_name'  => 'Doe',
+			'company'    => 'Company',
+			'email'      => 'john@company.com',
+			'phone'      => '555-555-5555',
+			'address_1'  => '123 Fake Street',
+			'city'       => 'Faketown',
+			'postcode'   => '12345',
+			'country'    => 'US',
+			'state'      => 'CA',
+		];
+
+		/**
+		 * Filter the dummy address used in email previews.
+		 *
+		 * @param array  $address    The dummy address.
+		 * @param string $email_type The email type being previewed.
+		 */
+		return apply_filters( 'woocommerce_subscriptions_email_preview_dummy_address', $address, $this->email_type );
+	}
+
+	/**
+	 * Check if an email is a subscription email.
+	 *
+	 * @param WC_Email $email The email class being previewed.
+	 *
+	 * @return bool
+	 */
+	private function is_subscription_email( $email ) {
+		$class = get_class( $email );
+		return isset( WC_Subscriptions_Email::$email_classes[ $class ] ) || isset( WC_Subscriptions_Email_Notifications::$email_classes[ $class ] );
+	}
+
+	/**
+	 * Set up filters for previewing emails.
+	 */
+	private function set_up_filters() {
+		// Filter the last order date created for a subscription to be displayed in the Cancelled Subscription email.
+		add_filter( 'woocommerce_subscription_get_last_order_date_created_date', [ $this, 'mock_last_order_date_created' ], 10, 2 );
+		// For the purpose of previewing an email, force the subscription to be early renewable if the feature is enabled.
+		add_filter( 'woocommerce_subscriptions_can_user_renew_early', [ $this, 'allow_early_renewals_during_preview' ], 10, 3 );
+	}
+
+	/**
+	 * Clean up filters at the end of previewing emails.
+	 *
+	 * @param string $preview_content The email content.
+	 *
+	 * @return string
+	 */
+	public function clean_up_filters( $preview_content ) {
+		remove_filter( 'woocommerce_subscription_get_last_order_date_created_date', [ $this, 'mock_last_order_date_created' ] );
+		remove_filter( 'woocommerce_subscriptions_can_user_renew_early', [ $this, 'allow_early_renewals_during_preview' ] );
+
+		return $preview_content;
+
+	}
+
+	/**
+	 * Mock the last order date created for a subscription to the current date.
+	 *
+	 * @param string $date The date.
+	 *
+	 * @return string
+	 */
+	public function mock_last_order_date_created( $date, $subscription ) {
+		if ( 12346 === $subscription->get_id() && 1 === $subscription->customer_id ) {
+			return gmdate( 'Y-m-d H:i:s' );
+		}
+
+		return $date;
+	}
+
+	/**
+	 * Allow early renewals for previewing emails.
+	 *
+	 * @param bool $can_renew_early Whether the subscription can be renewed early.
+	 * @param WC_Subscription $subscription The subscription.
+	 *
+	 * @return bool
+	 */
+	public function allow_early_renewals_during_preview( $can_renew_early, $subscription, $user_id ) {
+		if ( 1 === $user_id ) {
+			return true;
+		}
+
+		return $can_renew_early;
+	}
+}

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -181,7 +181,7 @@ class WC_Subscriptions_Email_Preview {
 	 * @return string
 	 */
 	public function mock_last_order_date_created( $date, $subscription ) {
-		if ( 12346 === $subscription->get_id() && 1 === $subscription->customer_id ) {
+		if ( is_a( $subscription, 'WC_Subscription' ) && 12346 === $subscription->get_id() && 1 === $subscription->get_customer_id() ) {
 			return gmdate( 'Y-m-d H:i:s' );
 		}
 

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -191,8 +191,9 @@ class WC_Subscriptions_Email_Preview {
 	/**
 	 * Allow early renewals for previewing emails.
 	 *
-	 * @param bool $can_renew_early Whether the subscription can be renewed early.
-	 * @param WC_Subscription $subscription The subscription.
+	 * @param bool            $can_renew_early Whether the subscription can be renewed early.
+	 * @param WC_Subscription $subscription    The subscription.
+	 * @param int             $user_id         The user ID.
 	 *
 	 * @return bool
 	 */

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -118,7 +118,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	public function get_content_html() {
 		$subscription = $this->object;
 
-		if ( wcs_can_user_renew_early( $subscription )
+		if ( wcs_can_user_renew_early( $subscription, $subscription->get_customer_id() )
 			&& $subscription->payment_method_supports( 'subscription_date_changes' )
 			&& WCS_Early_Renewal_Manager::is_early_renewal_enabled()
 			&& WCS_Manual_Renewal_Manager::is_manual_renewal_enabled()
@@ -164,7 +164,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	public function get_content_plain() {
 		$subscription = $this->object;
 
-		if ( wcs_can_user_renew_early( $subscription )
+		if ( wcs_can_user_renew_early( $subscription, $subscription->get_customer_id() )
 			&& $subscription->payment_method_supports( 'subscription_date_changes' )
 			&& WCS_Early_Renewal_Manager::is_early_renewal_enabled()
 			&& WCS_Manual_Renewal_Manager::is_manual_renewal_enabled()

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -65,7 +65,7 @@ function wcs_get_edit_post_link( $post_id ) {
 	$object = wc_get_order( $post_id ); // works for both WC Order and WC Subscription objects.
 
 	if ( ! $object || ! in_array( $object->get_type(), array( 'shop_order', 'shop_subscription' ), true ) ) {
-		return;
+		return '';
 	}
 
 	return apply_filters( 'get_edit_post_link', $object->get_edit_order_url(), $post_id, '' );


### PR DESCRIPTION
Fixes 4760-gh-woocommerce/woocommerce-subscriptions

> [!NOTE]
> You will need to checkout `checking_can_renew_early_invalid_subscription` on the woocommerce-subscriptions repo (see 4770-gh-woocommerce/woocommerce-subscriptions) before testing this branch.

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR adds Subscriptions support for the new Preview Email feature coming in WooCommerce 9.6 (releasing this month). Since originally opening the issue, some of the issues I found have already been addressed in WooCommerce core and so there were really only two key issues that needed to be fixed:
- When previewing the Switching emails, the `WCS_Email_New_Switch_Order` and `WCS_Email_Completed_Switch_Order` emails expected `$email->subscriptions` to be an array of subscriptions [see here](https://github.com/Automattic/woocommerce-subscriptions-core/blob/13783514ffb9833f93b38355a8d7b5cbc8cff89a/includes/emails/class-wcs-email-completed-switch-order.php#L141).
- When previewing the majority of our subscription emails, `$email->object` was expected to be an instance of `WC_Subscription`, not a `WC_Order`

![image](https://github.com/user-attachments/assets/462ac4f7-4cae-4fa8-a099-8791a69371b8)

While working on these changes I found a couple of small issues that I've also addressed in this PR since they impacted testing. These include:
- 2050be8a5485246e95151fb88e1d9fe78cc2f001 - Store managers can manually trigger the customer notification email from Admin Edit Subscription page, so we should be calling `wcs_can_user_renew_early()` with the subscription's customer ID, not the current logged in user.
- cd24deb168c384f6d4c1453310a0b7e9c0b07e42 - Undefined `$subscription` variable called in our `subscription_details()` function.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Download the latest [WooCommerce core nightly build or download the 9.6 beta/RC](https://github.com/woocommerce/woocommerce/releases)
2. While on `trunk` of `subscriptions-core`, go to **WooCommerce > Settings > Emails**
3. Under the table of emails, you should see the new email improvements, including a preview of the email.
4. From the dropdown, attempt to preview the "Subscription Cancelled" email and you should see some errors.

| Subscription cancelled | Switch Completed | Customer Notification |
|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/b8a6996c-7ae0-47af-b205-74fca19ffae4) | ![image](https://github.com/user-attachments/assets/79ba9aa3-1d3d-46cf-9c2f-971d4106536a) | ![image](https://github.com/user-attachments/assets/d4aa0d79-540e-4a34-a4aa-95b09d7a997e) |

5. Checkout this branch and confirm all subscription emails are previewing correctly without any errors

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
