### PR TITLE
Add subscription item table to our customer notification emails and introduce before/after hooks for further customisations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
+* Update - Include subscription items table in all customer notification emails.
+* Dev - Introduce before & after hooks within the subscription-info.php template.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,6 @@
 * Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
 * Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
 * Update - Include subscription items table in all customer notification emails.
-* Dev - Introduce before & after hooks within the subscription-info.php template.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/includes/class-wc-subscriptions-email.php
+++ b/includes/class-wc-subscriptions-email.php
@@ -329,6 +329,7 @@ class WC_Subscriptions_Email {
 				'order'                => $order,
 				'subscriptions'        => $subscriptions,
 				'is_admin_email'       => $sent_to_admin,
+				'plain_text'           => $plain_text,
 				'skip_my_account_link' => $skip_my_account_link,
 			),
 			'',

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -756,6 +756,7 @@ class WC_Subscriptions_Order {
 					'order'                => $order,
 					'subscriptions'        => $subscriptions,
 					'is_admin_email'       => $is_admin_email,
+					'plain_text'           => $plaintext,
 					'skip_my_account_link' => $skip_my_account_link,
 				),
 				'',

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -45,14 +45,6 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		);
 		?>
 	</p>
-
-	<p>
-		<?php
-			esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-		?>
-	</p>
-
-
 <?php
 
 // Show subscription details.

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -57,6 +57,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
+
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 ?>
 	<p>
 		<small>

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -3,7 +3,7 @@
  * Customer Notification: Notify the customer that an automated renewal their subscription is about to happen.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @hooked WC_Emails::email_header() Output the email header.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
@@ -78,6 +78,6 @@ if ( $additional_content ) {
 /**
  * @hooked WC_Emails::email_footer() Output the email footer.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-notification-auto-renewal.php
+++ b/templates/emails/customer-notification-auto-renewal.php
@@ -50,6 +50,18 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 ?>
 	<p>

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -64,6 +64,18 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -3,7 +3,7 @@
  * Customer Notification: Free trial of an automatically renewed subscription is about to expire email.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @hooked WC_Emails::email_header() Output the email header.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
@@ -76,6 +76,6 @@ if ( $additional_content ) {
 /**
  * @hooked WC_Emails::email_footer() Output the email footer.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -64,18 +64,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -71,6 +71,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */

--- a/templates/emails/customer-notification-auto-trial-ending.php
+++ b/templates/emails/customer-notification-auto-trial-ending.php
@@ -59,13 +59,6 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		);
 		?>
 	</p>
-
-	<p>
-		<?php
-			esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-		?>
-	</p>
-
 <?php
 
 // Show subscription details.

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -50,6 +50,18 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -50,18 +50,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -58,6 +58,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -3,7 +3,7 @@
  * Customer Notification: Subscription is about to expire email.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @hooked WC_Emails::email_header() Output the email header.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
@@ -62,6 +62,6 @@ if ( $additional_content ) {
 /**
  * @hooked WC_Emails::email_footer() Output the email footer.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-notification-expiring-subscription.php
+++ b/templates/emails/customer-notification-expiring-subscription.php
@@ -45,14 +45,6 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 		);
 		?>
 	</p>
-
-	<p>
-		<?php
-		esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-		?>
-	</p>
-
-
 <?php
 
 // Show subscription details.

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -87,13 +87,6 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	</table>
 
 	<br>
-	<p>
-		<?php
-		esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-		?>
-	</p>
-
-
 <?php
 
 // Show subscription details.

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -99,6 +99,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -92,18 +92,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -92,6 +92,18 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-manual-renewal.php
+++ b/templates/emails/customer-notification-manual-renewal.php
@@ -3,7 +3,7 @@
  * Customer Notification: Manual renewal needed.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @hooked WC_Emails::email_header() Output the email header.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
@@ -104,6 +104,6 @@ if ( $additional_content ) {
 /**
  * @hooked WC_Emails::email_footer() Output the email footer.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-notification-manual-trial-ending.php
+++ b/templates/emails/customer-notification-manual-trial-ending.php
@@ -53,6 +53,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */

--- a/templates/emails/customer-notification-manual-trial-ending.php
+++ b/templates/emails/customer-notification-manual-trial-ending.php
@@ -53,6 +53,18 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-manual-trial-ending.php
+++ b/templates/emails/customer-notification-manual-trial-ending.php
@@ -53,18 +53,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/customer-notification-manual-trial-ending.php
+++ b/templates/emails/customer-notification-manual-trial-ending.php
@@ -3,7 +3,7 @@
  * Customer Notification: Free trial of a manually renewed subscription is about to expire email.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * @hooked WC_Emails::email_header() Output the email header.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
@@ -65,6 +65,6 @@ if ( $additional_content ) {
 /**
  * @hooked WC_Emails::email_footer() Output the email footer.
  *
- * @since x.x.x
+ * @since 6.9.0
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -42,6 +42,8 @@ echo "\n";
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 esc_html_e( 'You can manage this subscription from your account dashboard: ', 'woocommerce-subscriptions' );
 echo esc_url( wc_get_page_permalink( 'myaccount' ) );
 

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -40,18 +40,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 esc_html_e( 'You can manage this subscription from your account dashboard: ', 'woocommerce-subscriptions' );

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -3,7 +3,7 @@
  * Customer Notification: Notify the customer that an automated renewal their subscription is about to happen. Plain text version.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails/Plain
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -37,8 +37,6 @@ echo esc_html(
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
-esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-echo "\n";
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 

--- a/templates/emails/plain/customer-notification-auto-renewal.php
+++ b/templates/emails/plain/customer-notification-auto-renewal.php
@@ -40,6 +40,18 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 esc_html_e( 'You can manage this subscription from your account dashboard: ', 'woocommerce-subscriptions' );

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -3,7 +3,7 @@
  * Customer Notification: Free trial of an automatically renewed subscription is about to expire email. Plain text version.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails/Plain
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -46,18 +46,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -46,6 +46,18 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -48,6 +48,8 @@ esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
 /**

--- a/templates/emails/plain/customer-notification-auto-trial-ending.php
+++ b/templates/emails/plain/customer-notification-auto-trial-ending.php
@@ -43,8 +43,6 @@ echo esc_url( wc_get_page_permalink( 'myaccount' ) );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
-esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -40,18 +40,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -40,6 +40,18 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 /**

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -42,6 +42,8 @@ esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 /**
  * Show user-defined additional content - this is set in each email's settings.
  */

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -3,7 +3,7 @@
  * Customer Notification: Subscription is about to expire email. Plain text version.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails/Plain
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly

--- a/templates/emails/plain/customer-notification-expiring-subscription.php
+++ b/templates/emails/plain/customer-notification-expiring-subscription.php
@@ -37,8 +37,6 @@ echo esc_html(
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
-esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text, true );
 

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -58,8 +58,6 @@ if ( $can_renew_early ) {
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
-esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
-
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -61,6 +61,18 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+/**
+ * 'woocommerce_subscriptions_email_order_details' hook.
+ *
+ * @since 7.2.0
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -3,7 +3,7 @@
  * Customer Notification: Manual renewal needed. Plain text version.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails/Plain
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -61,18 +61,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
-/**
- * 'woocommerce_subscriptions_email_order_details' hook.
- *
- * @since 7.2.0
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";

--- a/templates/emails/plain/customer-notification-manual-renewal.php
+++ b/templates/emails/plain/customer-notification-manual-renewal.php
@@ -63,6 +63,8 @@ esc_html_e( 'Here are the details:', 'woocommerce-subscriptions' );
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
 /**

--- a/templates/emails/plain/customer-notification-manual-trial-ending.php
+++ b/templates/emails/plain/customer-notification-manual-trial-ending.php
@@ -3,7 +3,7 @@
  * Customer Notification: Free trial of a manually renewed subscription is about to expire email. Plain text version.
  *
  * @package WooCommerce_Subscriptions/Templates/Emails/Plain
- * @version x.x.x
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly

--- a/templates/emails/plain/customer-notification-manual-trial-ending.php
+++ b/templates/emails/plain/customer-notification-manual-trial-ending.php
@@ -40,6 +40,8 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
 
 /**

--- a/templates/emails/plain/customer-notification-manual-trial-ending.php
+++ b/templates/emails/plain/customer-notification-manual-trial-ending.php
@@ -40,18 +40,7 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
-/**
- * Shows the subscription or order details table.
- *
- * @param WC_Subscription|WC_Order $subscription  The subscription object.
- * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
- * @param bool                     $plain_text    Whether the email is being sent as plain text.
- * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
- *
- * @hooked WC_Subscriptions_Email::order_details() - 10.
- *
- * @since 7.2.0
- */
+/** This action is documented in templates/emails/customer-notification-auto-renewal.php */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";

--- a/templates/emails/plain/customer-notification-manual-trial-ending.php
+++ b/templates/emails/plain/customer-notification-manual-trial-ending.php
@@ -40,6 +40,18 @@ echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\
 // Show subscription details.
 \WC_Subscriptions_Email::subscription_details( $subscription, $order, $sent_to_admin, $plain_text );
 
+/**
+ * Shows the subscription or order details table.
+ *
+ * @param WC_Subscription|WC_Order $subscription  The subscription object.
+ * @param bool                     $sent_to_admin Whether the email is being sent to an admin.
+ * @param bool                     $plain_text    Whether the email is being sent as plain text.
+ * @param WC_Email                 $email         The email object, useful for accessing the email's properties and methods.
+ *
+ * @hooked WC_Subscriptions_Email::order_details() - 10.
+ *
+ * @since 7.2.0
+ */
 do_action( 'woocommerce_subscriptions_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 echo "\n\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";

--- a/templates/emails/plain/subscription-info.php
+++ b/templates/emails/plain/subscription-info.php
@@ -4,7 +4,7 @@
  *
  * @author  Brent Shepherd / Chuck Mac
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.4
+ * @version 7.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +16,8 @@ if ( empty( $subscriptions ) ) {
 
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
+
+do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );
 
 echo "\n\n" . __( 'Subscription information', 'woocommerce-subscriptions' ) . "\n\n";
 foreach ( $subscriptions as $subscription ) {
@@ -61,3 +63,5 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 		)
 	);
 }
+
+do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );

--- a/templates/emails/plain/subscription-info.php
+++ b/templates/emails/plain/subscription-info.php
@@ -16,7 +16,7 @@ if ( empty( $subscriptions ) ) {
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
 
-do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );
+do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );
 
 echo "\n\n" . __( 'Subscription information', 'woocommerce-subscriptions' ) . "\n\n";
 foreach ( $subscriptions as $subscription ) {
@@ -63,4 +63,4 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 	);
 }
 
-do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );
+do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );

--- a/templates/emails/plain/subscription-info.php
+++ b/templates/emails/plain/subscription-info.php
@@ -2,7 +2,6 @@
 /**
  * Subscription information template
  *
- * @author  Brent Shepherd / Chuck Mac
  * @package WooCommerce_Subscriptions/Templates/Emails
  * @version 7.2.0
  */

--- a/templates/emails/plain/subscription-info.php
+++ b/templates/emails/plain/subscription-info.php
@@ -16,8 +16,6 @@ if ( empty( $subscriptions ) ) {
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
 
-do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );
-
 echo "\n\n" . __( 'Subscription information', 'woocommerce-subscriptions' ) . "\n\n";
 foreach ( $subscriptions as $subscription ) {
 	$has_automatic_renewal = $has_automatic_renewal || ! $subscription->is_manual();
@@ -62,5 +60,3 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 		)
 	);
 }
-
-do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -16,7 +16,7 @@ if ( empty( $subscriptions ) ) {
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
 
-do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );
+do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );
 ?>
 <div style="margin-bottom: 40px;">
 <h2><?php esc_html_e( 'Subscription information', 'woocommerce-subscriptions' ); ?></h2>
@@ -33,6 +33,7 @@ do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscrip
 	<?php foreach ( $subscriptions as $subscription ) : ?>
 		<?php $has_automatic_renewal = $has_automatic_renewal || ! $subscription->is_manual(); ?>
 		<tr>
+			<?php // translators: placeholder is the subscription number. ?>
 			<td class="td" scope="row" style="text-align:left;"><a href="<?php echo esc_url( ( $is_admin_email ) ? wcs_get_edit_post_link( $subscription->get_id() ) : $subscription->get_view_order_url() ); ?>"><?php echo sprintf( esc_html_x( '#%s', 'subscription number in email table. (eg: #106)', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) ); ?></a></td>
 			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'start_date', 'site' ) ) ); ?></td>
 			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions' ) ); ?></td>
@@ -40,6 +41,7 @@ do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscrip
 				<?php echo wp_kses_post( $subscription->get_formatted_order_total() ); ?>
 				<?php if ( $is_parent_order && $subscription->get_time( 'next_payment' ) > 0 ) : ?>
 					<br>
+					<?php // translators: placeholder is the next payment date. ?>
 					<small><?php printf( esc_html__( 'Next payment: %s', 'woocommerce-subscriptions' ), esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'next_payment', 'site' ) ) ) ); ?></small>
 				<?php endif; ?>
 			</td>
@@ -56,11 +58,11 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 		$my_account_url = wc_get_endpoint_url( 'subscriptions', '', wc_get_page_permalink( 'myaccount' ) );
 	}
 
-	// Translators: Placeholders are opening and closing My Account link tags.
 	printf(
 		'<small>%s</small>',
 		wp_kses_post(
 			sprintf(
+				// Translators: Placeholders are opening and closing My Account link tags.
 				_n(
 					'This subscription is set to renew automatically using your payment method on file. You can manage or cancel this subscription from your %1$smy account page%2$s.',
 					'These subscriptions are set to renew automatically using your payment method on file. You can manage or cancel your subscriptions from your %1$smy account page%2$s.',
@@ -77,4 +79,4 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 </div>
 <?php
 
-do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );
+do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -4,7 +4,7 @@
  *
  * @author  Brent Shepherd / Chuck Mac
  * @package WooCommerce_Subscriptions/Templates/Emails
- * @version 1.0.0 - Migrated from WooCommerce Subscriptions v3.0.4
+ * @version 7.2.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
@@ -16,6 +16,8 @@ if ( empty( $subscriptions ) ) {
 
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
+
+do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );
 ?>
 <div style="margin-bottom: 40px;">
 <h2><?php esc_html_e( 'Subscription information', 'woocommerce-subscriptions' ); ?></h2>
@@ -74,4 +76,6 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 }
 ?>
 </div>
+<?php
 
+do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text );

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -33,7 +33,7 @@ do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscrip
 	<?php foreach ( $subscriptions as $subscription ) : ?>
 		<?php $has_automatic_renewal = $has_automatic_renewal || ! $subscription->is_manual(); ?>
 		<tr>
-			<?php // translators: placeholder is the subscription number. ?>
+			<?php // Translators: placeholder is the subscription number. ?>
 			<td class="td" scope="row" style="text-align:left;"><a href="<?php echo esc_url( ( $is_admin_email ) ? wcs_get_edit_post_link( $subscription->get_id() ) : $subscription->get_view_order_url() ); ?>"><?php echo sprintf( esc_html_x( '#%s', 'subscription number in email table. (eg: #106)', 'woocommerce-subscriptions' ), esc_html( $subscription->get_order_number() ) ); ?></a></td>
 			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'start_date', 'site' ) ) ); ?></td>
 			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions' ) ); ?></td>
@@ -41,7 +41,7 @@ do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscrip
 				<?php echo wp_kses_post( $subscription->get_formatted_order_total() ); ?>
 				<?php if ( $is_parent_order && $subscription->get_time( 'next_payment' ) > 0 ) : ?>
 					<br>
-					<?php // translators: placeholder is the next payment date. ?>
+					<?php // Translators: placeholder is the next payment date. ?>
 					<small><?php printf( esc_html__( 'Next payment: %s', 'woocommerce-subscriptions' ), esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'next_payment', 'site' ) ) ) ); ?></small>
 				<?php endif; ?>
 			</td>

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -2,7 +2,6 @@
 /**
  * Subscription information template
  *
- * @author  Brent Shepherd / Chuck Mac
  * @package WooCommerce_Subscriptions/Templates/Emails
  * @version 7.2.0
  */

--- a/templates/emails/subscription-info.php
+++ b/templates/emails/subscription-info.php
@@ -15,8 +15,6 @@ if ( empty( $subscriptions ) ) {
 
 $has_automatic_renewal = false;
 $is_parent_order       = wcs_order_contains_subscription( $order, 'parent' );
-
-do_action( 'woocommerce_subscriptions_email_before_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );
 ?>
 <div style="margin-bottom: 40px;">
 <h2><?php esc_html_e( 'Subscription information', 'woocommerce-subscriptions' ); ?></h2>
@@ -77,6 +75,3 @@ if ( $has_automatic_renewal && ! $is_admin_email && $subscription->get_time( 'ne
 }
 ?>
 </div>
-<?php
-
-do_action( 'woocommerce_subscriptions_email_after_subscription_info', $subscriptions, $order, $has_automatic_renewal, $is_parent_order, $is_admin_email, $plain_text, $skip_my_account_link );


### PR DESCRIPTION
Fixes #752

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

We received the following feedback related to ur new [Subscriptions notification feature](https://woocommerce.com/document/subscriptions/subscriptions-notifications/) we released in 6.9.0: 
> the information on the "Subscription information" email template might not be enough for the customer to understand why is he getting this email.

> there's absolutely no information about the subscription items. Yes, they can click the subscription ID, log in, and see its details, but we have a serious risk here that the customer just ignores this email, as they see no identifiable information

The author opened a PR (https://github.com/Automattic/woocommerce-subscriptions-core/pull/753) to address these issues, however, while I was reviewing the PR, there were a few things I wanted to change so I figured it was easier to open a new PR instead of working from their fork.

Key changes in this PR:
- 0e10ca601537b9573efb2e99e9034bf59324f523 - Adds the subscription item table to all of our customer notification emails.
- 9f2f7fbfe2158a9f0a665c805f6478176bb437e3 - Adds new hooks at the start and end of the `subscription-info.php` template for further customisations
- 9aa0ad6d219d9c08eb49f0342c1b7792295a923a - Removes the "Here are the details" paragraphs as it felt unnecessary.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/202a1088-fda1-483b-ab50-2e0ad1e27bf2) | ![image](https://github.com/user-attachments/assets/6e82c4ca-871b-49ae-8843-bdfdfa6442b1) | 

> [!NOTE]
> When I started looking more closely at this issue, I noticed there are a lot of inconsistencies across many of our subscription emails. For example:
> - our Cancelled email doesn't have the `"Subscriptions #123` header between the two tables, but our Expired and Suspended emails do (see images below)
> - these emails show a different subscription info table where the recurring price is the second column, vs our customer notification emails have it in the 4th column
>
> 🙈 I had to stop myself from turning PR this into a massive refactor... I do think we should tackle this at some stage, but maybe it can wait for the Woo core email improvements that are also in the pipeline.

| Cancelled email | Expired email |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0536ff5e-9e4d-4a66-8b1b-a243a89d57a8) | ![image](https://github.com/user-attachments/assets/cfda40f6-e19b-424f-b022-a0296973d83b) | 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With WooCommerce 9.6 installed, you are to preview emails within **WooCommerce > Settings > Emails** which makes testing this feature a little easier. That said, it uses dummy data and doesn't use the plain text templates properly, therefore testing this PR requires:
1. Installing and activate the [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/) plugin for ease with testing emails locally.
2. Adding `define( 'WP_ENVIRONMENT_TYPE', 'production' );` to your `wp-config.php` file. This is needed because notification emails are not sent on development/test sites.

### 1. Testing email template changes

1. Go to **WooCommerce > Settings > Subscriptions** and enable the "Customer Notification" feature (set any reminder time)
2. Go to **WooCommerce > Settings > Emails**
3. Enable the "Customer Notification: Automatic renewal notice" email and make sure it's set to HTML format.
4. Enable the "Customer Notification: Manual renewal notice" email and set this one to **plain text** format
![image](https://github.com/user-attachments/assets/b8f78149-c1df-4ff5-b211-138ee2e1bea7)
5. Visit the WP Admin Edit subscription page for a subscription purchased with Stripe (or any other automatic payment method).
6. From the subscription actions, run the "Send upcoming renewal notification" action.
![image](https://github.com/user-attachments/assets/2c4b56fb-abb5-4d3b-927f-10ab0a5b3e52)
8. View the email and confirm you see an email with both the subscription info table and subscription items table:
![image](https://github.com/user-attachments/assets/259ec9a1-08be-4ace-99fa-a7b91e507806)
9. Go back to Admin Edit Subscription and switch the subscription from Stripe to manual renewal:
![image](https://github.com/user-attachments/assets/85d99750-71cb-4fb7-b969-d671c9cc2d36)
10. Now that subscription is manual, run the "Send upcoming renewal notification" action again.
11. Because we set this to a plain text email, confirm the new subscription item table is correct in plain text 🙈👍 
![image](https://github.com/user-attachments/assets/fec90f36-3625-42e8-bc00-25e731b25414)

--

### 2. Testing the new hooks

This PR introduces new `woocommerce_subscriptions_email_before_subscription_info` and `woocommerce_subscriptions_email_after_subscription_info` hooks, as well as adds the subscriptions item table which is attached to the `woocommerce_subscriptions_email_order_details` hook.

For testing customisation options, you can use the following snippet:

```php
add_action( 'woocommerce_before_template_part', function( $template_name, $template_path, $located, $args ) {
	if ( in_array( $template_name, [ 'emails/subscription-info.php', 'emails/plain/subscription-info.php' ], true ) ) {
		echo '<p style="color:red;"><strong>[[ TESTING ]] Before subscription info template</strong></p>';
	}
}, 10, 4 );

add_action( 'woocommerce_after_template_part', function( $template_name, $template_path, $located, $args ) {
	if ( in_array( $template_name, [ 'emails/subscription-info.php', 'emails/plain/subscription-info.php' ], true ) ) {
		echo '<p style="color:red;"><strong>[[ TESTING ]] After subscription info template</strong></p>';
	}
}, 10, 4 );

add_action( 'woocommerce_subscriptions_email_order_details', function() {
	echo '<p style="color:red;"><strong>[[ TESTING ]] After subscription item table</strong></p>';
}, 20, 0 );
```

Rather than going through and running the WP Admin actions, I used the email preview to confirm this is working as intended.

1. Add the above snippet to your store.
2. Go to **WooCommerce > Settings > Emails** and scroll to the bottom of the page.
3. Using the dropdown, preview a Customer Notification email and confirm your customisations are there:
![image](https://github.com/user-attachments/assets/191b29ef-7cc2-4abf-8d87-4d73d1e5015e)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)

> [!IMPORTANT]
> Once we ship these changes, we'll need to update [our documentation](https://woocommerce.com/document/subscriptions/subscriptions-notifications/) to include the latest images.
