### PR TITLE
Initial work to improve performance of the SSR integration.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - After enabling the Customer Notification feature or changing the reminder timer setting, ensure notification emails are scheduled for subscriptions with pending cancellation status.
 * Update - Include subscription items table in all customer notification emails.
 * Update - Subscription notes for unsent customer notification emails now only occurs if WCS_DEBUG is enabled.
+* Update - Improved performance of Subscriptions-related aspects of the WooCommerce System Status Report.
 * Dev - Introduces a new `woocommerce_subscription_valid_customer_notification_types` filter to modify which notification types are scheduled in Action Scheduler.
 
 = 7.9.0 - 2025-01-10 =

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -167,7 +167,7 @@ class WCS_Admin_System_Status {
 		$debug_data['wcs_live_site_url'] = array(
 			'name'      => _x( 'Subscriptions Live URL', 'Live URL, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
 			'label'     => 'Subscriptions Live URL',
-			'note'      => '<a href="' . esc_url( $site_url ) . '">' . esc_html( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '</a>',
+			'note'      => '<a href="' . esc_url( $site_url ) . '">' . esc_html( $site_url ) . '</a>',
 			'mark'      => '',
 			'mark_icon' => '',
 		);

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -24,6 +24,19 @@ class WCS_Admin_System_Status {
 	private static $report_data = [];
 
 	/**
+	 * Used to cache the result of the comparatively expensive queries executed by
+	 * the get_subscriptions_by_gateway() method.
+	 *
+	 * This cache is short-lived by design, as we don't necessarily want to cache this
+	 * across requests (in some troubleshooting/debug scenarios, that could be confusing
+	 * for the troubleshooter), which is why a transient or WP caching functions are not
+	 * used.
+	 *
+	 * @var null|array
+	 */
+	private static $statuses_by_gateway = null;
+
+	/**
 	 * Attach callbacks
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
@@ -388,10 +401,17 @@ class WCS_Admin_System_Status {
 	/**
 	 * Gets the store's subscription broken down by payment gateway and status.
 	 *
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v3.1.0
+	 * @since 1.0.0 Migrated from WooCommerce Subscriptions v3.1.0.
+	 * @since 7.2.0 Information is cached per request.
+	 *
 	 * @return array The subscription gateway and status data array( 'gateway_id' => array( 'status' => count ) );
 	 */
 	public static function get_subscriptions_by_gateway() {
+		// Return cached result if possible.
+		if ( isset( self::$statuses_by_gateway ) ) {
+			return self::$statuses_by_gateway;
+		}
+
 		global $wpdb;
 		$subscription_gateway_data = [];
 		$is_hpos_in_use            = wcs_is_custom_order_tables_usage_enabled();
@@ -435,6 +455,7 @@ class WCS_Admin_System_Status {
 			$subscription_gateway_data[ $result['payment_method'] ][ $result[ $order_status_column_name ] ] = $result['count'];
 		}
 
+		self::$statuses_by_gateway = $subscription_gateway_data;
 		return $subscription_gateway_data;
 	}
 

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -37,6 +37,15 @@ class WCS_Admin_System_Status {
 	private static $statuses_by_gateway = null;
 
 	/**
+	 * Used to cache the subscriptions-by-status counts.
+	 *
+	 * As with with self::$statuses_by_gateway, the cache is deliberately short-lived.
+	 *
+	 * @var null|array
+	 */
+	private static $subscription_status_counts = null;
+
+	/**
 	 * Attach callbacks
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
@@ -466,10 +475,9 @@ class WCS_Admin_System_Status {
 	 * @return array
 	 */
 	public static function get_subscription_statuses() {
-		$subscriptions_by_status = isset( self::$report_data['statuses'] )
-			? self::$report_data['statuses']
-			: WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
-
+		// We don't look inside self::$report_data here, because the REST API report itself
+		// also uses self::get_subscription_status_counts().
+		$subscriptions_by_status        = self::get_subscription_status_counts();
 		$subscriptions_by_status_output = array();
 
 		foreach ( $subscriptions_by_status as $status => $count ) {
@@ -479,5 +487,37 @@ class WCS_Admin_System_Status {
 		}
 
 		return $subscriptions_by_status_output;
+	}
+
+	/**
+	 * Returns a cached array of subscription statuses along with the corresponding number
+	 * of subscriptions for each (the values).
+	 *
+	 * Example:
+	 *
+	 *     [
+	 *         'wc-active'    => 100,
+	 *         'wc-cancelled' => 200,
+	 *         '...'          => 300,
+	 *     ]
+	 *
+	 * @param bool $fresh If cached results should be discarded.
+	 *
+	 * @return array
+	 */
+	public static function get_subscription_status_counts( bool $fresh = false ): array {
+		// Return cached result if possible.
+		if ( ! $fresh && isset( self::$subscription_status_counts ) ) {
+			return self::$subscription_status_counts;
+		}
+
+		try {
+			self::$subscription_status_counts = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
+		} catch ( Exception $e ) {
+			// If an exception was raised, don't cache the result.
+			return [];
+		}
+
+		return self::$subscription_status_counts;
 	}
 }

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -17,6 +17,13 @@ class WCS_Admin_System_Status {
 	const WCS_PRODUCT_ID = 27147;
 
 	/**
+	 * Contains pre-determined SSR report data.
+	 *
+	 * @var array
+	 */
+	private static $report_data = [];
+
+	/**
 	 * Attach callbacks
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
@@ -28,9 +35,21 @@ class WCS_Admin_System_Status {
 	/**
 	 * Renders the Subscription information in the WC status page
 	 *
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
+	 * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.3.0
+	 * @since 7.2.0 Uses supplied report data if available.
+	 *
+	 * @param mixed $report Pre-determined SSR report data.
 	 */
-	public static function render_system_status_items() {
+	public static function render_system_status_items( $report = null ) {
+		/**
+		 * From WooCommerce 9.8.0, we will be supplied with SSR data fetched via a (programmatic)
+		 * REST API request. Using this when available can help prevent duplicated work.
+		 *
+		 * @see WC_REST_Subscription_System_Status_Manager::add_subscription_fields_to_response()
+		 */
+		if ( is_array( $report ) && is_array( $report['subscriptions'] ) && ! empty( $report['subscriptions'] ) ) {
+			self::$report_data = $report['subscriptions'];
+		}
 
 		$store_data                            = [];
 		$subscriptions_data                    = [];
@@ -118,10 +137,15 @@ class WCS_Admin_System_Status {
 	 * @param array $debug_data
 	 */
 	private static function set_live_site_url( &$debug_data ) {
+		// Use pre-determined SSR data if possible.
+		$site_url = isset( self::$report_data['live_url'] )
+			? self::$report_data['live_url']
+			: WCS_Staging::get_site_url_from_source( 'subscriptions_install' );
+
 		$debug_data['wcs_live_site_url'] = array(
 			'name'      => _x( 'Subscriptions Live URL', 'Live URL, Label on WooCommerce -> System Status page', 'woocommerce-subscriptions' ),
 			'label'     => 'Subscriptions Live URL',
-			'note'      => '<a href="' . esc_url( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '">' . esc_html( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '</a>',
+			'note'      => '<a href="' . esc_url( $site_url ) . '">' . esc_html( WCS_Staging::get_site_url_from_source( 'subscriptions_install' ) ) . '</a>',
 			'mark'      => '',
 			'mark_icon' => '',
 		);
@@ -202,7 +226,7 @@ class WCS_Admin_System_Status {
 				if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {
 					$outdated                    = true;
 					$overridden_template_output .= sprintf(
-						/* translators: %1$s is the file version, %2$s is the core version */
+					/* translators: %1$s is the file version, %2$s is the core version */
 						esc_html__( 'version %1$s is out of date. The core version is %2$s', 'woocommerce-subscriptions' ),
 						'<strong style="color:red">' . esc_html( $theme_version ) . '</strong>',
 						'<strong>' . esc_html( $core_version ) . '</strong>'
@@ -222,7 +246,6 @@ class WCS_Admin_System_Status {
 	 * Add a breakdown of Subscriptions per status.
 	 */
 	private static function set_subscription_statuses( &$debug_data ) {
-
 		$debug_data['wcs_subscriptions_by_status'] = array(
 			'name'      => _x( 'Subscription Statuses', 'label for the system status page', 'woocommerce-subscriptions' ),
 			'label'     => 'Subscription Statuses',
@@ -281,7 +304,11 @@ class WCS_Admin_System_Status {
 	private static function set_subscriptions_by_payment_gateway( &$debug_data ) {
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		foreach ( self::get_subscriptions_by_gateway() as $payment_method => $status_counts ) {
+		$subscriptions_by_gateway = isset( self::$report_data['subscriptions_by_payment_gateway'] )
+			? self::$report_data['subscriptions_by_payment_gateway']
+			: self::get_subscriptions_by_gateway();
+
+		foreach ( $subscriptions_by_gateway as $payment_method => $status_counts ) {
 			if ( isset( $gateways[ $payment_method ] ) ) {
 				$payment_method_name  = $gateways[ $payment_method ]->method_title;
 				$payment_method_label = $gateways[ $payment_method ]->method_title;
@@ -418,7 +445,10 @@ class WCS_Admin_System_Status {
 	 * @return array
 	 */
 	public static function get_subscription_statuses() {
-		$subscriptions_by_status        = WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
+		$subscriptions_by_status = isset( self::$report_data['statuses'] )
+			? self::$report_data['statuses']
+			: WC_Data_Store::load( 'subscription' )->get_subscriptions_count_by_status();
+
 		$subscriptions_by_status_output = array();
 
 		foreach ( $subscriptions_by_status as $status => $count ) {

--- a/includes/admin/class-wcs-admin-system-status.php
+++ b/includes/admin/class-wcs-admin-system-status.php
@@ -239,7 +239,7 @@ class WCS_Admin_System_Status {
 				if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {
 					$outdated                    = true;
 					$overridden_template_output .= sprintf(
-					/* translators: %1$s is the file version, %2$s is the core version */
+						/* translators: %1$s is the file version, %2$s is the core version */
 						esc_html__( 'version %1$s is out of date. The core version is %2$s', 'woocommerce-subscriptions' ),
 						'<strong style="color:red">' . esc_html( $theme_version ) . '</strong>',
 						'<strong>' . esc_html( $core_version ) . '</strong>'


### PR DESCRIPTION
WooCommerce provides a [System Status Report (SSR)](https://woocommerce.com/document/understanding-the-woocommerce-system-status-report/) which is accessible via both the REST API and the admin environment. WooCommerce Subscriptions integrates with both.

![ssr-subscriptions](https://github.com/user-attachments/assets/5e11a3e0-2bf9-4df0-b85e-8c9441925663)

However, it was [recently highlighted](https://github.com/woocommerce/woocommerce-subscriptions/issues/4769) that the query generated by [WCS_Admin_System_Status::get_subscriptions_by_gateway()](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.9.0/includes/admin/class-wcs-admin-system-status.php#L367-L412) in particular can be relatively slow. The problem is exacerbated by the fact that, currently, this query is executed twice on the same page. But why?

- When the **WooCommerce ‣ Status** page is rendered, it actually generates an internal/programmatic REST API request and fetches information from the endpoint noted above.
- Since WooCommerce Subscriptions integrates with both the REST and the HTML versions of the SSR, it runs the *subscription-statuses-by-gateway* query for both. Which means, for the HTML SSR, it runs the query twice.

Of course, we really only need to execute it *once.* To that end, in this PR, so long as WooCommerce makes the results of the REST API request available (and, as of [9.8](https://github.com/woocommerce/woocommerce/pull/55161), it *should)* then we reuse as much of that as is reasonable. Additionally, in cases where we are running alongside an older version of WooCommerce, we will now cache the results of the query (on a per-request basis).

This should significantly improve performance for merchants who have a very large number of historic subscriptions/orders.

- See also https://github.com/woocommerce/woocommerce/pull/55161
- Closes https://github.com/woocommerce/woocommerce-subscriptions/issues/4769

## How to test this PR

Setup:

- You will need the latest `trunk` code for WooCommerce (it needs to contain [this change](https://github.com/woocommerce/woocommerce/pull/55161)).
- I recommend using [Query Monitor](https://wordpress.org/plugins/query-monitor/) to verify test results.

With those things in place, we can start testing!

1. Start *without* this branch, and visit the **WooCommerce ‣ Status** page. You should see something similar to the screenshot shared earlier (we are focused on the sections relating to Subscriptions).
2. Using Query Monitor, or tool of your choice, it should be possible to see that the *subscription-statuses-by-gateway* query is executed twice (the actual time/cost may not be too bad, though—this really is a function of how many orders you have):

![ssr-duplicate-query](https://github.com/user-attachments/assets/3d0f8618-3e3c-4beb-af4c-f1831c123d6b)

3. Switch to this branch, and verify that the duplicate query disappears.
4. Additionally, you can roll back WooCommerce to an earlier commit (or, a little easier and faster, simply visit [this line](https://github.com/woocommerce/woocommerce/blob/dd4bcf0f14ca89c37645f018426ca8c209da42f7/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php#L1099) and remove the `$report` param from the `do_action()` call) ... this simulates a scenario where we are running alongside a pre-9.8 version of WooCommerce. Repeat the test, and verify there is still no duplication of the relevant query.
5. Last but not least (this can be considered an optional test), you can verify that we are reusing some of the REST API request results by adding a snippet like the following to a mu-plugin (or other suitable location):

```php
add_filter( 'woocommerce_rest_prepare_system_status', function ( $response ) {
	if ( ! isset( $response->data, $response->data['subscriptions'] ) ) {
		return $response;
	}

	$response->data['subscriptions']['statuses'] = [
		'apollo'     => '13',
		'area'       => '51',
		'dalmatians' => '101'
	];

	return $response;
}, 100 );
```

6. The above snippet changes the data we inject into the REST API response. Specifically, it changes the count of subscriptions-by-status. If you refresh the **WooCommerce ‣ Status** page, you should see the corresponding information within the **Subscriptions ‣ Subscription Statuses** list:

<div align="center"><img src="https://github.com/user-attachments/assets/39c9d750-a470-4cc5-ba09-0e79cf734bbd" width="500" /></div>

## Open questions

1. Query caching is very simple/per-request. We *could* however use a transient, or else use the WP cache (and therefore the persistent cache, if available). Do we want to? I'm reluctant because at the time people view the SSR or, if troubleshooting, immediately after refreshing, they should see accurate and up-to-date results. If we do want to do this, what sort of expiration period should we apply?


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? ***yes***
- [x] Will this PR affect WooCommerce Payments? ***no***
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) ***not applicable***
