### PR TITLE
Fix WooCommerce Subscriptions unit tests

### DIFF
--- a/includes/upgrades/class-wcs-repair-2-0.php
+++ b/includes/upgrades/class-wcs-repair-2-0.php
@@ -395,8 +395,7 @@ class WCS_Repair_2_0 {
 	public static function repair_start_date( $subscription, $item_id, $item_meta ) {
 		global $wpdb;
 
-		$order      = wc_get_order( $subscription['order_id'] );
-		$start_date = $order->get_meta( '_paid_date', true );
+		$start_date = get_post_meta( $subscription['order_id'], '_paid_date', true );
 
 		WCS_Upgrade_Logger::add( sprintf( 'Repairing start_date for order %d: Trying to use the _paid date for start date.', $subscription['order_id'] ) );
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/pull/4771

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

This PR undo a change introduced by https://github.com/Automattic/woocommerce-subscriptions-core/pull/718 which made a unit test stop working due to the HPOS support.

This change was made on a deprecated class and would require some more updates to support HPOS, for example use `date_created_gmt` instead of `post_created_gmt` [here](https://github.com/Automattic/woocommerce-subscriptions-core/blob/8588c3500ce5468d0eaa68c9481229946188dbe8/includes/upgrades/class-wcs-repair-2-0.php#L405).

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load this PR changes into WooCommerce Subscriptions test environment.
2. Run unit tests.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
