### PR TITLE
Customer Notification fixes and slight improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
 * Fix - After enabling the Customer Notification feature or changing the reminder timer setting, ensure notification emails are scheduled for subscriptions with pending cancellation status.
 * Update - Include subscription items table in all customer notification emails.
-* Update - Adding Subscription notes when a customer notification email is not sent now requires WCS_DEBUG to be enabled.
+* Update - Subscription notes for unsent customer notification emails now only occurs if WCS_DEBUG is enabled.
 * Dev - Introduces a new `woocommerce_subscription_valid_customer_notification_types` filter to modify which notification types are scheduled in Action Scheduler.
 
 = 7.9.0 - 2025-01-10 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,10 @@
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
 * Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
+* Fix - After enabling the Customer Notification feature or changing the reminder timer setting, ensure notification emails are scheduled for subscriptions with pending cancellation status.
 * Update - Include subscription items table in all customer notification emails.
+* Update - Adding Subscription notes when a customer notification email is not sent now requires WCS_DEBUG to be enabled.
+* Dev - Introduces a new `woocommerce_subscription_valid_customer_notification_types` filter to modify which notification types are scheduled in Action Scheduler.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -178,7 +178,7 @@ class WC_Subscriptions_Email_Notifications {
 				break;
 		}
 
-		if ( $notification ) {
+		if ( $notification && $notification->is_enabled() ) {
 			$notification->trigger( $subscription_id );
 		}
 	}

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -497,7 +497,24 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 			}
 		}
 
-		return $notifications;
+		/**
+		 * 'woocommerce_subscription_valid_customer_notification_types' filter.
+		 *
+		 * Allows filtering the list of notification types that will be scheduled for a particular subscription.
+		 *
+		 * Default array format returned:
+		 * Array(
+		 *   'next_payment', // exists if the subscription contains a next payment date in the future.
+		 *   'trial_end',    // exists if the subscription contains a trial end date in the future.
+		 *   'end'           // exists if the subscription contains an end date in the future.
+		 * )
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param array           $notifications Array of valid notification types.
+		 * @param WC_Subscription $subscription  Subscription object.
+		 */
+		return apply_filters( 'woocommerce_subscription_valid_customer_notification_types', $notifications, $subscription );
 	}
 
 	/**

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -515,7 +515,7 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		 * @param array           $notifications Array of valid notification types.
 		 * @param WC_Subscription $subscription  Subscription object.
 		 */
-		return apply_filters( 'woocommerce_subscription_valid_customer_notification_types', $notifications, $subscription );
+		return (array) apply_filters( 'woocommerce_subscription_valid_customer_notification_types', $notifications, $subscription );
 	}
 
 	/**

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -498,15 +498,16 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		}
 
 		/**
-		 * 'woocommerce_subscription_valid_customer_notification_types' filter.
+		 * Filter: `woocommerce_subscription_valid_customer_notification_types`.
 		 *
 		 * Allows filtering the list of notification types that will be scheduled for a particular subscription.
 		 *
 		 * Default array format returned:
-		 * Array(
-		 *   'next_payment', // exists if the subscription contains a next payment date in the future.
-		 *   'trial_end',    // exists if the subscription contains a trial end date in the future.
-		 *   'end'           // exists if the subscription contains an end date in the future.
+		 *
+		 * array(
+		 *     'next_payment', // Exists if the subscription contains a next payment date in the future.
+		 *     'trial_end',    // Exists if the subscription contains a trial end date in the future.
+		 *     'end'           // Exists if the subscription contains an end date in the future.
 		 * )
 		 *
 		 * @since 7.2.0

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -49,6 +49,7 @@ class WCS_Notifications_Batch_Processor implements WCS_Batch_Processor {
 			'active',
 			'pending',
 			'on-hold',
+			'pending-cancel',
 		);
 
 		return array_map( 'wcs_sanitize_subscription_status_key', $allowed_statuses );

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -289,7 +289,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	}
 
 	/**
-	 * If WCS_DEBUG is enabled, attaches a note to the subscription to detail why a reminder email was not sent.
+	 * If WCS_DEBUG or WP_DEBUG is enabled, attach a note to the subscription to detail why a reminder email was not sent.
 	 *
 	 * @param WC_Subscription $subscription
 	 * @param array|string    $reasons
@@ -297,7 +297,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	 * @return false
 	 */
 	private function log_reminder_email_not_sent( $subscription, $reasons ) {
-		if ( defined( 'WCS_DEBUG' ) && WCS_DEBUG ) {
+		if ( ( defined( 'WCS_DEBUG' ) && WCS_DEBUG ) || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
 			$reasons = (array) $reasons;
 
 			// translators: %1$s: email title, %2$s: list of reasons why email was skipped.

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -274,7 +274,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 		$skipped_reasons = [];
 
 		if ( ! WC_Subscriptions_Email_Notifications::should_send_notification() ) {
-			$skipped_reasons[] = __( 'Not a production site', 'woocommerce-subscriptions' );
+			$skipped_reasons[] = __( 'Not a production site, or notifications have been globally disabled', 'woocommerce-subscriptions' );
 		}
 
 		if ( ! $this->get_recipient() ) {

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -254,7 +254,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	}
 
 	/**
-	 * Determine whether the customer reminder email should be sent and add an order note if it shouldn't.
+	 * Determines whether the customer reminder email should be sent.
 	 *
 	 * Reminder emails are not sent if:
 	 * - The Customer Notification feature is disabled.
@@ -267,30 +267,43 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	 * @return bool
 	 */
 	public function should_send_reminder_email( $subscription ) {
-		$should_skip = [];
-
 		if ( ! $this->is_enabled() ) {
-			$should_skip[] = __( 'Reminder emails disabled.', 'woocommerce-subscriptions' );
-		} else {
-			if ( ! WC_Subscriptions_Email_Notifications::should_send_notification() ) {
-				$should_skip[] = __( 'Not a production site', 'woocommerce-subscriptions' );
-			}
-
-			if ( ! $this->get_recipient() ) {
-				$should_skip[] = __( 'Recipient not found', 'woocommerce-subscriptions' );
-			}
-
-			if ( WCS_Action_Scheduler_Customer_Notifications::is_subscription_period_too_short( $subscription ) ) {
-				$should_skip[] = __( 'Subscription billing cycle too short', 'woocommerce-subscriptions' );
-			}
+			return $this->log_reminder_email_not_sent( $subscription, __( 'Reminder emails disabled.', 'woocommerce-subscriptions' ) );
 		}
 
-		if ( ! empty( $should_skip ) ) {
+		$skipped_reasons = [];
+
+		if ( ! WC_Subscriptions_Email_Notifications::should_send_notification() ) {
+			$skipped_reasons[] = __( 'Not a production site', 'woocommerce-subscriptions' );
+		}
+
+		if ( ! $this->get_recipient() ) {
+			$skipped_reasons[] = __( 'Recipient not found', 'woocommerce-subscriptions' );
+		}
+
+		if ( WCS_Action_Scheduler_Customer_Notifications::is_subscription_period_too_short( $subscription ) ) {
+			$skipped_reasons[] = __( 'Subscription billing cycle too short', 'woocommerce-subscriptions' );
+		}
+
+		return empty( $skipped_reasons ) || $this->log_reminder_email_not_sent( $subscription, $skipped_reasons );
+	}
+
+	/**
+	 * If WCS_DEBUG is enabled, attaches a note to the subscription to detail why a reminder email was not sent.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param array|string    $reasons
+	 *
+	 * @return false
+	 */
+	private function log_reminder_email_not_sent( $subscription, $reasons ) {
+		if ( defined( 'WCS_DEBUG' ) && WCS_DEBUG ) {
+			$reasons = (array) $reasons;
+
 			// translators: %1$s: email title, %2$s: list of reasons why email was skipped.
-			$subscription->add_order_note( sprintf( __( 'Skipped sending "%1$s": %2$s', 'woocommerce-subscriptions' ), $this->title, '<br>- ' . implode( '<br>- ', $should_skip ) ) );
-			return false;
+			$subscription->add_order_note( sprintf( __( 'Skipped sending "%1$s": %2$s', 'woocommerce-subscriptions' ), $this->title, '<br>- ' . implode( '<br>- ', $reasons ) ) );
 		}
 
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
Fixes #764 

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

Customer Notifications is a relatively new feature and while there hasn't been any critical bugs reported so far, one of our users has shared some concerns and warranted feedback (see #764) which I'm addressing in this PR.

### Bug Fixes

- c013987b5f86269125b9391136bb8830bc27f134 - **Our batch processor wasn't scheduling notifications for subscriptions that have `pending-cancel` status.**
  - There are two ways we schedule these notification events in Action Scheduler:
     1. **Batch Processor** - When a merchant first enables the Customer Notification feature, or updates the Reminder Timing settings, we use a batch processor unschedule and reschedule new actions using these settings.
     2. **Individual Subscription Update** - When a subscriptions date or status is updated, we also ensure all the notifications are properly scheduled in Action Scheduler.

> [!NOTE]
> This bug only exists within our batch processor code. Our code which scheduled these actions when a single subscription is saved is working correctly for pending cancelled subscriptions.

---

### Improvements/Changes

- 2a3565f933e7b4bda35d047ec2119b9bf3fee50a - Prevent calling `WCS_Email_Customer_Notification_{X}->trigger()` when the store has disabled the email.
  - If a merchant has enabled the Customer Notification feature in **WooCommerce > Settings > Subscriptions**, but has disabled the Trial End Notification email, we shouldn't be invoking the Email->trigger() function.
- 5b67c9fd72301e0569f896522fe72ff2dd8e3860 - Moves adding subscription notes to only when WCS_Debug is turned on.
  - Previously, if the Customer Notification settings were enabled but the notification email wasn't sent, we'd always add a note on the subscription to explain why. In the majority of cases, these notes would only create confusion to merchants who might be thinking they need to take action on this.
  - The reasons notification emails don't get sent are:
    1. Email is disabled
    2. Recipient not found
    3. Site is in development mode
    4. The reminder timer set (i.e. 1 week before subscription event) is greater than the actual Subscription's next payment or trial end etc.
  - Reasons 1, 3 & 4 are mostly unhelpful to merchants/store managers and as for 2, we don't have precedence for adding order notes if the recipient is not found and so I don't have a good enough reason why we should do it for these type of emails.

> [!NOTE]
> I've kept the subscription notes idea there for debugging purposes, but have made it so they require WCS_DEBUG to be enabled now.

- 2617772e9fec1546c4a697433724241990fd86f4 - Allow filtering the list of notifications that get scheduled in Action Scheduler
  - After enabling the Customer Notifications feature, by default, we will schedule the following scheduled actions:
    1. Next Payment notification - if the subscription has a next payment in the future
    2. Trial End notification - if the subscription has a trial end date in the future
    3. End/Expiration notification - if the subscription has an end date in the future (i.e. subscription has a defined billing length or the subscription has been canceled)
  - Some merchants may only be using this feature for the Next Payment notification and don't want scheduled actions created for the expiration notification. This filter allows them to remove it.

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Testing batch processor bug is fixed

1. Start on `trunk` branch
2. Go to **WooCommerce > Settings > Subscriptions** and disable the Customer Notifications feature.
3. Via Admin Edit Subscription page of My Account > View Subscription, mark a subscription as pending cancelled and make sure it has an end date that's at least 5 days in the future. While you're here, copy the subscription ID.
7. Go back to **WooCommerce > Settings > Subscriptions** and turn on the Customer Notification feature.
8. Visit **Tools > Scheduled Actions** and search for the pending cancelled subscription ID.
9. Notice that there's no pending `woocommerce_scheduled_subscription_customer_notification_expiration` action scheduled.
10. Switch to this branch and repeat the above steps, however this time, there should be a pending `woocommerce_scheduled_subscription_customer_notification_expiration` scheduled action.

> [!WARNING]
> If action scheduler isn't running by itself, you may need to manually kick-off the batch processor by running the following scheduled actions: `wcs_schedule_pending_batch_processes` & `wcs_run_batch_process`

### Testing small tweaks/improvements

1. Have the following custom code running on your store:
```php
add_filter( 'woocommerce_subscription_valid_customer_notification_types', function( $notification_types ) {
	return array_diff( $notification_types, [ 'end' ] );
}, 10, 1 );


// Place these in your wp-config.php
define( 'WCS_DEBUG', true );
define( 'WP_ENVIRONMENT_TYPE', 'development' );
```
2. Go to any Admin Edit Subscription page for an active subscription on your store and modify the dates by setting any valid next payment date, trial end date and end date. Make a note of the subscription ID being used for testing.
   - Update the status/dates ^ should trigger the customer notification actions for this subscription to be rescheduled in AS.
![image](https://github.com/user-attachments/assets/2c6fc59e-a768-460a-9361-f79df3677bf6)
4. Go to **WooCommerce > Settings > Emails** and make sure the "Customer Notification: Free trial expiration: automatic payment notice" email is disabled.
5. Go to **Tools > Scheduled Actions** and search for the subscription ID.
6. Confirm there's only the trial expiration notification (there shouldn't be an end date notification since we're using the filter to remove it. Also note there's no renewal notification as this subscription has a valid trial date in the future)
7. Manually run the `woocommerce_scheduled_subscription_customer_notification_trial_expiration` scheduled action and confirm this email wasn't sent.
8. Go to the Edit Subscription and confirm there's no notes saying it was skipped.
9. While on the Edit Subscription page, delete the trial end date on the subscription and save.
10. Go back Action Scheduler and now run the `woocommerce_scheduled_subscription_customer_notification_renewal` scheduled action for this subscription.
11. Because `WCS_DEBUG` is enabled and `WP_ENVIRONMENT_TYPE` is set to a development site, you should see a note on the subscription explaining that the email was not sent.
![image](https://github.com/user-attachments/assets/09fe765a-730b-41b5-9c48-6bc6ef0747a5)
13. Toggle `WCS_DEBUG` off and update the next payment date (+1 day or minute) and then re-run the `woocommerce_scheduled_subscription_customer_notification_renewal` scheduled action again and confirm no order notes were displayed and confirm no email was sent.
14. Now set `WP_ENVIRONMENT_TYPE` to `'production'`, update the next payment date again to create the scheduled action, then run the `woocommerce_scheduled_subscription_customer_notification_renewal` scheduled action one last time.
15. Confirm the next payment reminder email was sent.

Sorry for the large amount of testing instructions 😅 There's a lot involved when fully testing these changes. The changes are fairly straight forward though and considering I've tested the latest commits, feel free to focus more on code review :)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
