### PR TITLE
Improve performance of searching the subscriptions admin list table when using WP_Post data structures

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.1.0 - 2025-xx-xx =
+* Update - Improved subscription search performance for WP Post stores by removing unnecessary _order_key and _billing_email meta queries.
+
 = 8.0.1 - 2025-02-13 =
 * Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.
 

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -534,12 +534,9 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		global $wpdb;
 
 		$subscription_ids = array();
-
-		$search_fields = array_map( 'wc_clean', apply_filters( 'woocommerce_shop_subscription_search_fields', array(
-			'_order_key',
+		$search_fields    = array_map( 'wc_clean', apply_filters( 'woocommerce_shop_subscription_search_fields', array(
 			'_billing_address_index',
 			'_shipping_address_index',
-			'_billing_email',
 		) ) );
 
 		if ( is_numeric( $term ) ) {

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -534,10 +534,17 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		global $wpdb;
 
 		$subscription_ids = array();
-		$search_fields    = array_map( 'wc_clean', apply_filters( 'woocommerce_shop_subscription_search_fields', array(
-			'_billing_address_index',
-			'_shipping_address_index',
-		) ) );
+
+		$search_fields = array_map(
+			'wc_clean',
+			apply_filters(
+				'woocommerce_shop_subscription_search_fields',
+				[
+					'_billing_address_index',
+					'_shipping_address_index',
+				]
+			)
+		);
 
 		if ( is_numeric( $term ) ) {
 			$subscription_ids[] = absint( $term );


### PR DESCRIPTION
Fixes [#4398](https://github.com/woocommerce/woocommerce-subscriptions/issues/4398)

## Description
This PR optimizes the meta fields used when filtering the subscriptions admin list table in WP Post stores, removing unnecessary searches on:

```diff
-'_order_key'
-'_billing_email'
```
### Why remove these fields?
**Order Key (_order_key)**
- Searching this field produces irrelevant results. For example, searching for "Joe" may return orders with an order key like `wc_order_ZodcjoeHThbOK`, leading to false positives.

**Billing Email (_billing_email)**
- This field is already included in the billing address index, making a direct search redundant.

### Performance Improvement
By removing these fields from the query, there is a substantial performance boost. On a local test site with 111k orders and 20k subscriptions, query execution time was reduced from 6.4 seconds to 0.5 seconds (a 92% reduction).

**Before (6.4s)**
<img width="1232" alt="Before Optimization" src="https://github.com/user-attachments/assets/881e4e0b-08de-4873-9fc8-7faf5a989b8a" />
**After (0.5s)**
<img width="1244" alt="After Optimization" src="https://github.com/user-attachments/assets/f54c16cd-6162-46c1-bfef-c1ddce41b99f" />

<p align="center">
<sup><strong>Note: </strong>You may notice there are 39 fewer results. However that's the <a href="https://github.com/user-attachments/assets/4aad5427-51cb-426b-8507-80dba4513cbc">false positives of "joe" in order keys.</a></sup>

## How to test this PR

1. Ensure your site is using WP Posts (not HPOS).
2. Navigate to **WooCommerce → Subscriptions** in the WordPress admin.
3. Enter a search term in the subscriptions list table search box.
4. Using a tool like Query Monitor, measure:
   - Query execution time.
   - The number of results returned.
5. Checkout this branch and repeat the test.
6. Compare the query times and result count.
7. Verify that no expected results are missing:
  - If a subscription is missing, check whether it was previously matched via `_order_key`.
  
## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
