### PR TITLE
Fix blocks checkout local pickup

### DIFF
--- a/woocommerce-subscriptions-core.php
+++ b/woocommerce-subscriptions-core.php
@@ -8,3 +8,18 @@
  * Requires WP: 5.6
  * Version: 7.9.0
  */
+
+// Tell WooCommerce Blocks that all shipping methods
+// do not support local pickup because it originally does not
+// support mixing pickup and shipping methods.
+function disable_local_pickup_shipping_methods() {
+  add_filter('woocommerce_shipping_method_supports', function ( $supports, $feature ) {
+    if ( $feature === 'local-pickup' && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+      return false;
+    }
+
+    return $supports;
+  }, 3, 10);
+}
+
+add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before', 'disable_local_pickup_shipping_methods' );


### PR DESCRIPTION
Fixes #399

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
Alongside https://github.com/woocommerce/woocommerce/pull/54946 this PR fixes #399 issue by disabling the "supports local pickup" flag on the blocks checkout page shipping rates when there's a subscription on the cart.

This still allows the local pickup methods to be selected but changes the blocks checkout page to show all shipping methods on a single page.

| Before | After |
|-|-|
| <img width="763" alt="Screenshot 2025-01-28 at 7 30 26 PM" src="https://github.com/user-attachments/assets/89bb5f39-7fe3-43d5-894f-e1da617e13f5" /> | <img width="763" alt="Screenshot 2025-01-28 at 7 59 53 PM" src="https://github.com/user-attachments/assets/15f9f802-ae14-4469-8d87-a921ca23e864" /> |
|  <img width="483" alt="Screenshot 2025-01-28 at 7 28 53 PM" src="https://github.com/user-attachments/assets/963c67e0-0b23-44e8-96fe-f81198a41b27" /> | |

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load woocommerce/woocommerce#54946 changes on your WooCommerce installation.
* On WooCommerce direction run:

```
pnpm install
cd plugins/woocommerce
pnpm watch:build
```

* Follow https://github.com/woocommerce/woocommerce/pull/54946 testing instructions.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
