### PR TITLE
Fixes a fatal error in 8.0.0 caused by passing the incorrect amount of args to `woocommerce_cart_item_name` filter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.0.1 - 2025-xx-xx =
+* Fix: Revert a fix released in 8.0.0 which attempted to display HTML in product names within the cart/checkout shipping package section.
+
 = 8.0.0 - 2025-02-13 =
 * Fix - Recommend WooPayments when there is no available payment gateway.
 * Fix - Safeguards added to the Subscriptions Totals template used in the My Account area, to guard against fatal errors that could arise in unusual conditions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 8.0.1 - 2025-xx-xx =
-* Fix: Revert a fix released in 8.0.0 which attempted to display HTML in product names within the cart/checkout shipping package section.
+* Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.
 
 = 8.0.0 - 2025-02-13 =
 * Fix - Recommend WooPayments when there is no available payment gateway.

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -108,7 +108,7 @@ function wcs_cart_totals_shipping_html() {
 							<?php wcs_cart_print_shipping_input( $recurring_cart_package_key, $shipping_method ); ?>
 							<?php do_action( 'woocommerce_after_shipping_rate', $shipping_method, $recurring_cart_package_key ); ?>
 							<?php if ( ! empty( $show_package_details ) ) : ?>
-								<?php echo '<p class="woocommerce-shipping-contents"><small>' . wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $package_details ) ) . '</small></p>'; ?>
+								<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
 							<?php endif; ?>
 							<?php if ( $recurring_rates_match_initial_rates ) : ?>
 								<?php wcs_cart_print_inherit_shipping_flag( $recurring_cart_package_key ); ?>

--- a/templates/cart/cart-recurring-shipping.php
+++ b/templates/cart/cart-recurring-shipping.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endif; ?>
 
 		<?php if ( $show_package_details ) : ?>
-			<?php echo '<p class="woocommerce-shipping-contents"><small>' . wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $package_details ) ) . '</small></p>'; ?>
+			<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
 		<?php endif; ?>
 	</td>
 </tr>


### PR DESCRIPTION
Reverts: https://github.com/Automattic/woocommerce-subscriptions-core/pull/762

See slack thread for details: p1739441477388209-slack-C07CBV7SKPH