### PR TITLE
Add safeguards to guard against unexpected types (in the subscriptions totals template)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,13 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.0.0 - xxxx-xx-xx =
+* Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
+
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.
 * Fix - Prevent payment gateways that complete Change Payment requests asynchronously from blocking future attempts to update payment methods for all subscriptions.
 * Fix - Resolved an issue that could lead to undefined variable when attempting to send a customer notification email with no order.
 * Fix - Prevents the customer's postal code being used as their billing city in the current session, following a change to payment details.
-* Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Dev - Use the subscription's customer ID during the `wcs_can_user_renew_early()` function call when sending customer notification emails.
 * Dev - Fix PHP deprecated warnings caused by calling esc_url with null.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Prevent payment gateways that complete Change Payment requests asynchronously from blocking future attempts to update payment methods for all subscriptions.
 * Fix - Resolved an issue that could lead to undefined variable when attempting to send a customer notification email with no order.
 * Fix - Prevents the customer's postal code being used as their billing city in the current session, following a change to payment details.
+* Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Dev - Use the subscription's customer ID during the `wcs_can_user_renew_early()` function call when sending customer notification emails.
 * Dev - Fix PHP deprecated warnings caused by calling esc_url with null.
 

--- a/templates/myaccount/subscription-totals-table.php
+++ b/templates/myaccount/subscription-totals-table.php
@@ -4,7 +4,7 @@
  *
  * @package WooCommerce_Subscription/Templates
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
- * @version 7.1.0
+ * @version 7.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/myaccount/subscription-totals-table.php
+++ b/templates/myaccount/subscription-totals-table.php
@@ -35,7 +35,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 						'entity_type' => gettype( $_product ),
 					)
 				);
-				continue;
 			}
 
 			if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
@@ -51,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php endif; ?>
 					<td class="product-name">
 						<?php
-						if ( $_product && ! $_product->is_visible() ) {
+						if ( is_a( $_product, WC_Product::class ) && ! $_product->is_visible() ) {
 							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item['name'], $item, false ) );
 						} else {
 							echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', sprintf( '<a href="%s">%s</a>', get_permalink( $item['product_id'] ), $item['name'] ), $item, false ) );
@@ -89,7 +88,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php
 			}
 
-			$purchase_note = $_product->get_purchase_note();
+			$purchase_note = is_a( $_product, WC_Product::class ) ? $_product->get_purchase_note() : false;
+
 			if ( $subscription->has_status( array( 'completed', 'processing' ) ) && $purchase_note ) {
 				?>
 				<tr class="product-purchase-note">

--- a/templates/myaccount/subscription-totals-table.php
+++ b/templates/myaccount/subscription-totals-table.php
@@ -4,7 +4,7 @@
  *
  * @package WooCommerce_Subscription/Templates
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
- * @version 7.9.0 - Safety checks added to guard against fatal errors in certain unusual conditions
+ * @version 7.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/myaccount/subscription-totals-table.php
+++ b/templates/myaccount/subscription-totals-table.php
@@ -4,7 +4,7 @@
  *
  * @package WooCommerce_Subscription/Templates
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
- * @version 1.0.0 - Migrated from WooCommerce Subscriptions v2.6.0
+ * @version 7.9.0 - Safety checks added to guard against fatal errors in certain unusual conditions
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -25,6 +25,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php
 		foreach ( $subscription->get_items() as $item_id => $item ) {
 			$_product = apply_filters( 'woocommerce_subscriptions_order_item_product', $item->get_product(), $item );
+
+			if ( ! is_a( $_product, WC_Product::class ) ) {
+				wc_get_logger()->warning(
+					'A non-product was encountered while summarizing subscription product totals.',
+					array(
+						'backtrace'   => true,
+						'entity'      => $_product,
+						'entity_type' => gettype( $_product ),
+					)
+				);
+				continue;
+			}
+
 			if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 				?>
 				<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $subscription ) ); ?>">


### PR DESCRIPTION
There's a great summary of the problem in the [linked issue](https://github.com/Automattic/woocommerce-subscriptions-core/issues/750) but, in brief, the problem is that (within the [subscription totals template](https://github.com/Automattic/woocommerce-subscriptions-core/blob/14e7b3d5df82a0f4d4942b8119e85087e4863a65/templates/myaccount/subscription-totals-table.php)) we support filtering of product objects:

```php
$_product = apply_filters( 'woocommerce_subscriptions_order_item_product', $item->get_product(), $item );
```

Of course, nothing really stops a filter function from changing the filtered thing into some other type. Indeed, based on Nic's note in the original issue, it sounds like there has been at least one real-world report of this in which `$_product` is set to `(bool) false`. 

In situations like this, trying to call product object methods will obviously fail *("Fatal error: call to a member function get_purchase_note() on bool"),* so we need to guard against that risk. So, in this PR, we:

- Check if `$_product` has been filtered to an unexpected value
- If so, we log a warning
- We also place some additional safeguards around our subsequent use of `$_product`

Fixes #750

## How to test this PR

To test this you will need:

1. A WordPress site running WooCommerce Subscriptions.
2. The ability to log in as a customer who has one or more subscriptions (if necessary, go ahead and create these things).

Let's start by verifying we haven't introduced any problems to the happy path:

1. As the customer, login to the **My Account** area, click on the **Subscriptions** tab, and click to view one of your subscriptions.
2. It should render correctly and without errors. Tip: pay particular attention to the **Subscription Totals** area, which is one of the things we have modified.

Let's also verify a variant of the happy path, in which the catalog visibility of one of the subscription products is set to 'hidden':

1. Edit one of the subscription products.
2. Change the catalog visibility to private and save.
3. As the customer, reload the subscription view you were looking at previously. Everything should still render correctly and, within the totals table, the item name should no longer be a link (because of the change to the catalog visibility setting):

<div align="center"><img width="600" src="https://github.com/user-attachments/assets/60d1a88e-5194-456c-a302-df0837e649dd" alt="Subscription totals table, showing unlinked items" /></div>

For our next piece of testing, please now introduce some custom code to change `$_product` into an unexpected type. You can do this by adding a snippet like the following to `wp-content/mu-plugins/test-pr-759.php`, or however else you prefer:

```php
<?php

add_filter( 'woocommerce_subscriptions_order_item_product', '__return_false' );
```

1. Refresh the customer's view of the subscription.
2. It should again render nicely and without obvious errors.
3. This time, for any subscription products where the catalog visibility is private, the individual items **should still be linked** (it's *possible* this is the reason some third parties may have been filtering `$_product` to false).
4. Finally, if you visit the **WooCommerce ‣ Status ‣ Logs** screen, you should be able to locate a log entry providing information about this problem:

<div align="center"><img width="600" src="https://github.com/user-attachments/assets/0f442f3e-d46e-4644-9137-7fdada6831f7" alt="Logged error" /></div>

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply) **added**
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref **it surfaces through that plugin, but doesn't have any other impacts**
- [x] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref **no**
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **no deprecations**
