### PR TITLE
Create pending renewal order (improve safety/error handling)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
+* Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -250,6 +250,8 @@ class WCS_Admin_Meta_Boxes {
 	 * @param WC_Subscription $subscription
 	 */
 	public static function create_pending_renewal_action_request( $subscription ) {
+		$subscription->add_order_note( __( 'Create pending renewal order requested by admin action.', 'woocommerce-subscriptions' ), false, true );
+
 		try {
 			$subscription->update_status( 'on-hold' );
 		} catch ( Exception $e ) {

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -247,21 +247,65 @@ class WCS_Admin_Meta_Boxes {
 	/**
 	 * Handles the action request to create a pending renewal order.
 	 *
-	 * @param array $subscription
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+	 * @param WC_Subscription $subscription
 	 */
 	public static function create_pending_renewal_action_request( $subscription ) {
-		$subscription->add_order_note( __( 'Create pending renewal order requested by admin action.', 'woocommerce-subscriptions' ), false, true );
-		$subscription->update_status( 'on-hold' );
+		try {
+			$subscription->update_status( 'on-hold' );
+		} catch ( Exception $e ) {
+			self::notify(
+				$subscription,
+				'error',
+				esc_html__( 'Pending renewal order was not created, as it was not possible to update the subscription status.', 'woocommerce-subscriptions' )
+			);
+
+			return;
+		}
 
 		$renewal_order = wcs_create_renewal_order( $subscription );
 
+		if ( is_wp_error( $renewal_order ) ) {
+			self::notify(
+				$subscription,
+				'error',
+				esc_html__( 'Creation of the pending renewal order failed.', 'woocommerce-subscriptions' )
+			);
+
+			return;
+		}
+
 		if ( ! $subscription->is_manual() ) {
+			$renewal_url = $renewal_order->get_edit_order_url();
 
-			$renewal_order->set_payment_method( wc_get_payment_gateway_by_order( $subscription ) ); // We need to pass the payment gateway instance to be compatible with WC < 3.0, only WC 3.0+ supports passing the string name
+			try {
+				// We need to pass the payment gateway instance to be compatible with WC < 3.0, only WC 3.0+ supports passing the string name.
+				$renewal_order->set_payment_method( wc_get_payment_gateway_by_order( $subscription ) );
 
-			if ( is_callable( array( $renewal_order, 'save' ) ) ) { // WC 3.0+
-				$renewal_order->save();
+				if ( is_callable( array( $renewal_order, 'save' ) ) ) { // WC 3.0+
+					$renewal_order->save();
+				}
+
+				self::notify(
+					$subscription,
+					'success',
+					sprintf(
+						/* Translators: %1$s opening link tag, %2$s closing link tag. */
+						__( 'A pending %1$srenewal order%2$s was successfully created!', 'woocommerce-subscriptions' ),
+						'<a href="' . esc_url( $renewal_url ) . '">',
+						'</a>'
+					)
+				);
+			} catch ( WC_Data_Exception $e ) {
+				self::notify(
+					$subscription,
+					'error',
+					sprintf(
+						/* Translators: %1$s opening link tag, %2$s closing link tag. */
+						__( 'A %1$spending renewal order%2$s was successfully created, but there was a problem setting the payment method. Please review the order.', 'woocommerce-subscriptions' ),
+						'<a href="' . esc_url( $renewal_url ) . '">',
+						'</a>'
+					)
+				);
 			}
 		}
 	}
@@ -721,5 +765,23 @@ class WCS_Admin_Meta_Boxes {
 			'high',
 			$items_meta_box['args']
 		);
+	}
+
+	/**
+	 * Notifies the user of an operational success or failure, and records a matching order note.
+	 *
+	 * In essence, it can be convenient to generate both an admin notice (to give the user some clear and
+	 * obvious feedback) and record the same as an order note (the admin notice could be missed, and is
+	 * auto-dismissed after the first view).
+	 *
+	 * @param WC_Subscription $subscription The subscription we are working with.
+	 * @param string          $type         Message type: 'success' or 'error.
+	 * @param string          $message      Message text, which will be used both for an admin notice and for the order note.
+	 *
+	 * @return void
+	 */
+	private static function notify( WC_Subscription $subscription, $type, $message ) {
+		$subscription->add_order_note( $message, false, true );
+		wcs_add_admin_notice( $message, $type );
 	}
 }

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -283,15 +283,14 @@ class WCS_Admin_Meta_Boxes {
 					$renewal_order->save();
 				}
 
-				self::notify(
-					$subscription,
-					'success',
+				wcs_add_admin_notice(
 					sprintf(
 						/* Translators: %1$s opening link tag, %2$s closing link tag. */
 						esc_html__( 'A pending %1$srenewal order%2$s was successfully created!', 'woocommerce-subscriptions' ),
 						'<a href="' . esc_url( $renewal_url ) . '">',
 						'</a>'
-					)
+					),
+					'success'
 				);
 			} catch ( WC_Data_Exception $e ) {
 				self::notify(

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -267,6 +267,7 @@ class WCS_Admin_Meta_Boxes {
 				$subscription,
 				'error',
 				esc_html__( 'Creation of the pending renewal order failed.', 'woocommerce-subscriptions' )
+				. ' ' . $renewal_order->get_error_message()
 			);
 
 			return;

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -290,7 +290,7 @@ class WCS_Admin_Meta_Boxes {
 					'success',
 					sprintf(
 						/* Translators: %1$s opening link tag, %2$s closing link tag. */
-						__( 'A pending %1$srenewal order%2$s was successfully created!', 'woocommerce-subscriptions' ),
+						esc_html__( 'A pending %1$srenewal order%2$s was successfully created!', 'woocommerce-subscriptions' ),
 						'<a href="' . esc_url( $renewal_url ) . '">',
 						'</a>'
 					)
@@ -301,7 +301,7 @@ class WCS_Admin_Meta_Boxes {
 					'error',
 					sprintf(
 						/* Translators: %1$s opening link tag, %2$s closing link tag. */
-						__( 'A %1$spending renewal order%2$s was successfully created, but there was a problem setting the payment method. Please review the order.', 'woocommerce-subscriptions' ),
+						esc_html__( 'A %1$spending renewal order%2$s was successfully created, but there was a problem setting the payment method. Please review the order.', 'woocommerce-subscriptions' ),
 						'<a href="' . esc_url( $renewal_url ) . '">',
 						'</a>'
 					)

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -253,12 +253,10 @@ class WCS_Admin_Meta_Boxes {
 		try {
 			$subscription->update_status( 'on-hold' );
 		} catch ( Exception $e ) {
-			self::notify(
-				$subscription,
-				'error',
-				esc_html__( 'Pending renewal order was not created, as it was not possible to update the subscription status.', 'woocommerce-subscriptions' )
+			wcs_add_admin_notice(
+				__( 'Pending renewal order was not created, as it was not possible to update the subscription status.', 'woocommerce-subscriptions' ),
+				'error'
 			);
-
 			return;
 		}
 

--- a/includes/admin/wcs-admin-functions.php
+++ b/includes/admin/wcs-admin-functions.php
@@ -109,7 +109,7 @@ function wcs_display_admin_notices( $clear = true ) {
 				continue;
 			}
 
-			$notice_output[] = esc_html( $notice['message'] );
+			$notice_output[] = $notice['message'];
 			unset( $notices[ $index ] );
 		}
 

--- a/includes/wcs-renewal-functions.php
+++ b/includes/wcs-renewal-functions.php
@@ -35,7 +35,17 @@ function wcs_create_renewal_order( $subscription ) {
 
 	WCS_Related_Order_Store::instance()->add_relation( $renewal_order, $subscription, 'renewal' );
 
-	return apply_filters( 'wcs_renewal_order_created', $renewal_order, $subscription );
+	/**
+	 * Provides an opportunity to monitor, interact with and replace renewal orders when they
+	 * are first created.
+	 *
+	 * @param WC_Order        $renewal_order The renewal order.
+	 * @param WC_Subscription $subscription  The subscription the renewal is related to.
+	 */
+	$filtered_renewal_order = apply_filters( 'wcs_renewal_order_created', $renewal_order, $subscription );
+
+	// It is possible that a filter function will replace the renewal order with something else entirely.
+	return $filtered_renewal_order instanceof WC_Order ? $filtered_renewal_order : $renewal_order;
 }
 
 /**

--- a/tests/unit/test-wcs-admin-functions.php
+++ b/tests/unit/test-wcs-admin-functions.php
@@ -158,13 +158,13 @@ class WCS_Admin_Functions_Test extends WP_UnitTestCase {
 		wcs_add_admin_notice( $message_text, 'error' );
 
 		$this->assertStringContainsString(
-			esc_html( $message_text ),
+			$message_text,
 			$this->capture_wcs_admin_notice_text( false ),
 			'The admin notice is displayed as expected.'
 		);
 
 		$this->assertStringContainsString(
-			esc_html( $message_text ),
+			$message_text,
 			$this->capture_wcs_admin_notice_text(),
 			'The admin notice is displayed a second time, because it was not cleared last time.'
 		);


### PR DESCRIPTION
For most active subscriptions, it's possible for the merchant to create a *pending renewal order.* This is generally done via the *Order Actions* dropdown:

<div align="center"><img width="600" src="https://github.com/user-attachments/assets/0c8e4825-5932-47b9-939e-6fedb53935d6" /></div>

However, as described in the [linked issue](https://github.com/woocommerce/woocommerce-subscriptions/issues/4735), it is possible for an uncaught exception to be raised (this might happen if it is not possible to change the subscription status), which breaks the process and leads the user to a blank screen or error message:

```
[17-Oct-2024 02:22:56 UTC] PHP Fatal error:  Uncaught Exception: Unable to change subscription status to "on-hold". in /.../woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/class-wc-subscription.php:450

Stack trace:
#0 /.../woocommerce-subscriptions/vendor/woocommerce/subscriptions-core/includes/admin/class-wcs-admin-meta-boxes.php(255): WC_Subscription->update_status('on-hold')
#1 /.../wp-includes/class-wp-hook.php(324): WCS_Admin_Meta_Boxes::create_pending_renewal_action_request(Object(WC_Subscription))
#2 /.../wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
```

Though the original report cites a problem when the subscription status cannot be changed, on further examination it looked to me like there are 3 points of failure within [`WCS_Admin_Meta_Boxes::create_pending_renewal_action_request()`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.9.0/includes/admin/class-wcs-admin-meta-boxes.php#L253-L267), so I've tried to address all three. However, if we prefer to stay tightly focused only on the potential for an uncaught exception (when the subscription status is changed), I'm more than happy to revise and simplify the PR. 

The three areas I felt could benefit from additional safety:

- [Status update](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.9.0/includes/admin/class-wcs-admin-meta-boxes.php#L255) → an exception can be raised, and is not caught (notice also that we add an order note *before* this happens).
- [Creation of the renewal order](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.9.0/includes/admin/class-wcs-admin-meta-boxes.php#L257) → we assume an order was successfully created, but it is possible a `WP_Error` will have been raised (if so, we'd hit problems when we subsequently try to call order methods).
- [Setting the payment method](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.9.0/includes/admin/class-wcs-admin-meta-boxes.php#L261) → An exception is again possible here and, similar to the first issue, is not caught.

Therefore, this change mostly involves adding try/catch blocks or conditionals so that we handle things gracefully should the unexpected happen. 

Lastly, the linked issue proposes we remove the *create pending renewal order* item from the *Order Actions* dropdown if it looks like creating it will lead to an error. As described above, there are lots of conditions in which this might happen, not just one, so I'm not too sure about the merits of this (and, it seems a fix has already been made to the extension with which this was being experienced). However, more than happy to follow-up and put this in place.

Updates https://github.com/woocommerce/woocommerce-subscriptions/issues/4735

## How to test this PR

We can contrive error conditions for each of the three points of failure by applying the following snippets, one at a time (you could, for instance, place these lines in a mu-plugin file as needed):

```php
# Trigger the originally reported problem, in which the subscription status
# cannot be updated to 'on-hold' (leads to an exception being raised).
add_filter( 'woocommerce_can_subscription_be_updated_to_on-hold', '__return_false' );
```

```php
# Triggers the second possible failure, in which the new order is not created
# and a WP_Error is raised.
add_filter( 'wcs_new_order_created', fn () => new WP_Error( 
	'simulated-order-creation-error',
	'(Details of the specific error.)'
) );
```

```php
# Triggers the third possible failure, in which setting the order's payment 
# method leads to an exception being raised.
add_filter( 'wcs_renewal_order_created', function () {
	class Problematic_Renewal_Order extends WC_Order {
		public function set_payment_method( $payment_method = '' ) {
			throw new WC_Data_Exception( 'problem', 'simulated' );
		}
	}

	return new Problematic_Renewal_Order;
}, 10000 );
```

Let's do some testing! Create or find a suitable existing subscription (one that is active, has a valid payment method already, etc):

1. Start by testing the 'happy path', and try creating a pending renewal order. This should succeed (note: you should not have any test snippets in place just yet). Once the editor reloads, you should see:
    - An admin notice reading, *"A pending [renewal order](#) was successfully created!"*
    - An order note reading, *"Create pending renewal order requested by admin action."*
    - A further order note reading, *"Order [#12345](#) created to record renewal."*
2. Since the last test succeeded, the subscription will now be *on hold.* We need to change this before we continue with our tests: set it back to *active.*
3. Add the first test snippet and create another pending renewal order. This time, an order will not be created, and you should see:
    - An order note reading, *"Create pending renewal order requested by admin action."*
    - An admin notice reading, *"Pending renewal order was not created, as it was not possible to update the subscription status."*
    - A further order note reading, *"Unable to change subscription status to 'on-hold'."*
4. Remove the test snippet, and replace with the second snippet, then repeat the test. Again, the order will not be created and we should see:
    - An order note reading, *"Create pending renewal order requested by admin action."*
    - An admin notice reading, *"Creation of the pending renewal order failed. (Details of the specific error.)"*
    - A further order note, with the same text as in the admin notice.
5. Finally, replace the test snippet with the last snippet, then repeat once more. This time the renewal order should have been created, but the payment method will not have been set. Accordingly, we should see:
    - As usual, an initial order note reading, *"Create pending renewal order requested by admin action."*
    - An order note reading, *"Order [#12345](#) created to record renewal."*
    - One more order note explaining that there was a problem: *"A [pending renewal order](#) was successfully created, but there was a problem setting the payment method. Please review the order."*
    - The text in that last order note will also be used to form an admin notice at the top of the screen.
6. You can of course repeat the tests without this fix branch, in which case you will encounter the naked errors.

## Questions/notes

- As above, are we happy to tackle all three potential failures from `::create_pending_renewal_action_request()` in the same PR? ***Yes, we agreed to tackle them all here.***
- Do we feel there is a need to follow-up, and try to proactive remove *create pending renewal order* from the order actions list (where possible)? This was one of the bug report author's recommendations, and it seems like this may already have happened from within WooCommerce Pre-Orders. ***This PR stands alone as a good improvement, and we can consider other UI changes separately (but, also feel it's really on extensions introducing these problems to tackle this).***
- It seems like essentially this same set of problems is also true of the *create pending **parent*** action: should we follow-up with similar fixes for that, too? ***Yes, we will follow-up separately for that aspect of the problem—but wish to conclude this one and ensure we're happy with our approach before doing so.***

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? ***yes [(#4735)](https://github.com/woocommerce/woocommerce-subscriptions/issues/4735)***
- [x] Will this PR affect WooCommerce Payments? ***no***
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) ***none***
