### PR TITLE
SSR performance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
 * Fix - After enabling the Customer Notification feature or changing the reminder timer setting, ensure notification emails are scheduled for subscriptions with pending cancellation status.
 * Update - Include subscription items table in all customer notification emails.
-* Update - Adding Subscription notes when a customer notification email is not sent now requires WCS_DEBUG to be enabled.
+* Update - Subscription notes for unsent customer notification emails now only occurs if WCS_DEBUG is enabled.
 * Dev - Introduces a new `woocommerce_subscription_valid_customer_notification_types` filter to modify which notification types are scheduled in Action Scheduler.
 
 = 7.9.0 - 2025-01-10 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,10 @@
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Fix - Improve our admin notice handling to ensure notices are displayed to the intended admin user.
 * Fix - Improve protections around the pending renewal order-creation process, to prevent uncaught exceptions and other errors from breaking the subscription editor.
+* Fix - After enabling the Customer Notification feature or changing the reminder timer setting, ensure notification emails are scheduled for subscriptions with pending cancellation status.
 * Update - Include subscription items table in all customer notification emails.
+* Update - Adding Subscription notes when a customer notification email is not sent now requires WCS_DEBUG to be enabled.
+* Dev - Introduces a new `woocommerce_subscription_valid_customer_notification_types` filter to modify which notification types are scheduled in Action Scheduler.
 
 = 7.9.0 - 2025-01-10 =
 * Add - Compatibility with WooCommerce's new preview email feature introduced in 9.6.

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -17,6 +17,13 @@ class WCS_Admin_System_Status {
 	const WCS_PRODUCT_ID = 27147;
 
 	/**
+	 * Contains pre-determined SSR report data.
+	 *
+	 * @var array
+	 */
+	private static $report_data = [];
+
+	/**
 	 * Attach callbacks
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
@@ -28,9 +35,21 @@ class WCS_Admin_System_Status {
 	/**
 	 * Renders the Subscription information in the WC status page
 	 *
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
+	 * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.3.0
+	 * @since 7.2.0 Uses supplied report data if available.
+	 *
+	 * @param mixed $report Pre-determined SSR report data.
 	 */
-	public static function render_system_status_items() {
+	public static function render_system_status_items( $report = null ) {
+		/**
+		 * From WooCommerce 9.8.0, we will be supplied with SSR data fetched via a (programmatic)
+		 * REST API request. Using this when available can help prevent duplicated work.
+		 *
+		 * @see WC_REST_Subscription_System_Status_Manager::add_subscription_fields_to_response()
+		 */
+		if ( is_array( $report ) && is_array( $report['subscriptions'] ) && ! empty( $report['subscriptions'] ) ) {
+			self::$report_data = $report['subscriptions'];
+		}
 
 		$store_data                            = [];
 		$subscriptions_data                    = [];
@@ -118,10 +137,15 @@ class WCS_Admin_System_Status {
 	 * @param array $debug_data
 	 */
 	private static function set_live_site_url( &$debug_data ) {
+		// Use pre-determined SSR data if possible.
+		$site_url = isset( self::$report_data['live_url'] )
+			? self::$report_data['live_url']
+			: WCS_Staging::get_site_url_from_source( 'subscriptions_install' );
+
 		$debug_data['wcs_live_site_url'] = array(
 			'name'      => _x( 'Subscriptions Live URL', 'Live URL, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
 			'label'     => 'Subscriptions Live URL',
-			'note'      => '<a href="' . esc_url( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '">' . esc_html( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '</a>',
+			'note'      => '<a href="' . esc_url( $site_url ) . '">' . esc_html( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '</a>',
 			'mark'      => '',
 			'mark_icon' => '',
 		);
@@ -222,7 +246,6 @@ class WCS_Admin_System_Status {
 	 * Add a breakdown of Subscriptions per status.
 	 */
 	private static function set_subscription_statuses( &$debug_data ) {
-
 		$debug_data['wcs_subscriptions_by_status'] = array(
 			'name'      => _x( 'Subscription Statuses', 'label for the system status page', 'woocommerce-subscriptions' ),
 			'label'     => 'Subscription Statuses',
@@ -281,7 +304,11 @@ class WCS_Admin_System_Status {
 	private static function set_subscriptions_by_payment_gateway( &$debug_data ) {
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		foreach ( self::get_subscriptions_by_gateway() as $payment_method => $status_counts ) {
+		$subscriptions_by_gateway = isset( self::$report_data['subscriptions_by_payment_gateway'] )
+			? self::$report_data['subscriptions_by_payment_gateway']
+			: self::get_subscriptions_by_gateway();
+
+		foreach ( $subscriptions_by_gateway as $payment_method => $status_counts ) {
 			if ( isset( $gateways[ $payment_method ] ) ) {
 				$payment_method_name  = $gateways[ $payment_method ]->method_title;
 				$payment_method_label = $gateways[ $payment_method ]->method_title;
@@ -418,7 +445,10 @@ class WCS_Admin_System_Status {
 	 * @return array
 	 */
 	public static function get_subscription_statuses() {
-		$subscriptions_by_status        = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
+		$subscriptions_by_status = isset( self::$report_data['statuses'] )
+			? self::$report_data['statuses']
+			: WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
+
 		$subscriptions_by_status_output = array();
 
 		foreach ( $subscriptions_by_status as $status => $count ) {

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -178,7 +178,7 @@ class WC_Subscriptions_Email_Notifications {
 				break;
 		}
 
-		if ( $notification ) {
+		if ( $notification && $notification->is_enabled() ) {
 			$notification->trigger( $subscription_id );
 		}
 	}

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -497,7 +497,24 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 			}
 		}
 
-		return $notifications;
+		/**
+		 * 'woocommerce_subscription_valid_customer_notification_types' filter.
+		 *
+		 * Allows filtering the list of notification types that will be scheduled for a particular subscription.
+		 *
+		 * Default array format returned:
+		 * Array(
+		 *   'next_payment', // exists if the subscription contains a next payment date in the future.
+		 *   'trial_end',    // exists if the subscription contains a trial end date in the future.
+		 *   'end'           // exists if the subscription contains an end date in the future.
+		 * )
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param array           $notifications Array of valid notification types.
+		 * @param WC_Subscription $subscription  Subscription object.
+		 */
+		return apply_filters( 'woocommerce_subscription_valid_customer_notification_types', $notifications, $subscription );
 	}
 
 	/**

--- a/includes/class-wcs-action-scheduler-customer-notifications.php
+++ b/includes/class-wcs-action-scheduler-customer-notifications.php
@@ -498,15 +498,16 @@ class WCS_Action_Scheduler_Customer_Notifications extends WCS_Scheduler {
 		}
 
 		/**
-		 * 'woocommerce_subscription_valid_customer_notification_types' filter.
+		 * Filter: `woocommerce_subscription_valid_customer_notification_types`.
 		 *
 		 * Allows filtering the list of notification types that will be scheduled for a particular subscription.
 		 *
 		 * Default array format returned:
-		 * Array(
-		 *   'next_payment', // exists if the subscription contains a next payment date in the future.
-		 *   'trial_end',    // exists if the subscription contains a trial end date in the future.
-		 *   'end'           // exists if the subscription contains an end date in the future.
+		 *
+		 * array(
+		 *     'next_payment', // Exists if the subscription contains a next payment date in the future.
+		 *     'trial_end',    // Exists if the subscription contains a trial end date in the future.
+		 *     'end'           // Exists if the subscription contains an end date in the future.
 		 * )
 		 *
 		 * @since 7.2.0

--- a/includes/class-wcs-notifications-batch-processor.php
+++ b/includes/class-wcs-notifications-batch-processor.php
@@ -49,6 +49,7 @@ class WCS_Notifications_Batch_Processor implements WCS_Batch_Processor {
 			'active',
 			'pending',
 			'on-hold',
+			'pending-cancel',
 		);
 
 		return array_map( 'wcs_sanitize_subscription_status_key', $allowed_statuses );

--- a/includes/emails/class-wcs-email-customer-notification.php
+++ b/includes/emails/class-wcs-email-customer-notification.php
@@ -254,7 +254,7 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	}
 
 	/**
-	 * Determine whether the customer reminder email should be sent and add an order note if it shouldn't.
+	 * Determines whether the customer reminder email should be sent.
 	 *
 	 * Reminder emails are not sent if:
 	 * - The Customer Notification feature is disabled.
@@ -267,30 +267,43 @@ class WCS_Email_Customer_Notification extends WC_Email {
 	 * @return bool
 	 */
 	public function should_send_reminder_email( $subscription ) {
-		$should_skip = [];
-
 		if ( ! $this->is_enabled() ) {
-			$should_skip[] = __( 'Reminder emails disabled.', 'woocommerce-subscriptions' );
-		} else {
-			if ( ! WC_Subscriptions_Email_Notifications::should_send_notification() ) {
-				$should_skip[] = __( 'Not a production site', 'woocommerce-subscriptions' );
-			}
-
-			if ( ! $this->get_recipient() ) {
-				$should_skip[] = __( 'Recipient not found', 'woocommerce-subscriptions' );
-			}
-
-			if ( WCS_Action_Scheduler_Customer_Notifications::is_subscription_period_too_short( $subscription ) ) {
-				$should_skip[] = __( 'Subscription billing cycle too short', 'woocommerce-subscriptions' );
-			}
+			return $this->log_reminder_email_not_sent( $subscription, __( 'Reminder emails disabled.', 'woocommerce-subscriptions' ) );
 		}
 
-		if ( ! empty( $should_skip ) ) {
+		$skipped_reasons = [];
+
+		if ( ! WC_Subscriptions_Email_Notifications::should_send_notification() ) {
+			$skipped_reasons[] = __( 'Not a production site', 'woocommerce-subscriptions' );
+		}
+
+		if ( ! $this->get_recipient() ) {
+			$skipped_reasons[] = __( 'Recipient not found', 'woocommerce-subscriptions' );
+		}
+
+		if ( WCS_Action_Scheduler_Customer_Notifications::is_subscription_period_too_short( $subscription ) ) {
+			$skipped_reasons[] = __( 'Subscription billing cycle too short', 'woocommerce-subscriptions' );
+		}
+
+		return empty( $skipped_reasons ) || $this->log_reminder_email_not_sent( $subscription, $skipped_reasons );
+	}
+
+	/**
+	 * If WCS_DEBUG is enabled, attaches a note to the subscription to detail why a reminder email was not sent.
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param array|string    $reasons
+	 *
+	 * @return false
+	 */
+	private function log_reminder_email_not_sent( $subscription, $reasons ) {
+		if ( defined( 'WCS_DEBUG' ) && WCS_DEBUG ) {
+			$reasons = (array) $reasons;
+
 			// translators: %1$s: email title, %2$s: list of reasons why email was skipped.
-			$subscription->add_order_note( sprintf( __( 'Skipped sending "%1$s": %2$s', 'woocommerce-subscriptions' ), $this->title, '<br>- ' . implode( '<br>- ', $should_skip ) ) );
-			return false;
+			$subscription->add_order_note( sprintf( __( 'Skipped sending "%1$s": %2$s', 'woocommerce-subscriptions' ), $this->title, '<br>- ' . implode( '<br>- ', $reasons ) ) );
 		}
 
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
- WIP/draft
- Relates to https://github.com/woocommerce/woocommerce/pull/55161
- Updates https://github.com/woocommerce/woocommerce-subscriptions/issues/4769
- Still need to consider applying caching to some of the more expensive operations, as a further fallback so that performance continues to be improved, even if Subs is running alongside an older version of WooCommerce (ie, where the changes proposed in [PR #55161](https://github.com/woocommerce/woocommerce/pull/55161) are not available.

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to …
2. Click on …

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
