### PR TITLE
Only fetch subscription object on subscription admin pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
 * Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
+* Fix - Prevent unnecessary subscription object lookups on non-subscription admin pages when global $post is set.
 * Update - Include subscription items table in all customer notification emails.
 
 = 7.9.0 - 2025-01-10 =

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -136,11 +136,6 @@ class WCS_Admin_Meta_Boxes {
 	public function enqueue_styles_scripts() {
 		global $theorder;
 
-		// If $theorder is empty, fallback to using the global post object.
-		if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
-			$theorder = wcs_get_subscription( $GLOBALS['post']->ID );
-		}
-
 		// Get admin screen ID.
 		$screen    = get_current_screen();
 		$screen_id = isset( $screen->id ) ? $screen->id : '';
@@ -148,7 +143,16 @@ class WCS_Admin_Meta_Boxes {
 		// Get the script version.
 		$ver = WC_Subscriptions_Core_Plugin::instance()->get_library_version();
 
-		if ( wcs_get_page_screen_id( 'shop_subscription' ) === $screen_id && wcs_is_subscription( $theorder ) ) {
+		if ( wcs_get_page_screen_id( 'shop_subscription' ) === $screen_id ) {
+			// If $theorder global is empty, fallback to using the global post object.
+			if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) && wcs_is_subscription( $GLOBALS['post']->ID ) ) {
+				$theorder = wcs_get_subscription( $GLOBALS['post']->ID );
+			}
+
+			if ( ! wcs_is_subscription( $theorder ) ) {
+				return;
+			}
+
 			// Declare a subscription variable for clearer use. The $theorder global on edit subscription screens is a subscription.
 			$subscription = $theorder;
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -145,11 +145,13 @@ class WCS_Admin_Meta_Boxes {
 
 		if ( wcs_get_page_screen_id( 'shop_subscription' ) === $screen_id ) {
 			// If $theorder global is empty, fallback to using the global post object.
-			if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) && wcs_is_subscription( $GLOBALS['post']->ID ) ) {
-				$theorder = wcs_get_subscription( $GLOBALS['post']->ID );
-			}
+			if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
+				$subscription = wcs_get_subscription( $GLOBALS['post']->ID );
 
-			if ( ! wcs_is_subscription( $theorder ) ) {
+				if ( $subscription ) {
+					$theorder = $subscription;
+				}
+			} elseif ( ! wcs_is_subscription( $theorder ) ) {
 				return;
 			}
 

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -151,13 +151,10 @@ class WCS_Admin_Meta_Boxes {
 				// If we have a subscription, set it as the global $theorder.
 				if ( $subscription ) {
 					$theorder = $subscription;
-				} else {
-					return;
 				}
+			} else {
+				$subscription = $theorder;
 			}
-
-			// Declare a subscription variable for clearer use. The $theorder global on edit subscription screens is a subscription.
-			$subscription = $theorder;
 
 			if ( ! wcs_is_subscription( $subscription ) ) {
 				return;

--- a/includes/admin/class-wcs-admin-meta-boxes.php
+++ b/includes/admin/class-wcs-admin-meta-boxes.php
@@ -144,19 +144,24 @@ class WCS_Admin_Meta_Boxes {
 		$ver = WC_Subscriptions_Core_Plugin::instance()->get_library_version();
 
 		if ( wcs_get_page_screen_id( 'shop_subscription' ) === $screen_id ) {
-			// If $theorder global is empty, fallback to using the global post object.
+			// If global $theorder is empty, fallback to using the global post object.
 			if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
 				$subscription = wcs_get_subscription( $GLOBALS['post']->ID );
 
+				// If we have a subscription, set it as the global $theorder.
 				if ( $subscription ) {
 					$theorder = $subscription;
+				} else {
+					return;
 				}
-			} elseif ( ! wcs_is_subscription( $theorder ) ) {
-				return;
 			}
 
 			// Declare a subscription variable for clearer use. The $theorder global on edit subscription screens is a subscription.
 			$subscription = $theorder;
+
+			if ( ! wcs_is_subscription( $subscription ) ) {
+				return;
+			}
 
 			wp_register_script( 'jstz', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/jstz.min.js' ), [], $ver, false );
 			wp_register_script( 'momentjs', WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory_url( 'assets/js/admin/moment.min.js' ), [], $ver, false );


### PR DESCRIPTION
Fixes #772 

## Description

This PR makes a slight improvement to performance on non-subscription related admin pages with `$post` globals. eg product, coupon, AW workflow etc. 

Prior to this change, if the `$theorder` global didn't exist but the `$post` global did exist, we would attempt to load a subscription object from that `$post` ID. 

This had 2 effects:

1. Because we are in `$theorder` global scope, we'd be setting the `$theorder` global to the result of `wcs_get_subscription()`.
   - On non-subscription pages this would result in overriding the `null` value and setting it to `false` which is fairly harmless, however not ideal.
2. Making unnecessary database calls to fetch the post type. 

This PR updates this section of the code to make sure we only attempt to set the `$theorder` value where necessary. ie when we're on the subscription page. 

## How to test this PR

1. Install Query Monitor
1. On `trunk` edit a coupon in WP Admin
2. View the query monitor and notice the following query:

```sql
SELECT id, type
FROM wp_wc_orders
WHERE id IN ( 71 )
```

3. On this branch there should be no query. 
4. All functionality on the WooCommerce > Subscriptions and Edit Subscription screen should be unaffected. 


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
