### PR TITLE
Correct oversight that led to mix-up of customer postcode and billing…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.
 * Fix - Prevent payment gateways that complete Change Payment requests asynchronously from blocking future attempts to update payment methods for all subscriptions.
 * Fix - Resolved an issue that could lead to undefined variable when attempting to send a customer notification email with no order.
+* Fix - Prevents the customer's postal code being used as their billing city in the current session, following a change to payment details.
 * Dev - Use the subscription's customer ID during the `wcs_can_user_renew_early()` function call when sending customer notification emails.
 * Dev - Fix PHP deprecated warnings caused by calling esc_url with null.
 

--- a/includes/class-wc-subscriptions-change-payment-gateway.php
+++ b/includes/class-wc-subscriptions-change-payment-gateway.php
@@ -294,7 +294,7 @@ class WC_Subscriptions_Change_Payment_Gateway {
 			$subscription_billing_country  = $subscription->get_billing_country();
 			$subscription_billing_state    = $subscription->get_billing_state();
 			$subscription_billing_postcode = $subscription->get_billing_postcode();
-			$subscription_billing_city     = $subscription->get_billing_postcode();
+			$subscription_billing_city     = $subscription->get_billing_city();
 
 			// Set customer location to order location
 			if ( $subscription_billing_country ) {


### PR DESCRIPTION
If a customer modifies their payment choices for a subscription then, within the current user session, we inadvertently set their billing city to the same value as their billing *post code*. If they then place a fresh order, the city will be incorrect.

This could be confusing for the user, the merchant, or both (and might lead to delays if it isn't caught early enough, especially if the product is something that is physically shipped).

Fixes #700 

## Description

<div align="center"><img width="700" src="https://github.com/user-attachments/assets/aff71000-d1ce-4eb4-86a8-963f5c22bb85" alt="Change payment button on the subscription view" /></div>
<div align="center"><img width="700" src="https://github.com/user-attachments/assets/e98a1bc5-e4d1-4d48-84ff-d420c4d1c170" alt="Change payment form" /></div>
<div align="center"><img width="700" src="https://github.com/user-attachments/assets/b7efa7df-ccc0-4611-a504-d0e460740816" alt="Checkout page, showing the post code being applied to the city field" /></div>

☝🏼 The above screenshots shows the My Accounts UI used to change a subscription's payment method. If the customer then adds another item to the cart (or already has an item in the cart), and they proceed to checkout, the billing city pulled from the session will have inadvertently been set to whatever their billing post code was.

## How to test this PR

To test this, you will need:

1. A suitable payment gateway, like Stripe.
2. A customer who has at least two payment methods (if they only have one, then just add a second one via **My Account ‣ Payment Methods**).
3. At least one subscription.
4. Their billing address (as found in **My Account ‣ Addresses**) should be set to something sensible, with the city and postcode being two different values.

With those things in place:

1. Navigate to **My Account ‣ Subscriptions**. Click on one of the subscriptions to edit it.
2. Now click on **Change Payment**, and then modify the payment method on the following screen. Click on the futher **Change Payment Method** button (it doesn't matter if you change only this one subscription or if you use the option to apply the change to all subscriptions: in relation to this bug, the outcome is the same).
3. Now add a new product to the cart, and proceed to checkout:
    - Without this fix, you will notice that the billing city field contains the value of whatever the customer's post code happens to be (rather like you can see in the screenshot shared earlier).
    - If you rinse and repeat with this fix in place, we will instead see their city as expected.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply) ***added***
- [x] Will this PR affect WooCommerce Subscriptions? ***no***
- [x] Will this PR affect WooCommerce Payments? ***no***
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) ***none***
