### PR TITLE
Recommend WooPayments when there is no available payment gateway

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 8.0.0 - xxxx-xx-xx =
-* Fix - Recommend WooPayments when there is no available payment gateway
+* Fix - Recommend WooPayments when there is no available payment gateway.
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 8.0.0 - xxxx-xx-xx =
+* Fix - Recommend WooPayments when there is no available payment gateway
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1893,7 +1893,7 @@ class WC_Subscriptions_Admin {
 
 		if ( ! $payment_gateways_handler::one_gateway_supports( 'subscriptions' ) ) {
 			// translators: $1-2: opening and closing tags of a link that takes to Woo marketplace / Stripe product page
-			$available_gateways_description = sprintf( __( 'No payment gateways capable of processing automatic subscription payments are enabled. If you would like to process automatic payments, we recommend the %1$sfree Stripe extension%2$s.', 'woocommerce-subscriptions' ), '<strong><a href="https://www.woocommerce.com/products/stripe/">', '</a></strong>' );
+			$available_gateways_description = sprintf( __( 'No %1$spayment gateways capable of processing automatic subscription payments%2$s are enabled. If you would like to process automatic payments, we recommend %3$sWooPayments%4$s.', 'woocommerce-subscriptions' ), '<a href="hhttps://woocommerce.com/document/subscriptions/payment-gateways/">', '</a>', '<strong><a href="https://woocommerce.com/payments/">', '</a></strong>' );
 		}
 
 		$recurring_payment_settings = apply_filters(

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1893,7 +1893,7 @@ class WC_Subscriptions_Admin {
 
 		if ( ! $payment_gateways_handler::one_gateway_supports( 'subscriptions' ) ) {
 			// translators: $1-2: opening and closing tags of a link that takes to Woo marketplace / Stripe product page
-			$available_gateways_description = sprintf( __( 'No %1$spayment gateways capable of processing automatic subscription payments%2$s are enabled. If you would like to process automatic payments, we recommend %3$sWooPayments%4$s.', 'woocommerce-subscriptions' ), '<a href="hhttps://woocommerce.com/document/subscriptions/payment-gateways/">', '</a>', '<strong><a href="https://woocommerce.com/payments/">', '</a></strong>' );
+			$available_gateways_description = sprintf( __( 'No payment gateways capable of processing automatic subscription payments are enabled. If you would like to process automatic payments, we recommend %1$sWooPayments%2$s.', 'woocommerce-subscriptions' ), '</a>', '<strong><a href="https://woocommerce.com/payments/">', '</a></strong>' );
 		}
 
 		$recurring_payment_settings = apply_filters(

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1893,7 +1893,7 @@ class WC_Subscriptions_Admin {
 
 		if ( ! $payment_gateways_handler::one_gateway_supports( 'subscriptions' ) ) {
 			// translators: $1-2: opening and closing tags of a link that takes to Woo marketplace / Stripe product page
-			$available_gateways_description = sprintf( __( 'No payment gateways capable of processing automatic subscription payments are enabled. If you would like to process automatic payments, we recommend %1$sWooPayments%2$s.', 'woocommerce-subscriptions' ), '</a>', '<strong><a href="https://woocommerce.com/payments/">', '</a></strong>' );
+			$available_gateways_description = sprintf( __( 'No payment gateways capable of processing automatic subscription payments are enabled. If you would like to process automatic payments, we recommend %1$sWooPayments%2$s.', 'woocommerce-subscriptions' ), '<strong><a href="https://woocommerce.com/payments/">', '</a></strong>' );
 		}
 
 		$recurring_payment_settings = apply_filters(


### PR DESCRIPTION
Fixes woocommerce/woocommerce-subscriptions#4023

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
Recommend WooPayments instead of Stripe when there is no available recurring payment gateway.

<img width="943" alt="Screenshot 2025-01-15 at 4 04 06 PM" src="https://github.com/user-attachments/assets/3c295e48-95a0-465a-8fef-284d33ba06f7" />

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Access WooCommerce > Settings > Payments.
2. Disable all payment methods.
3. Reload the page.
4. Scroll down, the `No payment gateways capable of processing automatic subscription payments...` message should recommend WooPayments instead of Stripe.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
