### PR TITLE
Make the admin notification mechanics contextually aware (of the user and of the admin screen)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 8.0.0 - xxxx-xx-xx =
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
-* Fix - Admin notices are now locked down to the current user by default.
+* Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 8.0.0 - xxxx-xx-xx =
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
+* Fix - Admin notices are now locked down to the current user by default.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -27,7 +27,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return void
  */
 function wcs_add_admin_notice( $message, $notice_type = 'success', $user_id = null, $screen_id = null ) {
-	$user_id = null === $user_id ? get_current_user_id() : $user_id;
+	$user_id = (int) ( null === $user_id ? get_current_user_id() : $user_id );
+
+	if ( $user_id < 1 ) {
+		wc_get_logger()->warning(
+			sprintf(
+				/* Translators: %1$s: notice type ('success' or 'error'), %2$s: notice text. */
+				'Admin notices can only be added if a user is currently logged in. Attemped (%1$s) notice: "%2$s"',
+				$notice_type,
+				$message
+			),
+			array(
+				'backtrace' => true,
+				'user_id'   => $user_id,
+			)
+		);
+
+		return;
+	}
+
 	$notices = get_transient( '_wcs_admin_notices_' . $user_id );
 
 	if ( ! is_array( $notices ) ) {

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -73,8 +73,9 @@ function wcs_display_admin_notices( $clear = true ) {
 		$notice_output = array();
 
 		foreach ( $notices as $index => $notice ) {
-			// Ensure the notice data now has the expected shape.
+			// Ensure the notice data now has the expected shape. If it does not, remove it.
 			if ( ! is_array( $notice ) || ! isset( $notice['message'] ) || ! array_key_exists( 'screen_id', $notice ) ) {
+				unset( $notices[ $index ] );
 				continue;
 			}
 
@@ -92,7 +93,7 @@ function wcs_display_admin_notices( $clear = true ) {
 
 		// $notice_output may be empty if some notices were withheld, due to not matching the screen context.
 		if ( ! empty( $notice_output ) ) {
-			echo '<div id="moderated" class="' . esc_attr( $class ) . '">' . wp_kses_post( implode( "</p>\n<p>", $notice_output ) ) . '</p></div>';
+			echo '<div id="moderated" class="' . esc_attr( $class ) . '"><p>' . wp_kses_post( implode( "</p>\n<p>", $notice_output ) ) . '</p></div>';
 		}
 	};
 

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -13,59 +13,118 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Store a message to display via @see wcs_display_admin_notices().
+ * Registers an admin notice to be displayed once to the current (or other specified) user.
  *
- * @param string The message to display
- * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+ * @see   wcs_display_admin_notices()
+ * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.0.
+ * @since 7.2.0 Added support for specifying the target user and context.
+ *
+ * @param string      $message     The message to display.
+ * @param string      $notice_type Either 'success' or 'error'.
+ * @param int|null    $user_id     The specific user who should see this message. If not specified, defaults to the current user.
+ * @param string|null $screen_id   The screen ID for which the message should be displayed. If not specified, it will show on the next admin page load.
+ *
+ * @return void
  */
-function wcs_add_admin_notice( $message, $notice_type = 'success' ) {
+function wcs_add_admin_notice( $message, $notice_type = 'success', $user_id = null, $screen_id = null ) {
+	$user_id = null === $user_id ? get_current_user_id() : $user_id;
+	$notices = get_transient( '_wcs_admin_notices_' . $user_id );
 
-	$notices = get_transient( '_wcs_admin_notices' );
-
-	if ( false === $notices ) {
+	if ( ! is_array( $notices ) ) {
 		$notices = array();
 	}
 
-	$notices[ $notice_type ][] = $message;
+	$notices[ $notice_type ][] = array(
+		'message'   => $message,
+		'screen_id' => $screen_id,
+	);
 
-	set_transient( '_wcs_admin_notices', $notices, 60 * 60 );
+	set_transient( '_wcs_admin_notices_' . $user_id, $notices, HOUR_IN_SECONDS );
 }
 
 /**
- * Display any notices added with @see wcs_add_admin_notice()
+ * Display any admin notices added with wcs_add_admin_notice().
  *
- * This method is also hooked to 'admin_notices' to display notices there.
+ * @see   wcs_add_admin_notice()
+ * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.0.
+ * @since 7.2.0 Supports contextual awareness of the user and screen.
  *
- * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+ * @param bool $clear If the message queue should be cleared after rendering the message(s). Defaults to true.
+ *
+ * @return void
  */
 function wcs_display_admin_notices( $clear = true ) {
+	$user_id = get_current_user_id();
+	$notices = get_transient( '_wcs_admin_notices_' . $user_id );
 
-	$notices = get_transient( '_wcs_admin_notices' );
-
-	if ( false !== $notices && ! empty( $notices ) ) {
-
-		if ( ! empty( $notices['success'] ) ) {
-			array_walk( $notices['success'], 'esc_html' );
-			echo '<div id="moderated" class="updated"><p>' . wp_kses_post( implode( "</p>\n<p>", $notices['success'] ) ) . '</p></div>';
-		}
-
-		if ( ! empty( $notices['error'] ) ) {
-			array_walk( $notices['error'], 'esc_html' );
-			echo '<div id="moderated" class="error"><p>' . wp_kses_post( implode( "</p>\n<p>", $notices['error'] ) ) . '</p></div>';
-		}
+	if ( ! is_array( $notices ) || empty( $notices ) ) {
+		return;
 	}
 
-	if ( false !== $clear ) {
+	/**
+	 * Normalizes, sanitizes and outputs the provided notices.
+	 *
+	 * @param array  &$notices The notice data.
+	 * @param string $class    The CSS notice class to be applied (typically 'updated' or 'error').
+	 *
+	 * @return void
+	 */
+	$handle_notices = static function ( &$notices, $class ) {
+		$notice_output = array();
+
+		foreach ( $notices as $index => $notice ) {
+			// Ensure the notice data now has the expected shape.
+			if ( ! is_array( $notice ) || ! isset( $notice['message'] ) || ! array_key_exists( 'screen_id', $notice ) ) {
+				continue;
+			}
+
+			$screen    = get_current_screen();
+			$screen_id = $screen instanceof WP_Screen ? $screen->id : '';
+
+			// Should the notice display in the current screen context?
+			if ( is_string( $notice['screen_id'] ) && $screen_id !== $notice['screen_id'] ) {
+				continue;
+			}
+
+			$notice_output[] = esc_html( $notice['message'] );
+			unset( $notices[ $index ] );
+		}
+
+		// $notice_output may be empty if some notices were withheld, due to not matching the screen context.
+		if ( ! empty( $notice_output ) ) {
+			echo '<div id="moderated" class="' . esc_attr( $class ) . '">' . wp_kses_post( implode( "</p>\n<p>", $notice_output ) ) . '</p></div>';
+		}
+	};
+
+	if ( ! empty( $notices['success'] ) ) {
+		$handle_notices( $notices['success'], 'updated' );
+	}
+
+	if ( ! empty( $notices['error'] ) ) {
+		$handle_notices( $notices['error'], 'error' );
+	}
+
+	// Under certain circumstances, the caller may not wish for the rendered messages to be cleared from the queue.
+	if ( false === $clear ) {
+		return;
+	}
+
+	// If all notices were rendered, clear the queue. If only some were rendered, clear what we can.
+	if ( empty( $notices ) ) {
 		wcs_clear_admin_notices();
+	} else {
+		set_transient( '_wcs_admin_notices_' . $user_id, $notices, HOUR_IN_SECONDS );
 	}
 }
+
 add_action( 'admin_notices', 'wcs_display_admin_notices' );
 
 /**
  * Delete any admin notices we stored for display later.
  *
- * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+ * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.0.
+ * @since 7.2.0 Became user aware.
  */
 function wcs_clear_admin_notices() {
-	delete_transient( '_wcs_admin_notices' );
+	delete_transient( '_wcs_admin_notices_' . get_current_user_id() );
 }

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -33,7 +33,7 @@ function wcs_add_admin_notice( $message, $notice_type = 'success', $user_id = nu
 		wc_get_logger()->warning(
 			sprintf(
 				/* Translators: %1$s: notice type ('success' or 'error'), %2$s: notice text. */
-				'Admin notices can only be added if a user is currently logged in. Attemped (%1$s) notice: "%2$s"',
+				'Admin notices can only be added if a user is currently logged in. Attempted (%1$s) notice: "%2$s"',
 				$notice_type,
 				$message
 			),

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -71,6 +71,7 @@ function wcs_display_admin_notices( $clear = true ) {
 	 */
 	$handle_notices = static function ( &$notices, $class ) {
 		$notice_output = array();
+		$screen_id     = false;
 
 		foreach ( $notices as $index => $notice ) {
 			// Ensure the notice data now has the expected shape. If it does not, remove it.
@@ -79,8 +80,11 @@ function wcs_display_admin_notices( $clear = true ) {
 				continue;
 			}
 
-			$screen    = get_current_screen();
-			$screen_id = $screen instanceof WP_Screen ? $screen->id : '';
+			// We only need to determine the current screen ID once.
+			if ( false === $screen_id ) {
+				$screen    = get_current_screen();
+				$screen_id = $screen instanceof WP_Screen ? $screen->id : '';
+			}
 
 			// Should the notice display in the current screen context?
 			if ( is_string( $notice['screen_id'] ) && $screen_id !== $notice['screen_id'] ) {

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -115,7 +115,7 @@ function wcs_display_admin_notices( $clear = true ) {
 	}
 
 	// If all notices were rendered, clear the queue. If only some were rendered, clear what we can.
-	if ( empty( $notices ) ) {
+	if ( empty( $notices['success'] ) && empty( $notices['error'] ) ) {
 		wcs_clear_admin_notices();
 	} else {
 		set_transient( '_wcs_admin_notices_' . $user_id, $notices, HOUR_IN_SECONDS );

--- a/includes/upgrades/class-wc-subscriptions-upgrader.php
+++ b/includes/upgrades/class-wc-subscriptions-upgrader.php
@@ -129,6 +129,11 @@ class WC_Subscriptions_Upgrader {
 			wp_unschedule_hook( 'wcs_cleanup_big_logs' );
 		}
 
+		if ( version_compare( self::$active_version, '8.0.0', '<' ) ) {
+			// As of Subscriptions 7.2.0 (Core 8.0.0), admin notices are stored one transient per-user.
+			delete_transient( '_wcs_admin_notices' );
+		}
+
 		self::upgrade_complete();
 	}
 

--- a/tests/unit/test-wcs-admin-functions.php
+++ b/tests/unit/test-wcs-admin-functions.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Tests for the functions contained in includes/admin/wcs-admin-functions.php.
+ */
+class WCS_Admin_Functions_Test extends WP_UnitTestCase {
+	/**
+	 * User ID of an administrator-level test user.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * User ID of a contributor-level test user.
+	 *
+	 * @var int
+	 */
+	private static $contributor_id;
+
+	/**
+	 * Ensure the admin functions are loaded in preparation for our tests.
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		if ( ! function_exists( 'wcs_admin_notice' ) ) {
+			require_once __DIR__ . '/../../includes/admin/wcs-admin-functions.php';
+		}
+
+		self::$admin_id       = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		self::$contributor_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
+	}
+
+	/**
+	 * Admin notices should target a specific user, and should not be visible to other users.
+	 *
+	 * @see wcs_add_admin_notice()
+	 * @see wcs_clear_admin_notices()
+	 * @see wcs_display_admin_notices()
+	 *
+	 * @return void
+	 */
+	public function test_wcs_admin_notice_visibility_by_user() {
+		$message_text = 'The first rule of subscription club, is you do not talk about subscription club.';
+
+		wp_set_current_user( self::$admin_id );
+		wcs_add_admin_notice( $message_text );
+
+		wp_set_current_user( self::$contributor_id );
+		$this->assertEquals(
+			'',
+			$this->capture_wcs_admin_notice_text(),
+			'The message was not exposed to the wrong user.'
+		);
+
+		wp_set_current_user( self::$admin_id );
+		$this->assertStringContainsString(
+			$message_text,
+			$this->capture_wcs_admin_notice_text(),
+			'The expected message was shared with the user.'
+		);
+
+		wcs_add_admin_notice( $message_text, 'success', self::$contributor_id );
+		$this->assertEquals(
+			'',
+			$this->capture_wcs_admin_notice_text(),
+			'The message (which does not target the current user) is not inadvertently shown to the current user.'
+		);
+
+		wp_set_current_user( self::$contributor_id );
+		$this->assertStringContainsString(
+			$message_text,
+			$this->capture_wcs_admin_notice_text(),
+			'The expected message was shared with the correct user.'
+		);
+	}
+
+	/**
+	 * Admin notices can target a specific admin screen, and should not render outside of that context.
+	 *
+	 * @see wcs_add_admin_notice()
+	 * @see wcs_clear_admin_notices()
+	 * @see wcs_display_admin_notices()
+	 *
+	 * @return void
+	 */
+	public function test_wcs_admin_notice_visibility_by_screen() {
+		global $current_screen;
+
+		$original_screen = $current_screen;
+		$message_text    = 'The second rule of subscription club, is you DO NOT talk about subscription club.';
+
+		wp_set_current_user( self::$admin_id );
+		wcs_add_admin_notice( $message_text, 'error', null, 'subscriptions-dashboard' );
+
+		$this->assertEquals(
+			'',
+			$this->capture_wcs_admin_notice_text(),
+			'The message was not exposed outside of the specified screen.'
+		);
+
+		$test_screen = WP_Screen::get( 'subscriptions-dashboard' );
+		set_current_screen( $test_screen );
+
+		$this->assertStringContainsString(
+			$message_text,
+			$this->capture_wcs_admin_notice_text(),
+			'The message was displayed in the context of the specified screen.'
+		);
+
+		set_current_screen( $original_screen );
+	}
+
+	/**
+	 * Admin notices generally act as 'flash messages' and are removed from the queue after they
+	 * have rendered. However, the system also allows for them to stay in the queue.
+	 *
+	 * @return void
+	 */
+	public function test_wcs_admin_notice_queue_clearance() {
+		$message_text = "That's no moon, it's a subscription notice.";
+		wcs_add_admin_notice( $message_text, 'error' );
+
+		$this->assertStringContainsString(
+			esc_html( $message_text ),
+			$this->capture_wcs_admin_notice_text( false ),
+			'The admin notice is displayed as expected.'
+		);
+
+		$this->assertStringContainsString(
+			esc_html( $message_text ),
+			$this->capture_wcs_admin_notice_text(),
+			'The admin notice is displayed a second time, because it was not cleared last time.'
+		);
+
+		$this->assertEquals(
+			'',
+			$this->capture_wcs_admin_notice_text(),
+			'The admin notice does not display, because it was cleared from the queue.'
+		);
+	}
+
+	/**
+	 * Equivalent to calling wcs_display_admin_notices() directly, except the function output is
+	 * captured and returned in a string.
+	 *
+	 * @param bool $clear If the message queue should be cleared after getting/displaying the messages.
+	 *
+	 * @return string
+	 */
+	private function capture_wcs_admin_notice_text( $clear = true ) {
+		ob_start();
+		wcs_display_admin_notices( $clear );
+		return (string) ob_get_clean();
+	}
+}

--- a/tests/unit/test-wcs-admin-functions.php
+++ b/tests/unit/test-wcs-admin-functions.php
@@ -79,6 +79,38 @@ class WCS_Admin_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Admin notices should not be accepted if a user is not actually logged in.
+	 *
+	 * This covers an edge case that generally should not arise. However, if it did, we would want to avoid
+	 * a scenario in which a '_wcs_admin_notices_0' transient is created and starts to balloon in size.
+	 *
+	 * @return void
+	 */
+	public function test_wcs_admin_notices_are_only_added_when_a_user_is_logged_in() {
+		$logged_messages = [];
+		$logging_monitor = function ( $message ) use ( &$logged_messages ) {
+			$logged_messages[] = $message;
+		};
+
+		add_filter( 'woocommerce_logger_log_message', $logging_monitor );
+		wp_set_current_user( 0 );
+		wcs_add_admin_notice( "You're gonna need a bigger subscription." );
+		remove_filter( 'woocommerce_logger_log_message', $logging_monitor );
+
+		$this->assertEquals(
+			'',
+			$this->capture_wcs_admin_notice_text(),
+			'If a user is not logged in, admin notifications are not accepted.'
+		);
+
+		$this->assertStringContainsString(
+			'Admin notices can only be added if a user is currently logged in',
+			$logged_messages[0],
+			'If an attempt is made to add an admin notice when nobody is logged in, a warning is logged.'
+		);
+	}
+
+	/**
 	 * Admin notices can target a specific admin screen, and should not render outside of that context.
 	 *
 	 * @see wcs_add_admin_notice()
@@ -121,6 +153,7 @@ class WCS_Admin_Functions_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_wcs_admin_notice_queue_clearance() {
+		wp_set_current_user( self::$admin_id );
 		$message_text = "That's no moon, it's a subscription notice.";
 		wcs_add_admin_notice( $message_text, 'error' );
 


### PR DESCRIPTION
If an admin notice is added via the `wcs_add_admin_notice()` function, then it will display on the next request for an admin screen—regardless of who the current user is or what screen they are viewing. Here's a hypothetical example:

- Merchant changes the subscription end date in the editor.
- In response, we add an admin notice to tell them the change was successful (or possibly to inform them that there was a problem of some kind).
- If some other user, like a contributor, just happens to request a different admin page at approximately the same time (and immediately before the admin's instance of the subscription editor finishes reloading), then that is the user who will, quite unexpectedly, see the admin notice.
- Additionally, these operate as "flash" messages by default—and so, once they've been consumed, they are gone: in other words, in this hypothetical scenario, the merchant would never see the message. Only the contributor would see it, and they'd probably be a little confused by it.

In this change, we tighten things up a little such that:

- If a notice is enqueued, we assume its intended audience is the current user (and that's the only person that will see it). We also make it possible to explicitly specify the intended recipient.
- Additionally, it can be 'locked' to a specific context, by specifying the relevant screen ID (this would mean we can constrain certain notices so they only render in the subscription editor, to pick an example).

**How can this code break?**

We previously stored these notices in a transient named `_wcs_admin_notices`, but will now use one or more transients named `_wcs_admin_notices_<user_id>`. So, an enqueued notice could be lost upon update (I think this is acceptable, and would be a very temporary problem that probably would impact very few users indeed ... but we *could* soften the landing if we think it's necessary to do so).
   
Updates http://github.com/woocommerce/woocommerce-subscriptions/issues/4776

## How to test this PR

Let's first test that existing admin notices continue work as expected. To do this, select an existing subscription and contrive a problem in which the subscription end date is *earlier* than the next payment date:

<div align="center"><img width="600" src="https://github.com/user-attachments/assets/b1d19195-ddc6-45f4-9d36-49e26bb8c072" alt="Subscription payment dates meta box" /></div>

Normally it's not possible to do this, so setting it up will require direct edits to the relevant row of the `wc_orders_meta` table (assuming you are using HPOS). Find the `_schedule_end` entry, and alter the date manually as needed.

With that done, return to the editor and click update. Upon reload, you should see that an admin notice is present on the page telling you that the end date is incorrect:

![Admin notices at the top of the subscription editor screen](https://github.com/user-attachments/assets/3281cdb3-0d98-44f2-99da-90dfb6112449)

On to the real testing! Let's confirm that admin notices are 'constrained' to the current user. Probably the easiest way to do this is to have two separate browser contexts: in one, you should be logged in as an admin user or shop manager, in the other you should be logged in as a contributor (or other less privileged user). You also need to add the following snippet to a suitable location, such as `wp-content/mu-plugins/test-pr-767.php`:

```php
<?php

add_action( 'admin_footer', function () {
	if (
		! isset( $_GET[ 'create-wcs-message' ] )
		|| ! function_exists( 'wcs_add_admin_notice' )
	) {
		return;
	}

	$user = wp_get_current_user();

	$username = $user instanceof WP_User ? $user->display_name : '&lt;unknown&gt;';
	wcs_add_admin_notice( "Hey there, $username! Time for a coffee?", 'success');
} );
```

- As the admin user, visit `example.com/wp-admin?create-wcs-message=1`. This triggers the code in the snippet.
- When the page finishes loading you should see ... nothing new (or, at least, you should not see an admin notice, unless perhaps WordPress adds one that is unrelated to the scenario we are testing).
- Now switch to the other browser context, where you are logged in as a contributor. Load or refresh one of the admin pages:
    - Without this fix, you should see a message reading something like _Hey there, **admin user**! Time for a coffee?_
    - If you repeat but with this fix, you should not see any admin notice message.
- Switch back to the original browser context, where you are logged in as an admin user. Load or refresh another admin page, but make sure `?create-wcs-message=1` is no longer in the URL.
    - Without this fix, you will not see an admin notice (it was consumed by the contributor).
    - *With* this fix, you *should* see the admin notice.

> [!TIP]
> In case it isn't clear, note that you need to run through the whole set of testing steps once without this fix, and then again *with* the fix. You can't flip between branches as you go along, or you will get unexpected results.

> [!NOTE]
> The change goes beyond what these testing instructions describe. For example, as noted earlier, it now becomes possible to lock a message to a specific screen. I have not detailed testing steps for this but will *probably* do so in a further PR that takes advantage of that functionality. Nonetheless, feel free to explore this area now if you feel so inclined!

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? ***Yes → [#4776](http://github.com/woocommerce/woocommerce-subscriptions/issues/4776)***
- [ ] Will this PR affect WooCommerce Payments? ***No***
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) ***None***
