### PR TITLE
Add function block comments to subscription date calculating functions to clarify intended use and logic

### DIFF
--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1520,6 +1520,7 @@ class WC_Subscription extends WC_Order {
 	 * @see WC_Subscription::calculate_next_payment_date() for more details about how the next payment date is calculated.
 	 *
 	 * @param string $date_type 'trial_end', 'next_payment', 'end_of_prepaid_term' or 'end'.
+	 *
 	 * @return string|int The calculated date in MySQL format (`YYYY-MM-DD HH:MM:SS`), or `0` if undefined.
 	 */
 	public function calculate_date( $date_type ) {
@@ -1565,7 +1566,7 @@ class WC_Subscription extends WC_Order {
 		 *  - 'woocommerce_subscription_calculated_trial_end_date'
 		 *  - 'woocommerce_subscription_calculated_end_of_prepaid_term_date'
 		 *
-		 * @param string|int $date The calculated date in MySQL format (`YYYY-MM-DD HH:MM:SS`), or `0` if undefined.
+		 * @param string|int      $date         The calculated date in MySQL format (`YYYY-MM-DD HH:MM:SS`), or `0` if undefined.
 		 * @param WC_Subscription $subscription The subscription object.
 		 */
 		return apply_filters( 'woocommerce_subscription_calculated_' . $date_type . '_date', $date, $this );

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1596,9 +1596,13 @@ class WC_Subscription extends WC_Order {
 	 *
 	 * Important notes:
 	 * - If the resulting calculated next payment date is less than 2 hours in the future, it will add an additional billing period
-	 *   until it finds a date a least 2 hours in the future.
+	 *   until it finds a date a least 2 hours in the future. This was originally necessary to combat daylight savings issues. ie if
+	 *   we added 1 billing period to the previous date but there has been a subsequent daylight savings change, the next payment date
+	 *   could be on the same day as the previous payment.
 	 * - If the subscription has an end date, and the calculated next payment occurs after it, the function returns 0. ie there are no
 	 *   more payments to be made.
+	 * - Although an inactive subscription does not have a public facing next payment date, this function will still calculate the date
+	 *   so it can be used when determining what the next date would be if the subscription were to be reactivated.
 	 *
 	 * Filters:
 	 * - wcs_calculate_next_payment_from_last_payment (bool) – Controls whether the function

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1514,7 +1514,13 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Calculate a given date for the subscription in GMT/UTC.
 	 *
-	 * @param string $date_type 'trial_end', 'next_payment', 'end_of_prepaid_term' or 'end'
+	 * This function is primarily used when the date needs to be recalculated (e.g., after a renewal or if the date has already passed).
+	 * If you need to retrieve the currently scheduled date, use get_date() or get_time() instead.
+	 *
+	 * @see WC_Subscription::calculate_next_payment_date() for more details about how the next payment date is calculated.
+	 *
+	 * @param string $date_type 'trial_end', 'next_payment', 'end_of_prepaid_term' or 'end'.
+	 * @return string|int The calculated date in MySQL format (`YYYY-MM-DD HH:MM:SS`), or `0` if undefined.
 	 */
 	public function calculate_date( $date_type ) {
 
@@ -1550,19 +1556,57 @@ class WC_Subscription extends WC_Order {
 				break;
 		}
 
+		/**
+		 * Filter the calculated date for a subscription.
+		 *
+		 * The filter hook is dynamic. 'woocommerce_subscription_calculated_{date_type}_date' where {date_type} is the date type passed to the function.
+		 * For example:
+		 *  - 'woocommerce_subscription_calculated_next_payment_date'
+		 *  - 'woocommerce_subscription_calculated_trial_end_date'
+		 *  - 'woocommerce_subscription_calculated_end_of_prepaid_term_date'
+		 *
+		 * @param string|int $date The calculated date in MySQL format (`YYYY-MM-DD HH:MM:SS`), or `0` if undefined.
+		 * @param WC_Subscription $subscription The subscription object.
+		 */
 		return apply_filters( 'woocommerce_subscription_calculated_' . $date_type . '_date', $date, $this );
 	}
 
 	/**
 	 * Calculates the next payment date for a subscription.
 	 *
-	 * Although an inactive subscription does not have a next payment date, this function will still calculate the date
-	 * so that it can be used to determine the date the next payment should be charged for inactive subscriptions.
+	 * This function calculates the next valid renewal date. This could be the currently scheduled next payment date if it's still valid or
+	 * it could be a newly calculated date based on specific conditions. It is primarily used when the next payment date needs to be
+	 * recalculated (e.g., after a renewal or if the next payment date has already passed).
 	 *
-	 * @return int | string Zero if the subscription has no next payment date, or a MySQL formatted date time if there is a next payment date
+	 * How it calculates the next payment date:
+	 * - If the subscription has a trial period, and the trial is still active, the next
+	 *   payment returned is the scheduled trial end date.
+	 * - Otherwise, the function selects a base date and adds {interval} {period} to it. The base date is chosen in this order:
+	 *   1. Current next payment date – Used if the subscription has a trial period and there's no first renewal payment yet or it is synced
+	 *      to a fixed billing day.
+	 *   2. Last payment date – This is the most common case. The last order payment date is used to ensure the customer is given a full
+	 *      billing term after they successfully paid the last order. This is important in cases where the last order payment failed and
+	 *      was paid sometime later.
+	 *        - This can be bypassed using the 'wcs_calculate_next_payment_from_last_payment' filter.
+	 *        - @see https://github.com/woocommerce/woocommerce-subscriptions-preserve-billing-schedule
+	 *   3. Next payment date – Used when the filter above is used and the subscription has a valid next payment date. This preserves the
+	 *      subscriptions current billing date. eg if the subscription's payment date occurs on the 10th of every month, it will continue
+	 *      even if the last payment was received late.
+	 *   4. Subscription start date – Used as a last resort if no valid payment dates exist.
+	 *
+	 * Important notes:
+	 * - If the resulting calculated next payment date is less than 2 hours in the future, it will add an additional billing period
+	 *   until it finds a date a least 2 hours in the future.
+	 * - If the subscription has an end date, and the calculated next payment occurs after it, the function returns 0. ie there are no
+	 *   more payments to be made.
+	 *
+	 * Filters:
+	 * - wcs_calculate_next_payment_from_last_payment (bool) – Controls whether the function
+	 *   should use the last payment date as the base for calculation. Default is true.
+	 *
+	 * @return int|string Zero if the subscription has no next payment date, or a MySQL formatted date (YYYY-MM-DD HH:MM:SS) if there is a next payment date.
 	 */
 	protected function calculate_next_payment_date() {
-
 		$next_payment_date = 0;
 
 		// If the subscription is not active, there is no next payment date


### PR DESCRIPTION
Fixes #211 

## Description

This PR adds function block comments to the **`WC_Subscription::calculate_date()`** and **`WC_Subscrtipion::calculate_next_payment_date()`** functions. 

**Background**
It was raised with us in [pdjTHR-1B1-p2](https://wp.me/pdjTHR-1B1) that there can be some confusion around the use of `calculate_date()`. In this specific case, the `$subscription->calculate_date()` function was being used, in part, to determine what the **current** next payment date is. This is because while the current date is valid, it will return the current date.

However, there are a couple of gotchas using it in that way. For example, if the current next payment date would occur in the next 2 hours, the result will be the next date, not the current one. This is because this function is designed to calculate a new date and to avoid calculating a new next payment date within 2 hours. This was originally necessary to combat daylight savings issues. 

In any case, this PR just adds detailed documented to both the **`WC_Subscription::calculate_date()`** and **`WC_Subscrtipion::calculate_next_payment_date()`** functions to clarify their intended use and how the extensive logic in `calculate_next_payment_date()` works. 

## How to test this PR

There is no change to logic included in this PR. Reviewing and confirming the changes should be enough. 

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
