### PR TITLE
Issue/4795 prevent related order duplicate queries on subscriptions list table

### DIFF
--- a/includes/abstracts/abstract-wcs-related-order-store.php
+++ b/includes/abstracts/abstract-wcs-related-order-store.php
@@ -148,4 +148,22 @@ abstract class WCS_Related_Order_Store {
 			throw new InvalidArgumentException( sprintf( __( 'Invalid relation type: %1$s. Order relationship type must be one of: %2$s.', 'woocommerce-subscriptions' ), $relation_type, implode( ', ', $this->get_relation_types() ) ) );
 		}
 	}
+
+	/**
+	 * Get related order IDs grouped by relation type.
+	 *
+	 * @param WC_Order $subscription  The subscription to find related orders.
+	 * @param array    $relation_type An array of relation types to fetch. Must be an array containing 'renewal', 'switch' or 'resubscribe' unless custom relationships are implemented.
+	 *
+	 * @return array An associative array where keys are relation types and values are arrays of related order IDs.
+	 */
+	public function get_related_order_ids_by_types( WC_Order $subscription, $relation_types ) {
+		$related_orders = [];
+
+		foreach ( $relation_types as $relation_type ) {
+			$related_orders[ $relation_type ] = $this->get_related_order_ids( $subscription, $relation_type );
+		}
+
+		return $related_orders;
+	}
 }

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -684,43 +684,43 @@ class WCS_Admin_Post_Types {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
 	 */
 	public static function get_date_column_content( $subscription, $column ) {
+		$date_type_map  = array( 'last_payment_date' => 'last_order_date_created' );
+		$date_type      = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
+		$date_timestamp = $subscription->get_time( $date_type );
 
-		$date_type_map = array( 'last_payment_date' => 'last_order_date_created' );
-		$date_type     = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
-		$datetime      = wcs_get_datetime_from( $subscription->get_time( $date_type ) );
+		if ( 0 === $date_timestamp ) {
+			return '-';
+		}
 
-		if ( 0 == $subscription->get_time( $date_type, 'gmt' ) ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-			$column_content = '-';
-		} else {
-			$accurate_date    = $datetime->date_i18n( __( 'Y/m/d g:i:s A', 'woocommerce-subscriptions' ) );
-			$fuzzy_human_date = $subscription->get_date_to_display( $date_type );
-			$column_content   = sprintf(
-				'<time class="%s" title="%s">%s</time>',
-				esc_attr( $column ),
-				esc_attr( $accurate_date ),
-				esc_html( $fuzzy_human_date )
-			);
+		$datetime         = wcs_get_datetime_from( $date_timestamp );
+		$accurate_date    = $datetime->date_i18n( __( 'Y/m/d g:i:s A', 'woocommerce-subscriptions' ) );
+		$fuzzy_human_date = $subscription->format_date_to_display( $date_timestamp, $date_type );
+		$column_content   = sprintf(
+			'<time class="%s" title="%s">%s</time>',
+			esc_attr( $column ),
+			esc_attr( $accurate_date ),
+			esc_html( $fuzzy_human_date )
+		);
 
-			// Custom handling for `Next payment` date column.
-			if ( 'next_payment_date' === $column ) {
-				$subscription_is_active = $subscription->has_status( 'active' );
+		// Custom handling for `Next payment` date column.
+		if ( 'next_payment_date' === $column ) {
+			$subscription_is_active = $subscription->has_status( 'active' );
 
-				$tooltip_message = '';
-				$tooltip_classes = 'woocommerce-help-tip';
+			$tooltip_message = '';
+			$tooltip_classes = 'woocommerce-help-tip';
 
-				if ( $subscription_is_active && $datetime->getTimestamp() < time() ) {
-					$tooltip_message .= __( '<b>Subscription payment overdue.</b></br>', 'woocommerce-subscriptions' );
-					$tooltip_classes .= ' wcs-payment-overdue';
-				}
+			if ( $subscription_is_active && $datetime->getTimestamp() < time() ) {
+				$tooltip_message .= __( '<b>Subscription payment overdue.</b></br>', 'woocommerce-subscriptions' );
+				$tooltip_classes .= ' wcs-payment-overdue';
+			}
 
-				if ( $subscription->payment_method_supports( 'gateway_scheduled_payments' ) && ! $subscription->is_manual() && $subscription_is_active ) {
-					$tooltip_message .= __( 'This date should be treated as an estimate only. The payment gateway for this subscription controls when payments are processed.</br>', 'woocommerce-subscriptions' );
-					$tooltip_classes .= ' wcs-offsite-renewal';
-				}
+			if ( $subscription->payment_method_supports( 'gateway_scheduled_payments' ) && ! $subscription->is_manual() && $subscription_is_active ) {
+				$tooltip_message .= __( 'This date should be treated as an estimate only. The payment gateway for this subscription controls when payments are processed.</br>', 'woocommerce-subscriptions' );
+				$tooltip_classes .= ' wcs-offsite-renewal';
+			}
 
-				if ( $tooltip_message ) {
-					$column_content .= '<div class="' . esc_attr( $tooltip_classes ) . '" data-tip="' . esc_attr( $tooltip_message ) . '"></div>';
-				}
+			if ( $tooltip_message ) {
+				$column_content .= '<div class="' . esc_attr( $tooltip_classes ) . '" data-tip="' . esc_attr( $tooltip_message ) . '"></div>';
 			}
 		}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2135,7 +2135,7 @@ class WC_Subscription extends WC_Order {
 		// Get the parent order ID first.
 		if ( in_array( 'parent', $order_types, true ) ) {
 			// Remove the parent order type from the list of order types.
-			$relation_types = array_diff( $order_types, [ 'parent' ] );
+			$order_types = array_diff( $order_types, [ 'parent' ] );
 			$parent_id      = $this->get_parent_id();
 
 			if ( $parent_id ) {
@@ -2143,9 +2143,9 @@ class WC_Subscription extends WC_Order {
 			}
 		}
 
-		if ( ! empty( $relation_types ) ) {
+		if ( ! empty( $order_types ) ) {
 			// Get the related order IDs based on the remaining order types.
-			$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $relation_types );
+			$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $order_types );
 		}
 
 		if ( 'flat' === $return_type && ! empty( $related_order_ids ) ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2147,6 +2147,7 @@ class WC_Subscription extends WC_Order {
 		$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $relation_types );
 
 		if ( 'flat' === $return_type ) {
+			// Flatten the array, remove duplicates and return in the [order_id] => order_id format.
 			$flattened         = array_merge( ...array_values( $related_order_ids ) );
 			$related_order_ids = array_combine( $flattened, $flattened );
 		}

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1307,26 +1307,26 @@ class WC_Subscription extends WC_Order {
 	}
 
 	/**
-	 * Undocumented function
+	 * Formats a subscription date timestamp for display.
 	 *
 	 * @param int    $timestamp The subscription date in a timestamp format.
 	 * @param string $date_type The subscription date type to display. @see WC_Subscription::get_valid_date_types()
 	 *
 	 *  @return string The formatted date to display.
 	 */
-	public function format_date_to_display( $timestamp, $date_type ) {
+	public function format_date_to_display( $timestamp_gmt, $date_type ) {
 
-		if ( $timestamp > 0 ) {
-			$time_diff = $timestamp - current_time( 'timestamp', true );
+		if ( $timestamp_gmt > 0 ) {
+			$time_diff = $timestamp_gmt - current_time( 'timestamp', true );
 
 			if ( $time_diff > 0 && $time_diff < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
+				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
 			} elseif ( $time_diff < 0 && absint( $time_diff ) < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
+				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
 			} else {
-				$date_to_display = date_i18n( wc_date_format(), $timestamp + wc_timezone_offset() );
+				$date_to_display = date_i18n( wc_date_format(), $timestamp_gmt + wc_timezone_offset() );
 			}
 		} else {
 			switch ( $date_type ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2095,10 +2095,11 @@ class WC_Subscription extends WC_Order {
 			$order_types = array( $order_types );
 		}
 
-		$related_orders = array();
-		foreach ( $order_types as $order_type ) {
-			$related_orders_for_order_type = array();
-			foreach ( $this->get_related_order_ids( $order_type ) as $order_id ) {
+		$related_orders = [];
+
+		foreach ( $this->get_related_order_ids( $order_types, 'grouped' ) as $order_type => $order_ids ) {
+			$related_orders_for_order_type = [];
+			foreach ( $order_ids as $order_id ) {
 				if ( 'all' === $return_fields && $order = wc_get_order( $order_id ) ) {
 					$related_orders_for_order_type[ $order_id ] = $order;
 				} elseif ( 'ids' === $return_fields ) {
@@ -2121,21 +2122,33 @@ class WC_Subscription extends WC_Order {
 	 * @return array List of related order IDs.
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
 	 */
-	protected function get_related_order_ids( $order_type = 'any' ) {
+	protected function get_related_order_ids( $order_type = 'any', $return_type = 'flat' ) {
+		$related_order_ids = [];
 
-		$related_order_ids = array();
-
-		if ( in_array( $order_type, array( 'any', 'parent' ) ) && $this->get_parent_id() ) {
-			$related_order_ids[ $this->get_parent_id() ] = $this->get_parent_id();
+		if ( 'any' === $order_type ) {
+			$order_types = array( 'parent', 'renewal', 'resubscribe', 'switch' );
+		} elseif ( is_array( $order_type ) ) {
+			$order_types = $order_type;
+		} else {
+			$order_types = array( $order_type );
 		}
 
-		if ( 'parent' !== $order_type ) {
+		// Get the parent order ID first.
+		if ( in_array( 'parent', $order_types, true ) ) {
+			$parent_id = [ $this->get_parent_id() ];
 
-			$relation_types = ( 'any' === $order_type ) ? array( 'renewal', 'resubscribe', 'switch' ) : array( $order_type );
-
-			foreach ( $relation_types as $relation_type ) {
-				$related_order_ids = array_merge( $related_order_ids, WCS_Related_Order_Store::instance()->get_related_order_ids( $this, $relation_type ) );
+			if ( $parent_id ) {
+				$related_order_ids['parent'] = $parent_id;
 			}
+		}
+
+		// Remove the parent order type from the list of order types.
+		$relation_types = array_diff( $order_types, [ 'parent' ] );
+		$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $relation_types );
+
+		if ( 'flat' === $return_type ) {
+			$flattened         = array_merge( ...array_values( $related_order_ids ) );
+			$related_order_ids = array_combine( $flattened, $flattened );
 		}
 
 		return $related_order_ids;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2136,7 +2136,7 @@ class WC_Subscription extends WC_Order {
 		if ( in_array( 'parent', $order_types, true ) ) {
 			// Remove the parent order type from the list of order types.
 			$order_types = array_diff( $order_types, [ 'parent' ] );
-			$parent_id      = $this->get_parent_id();
+			$parent_id   = $this->get_parent_id();
 
 			if ( $parent_id ) {
 				$related_order_ids['parent'] = [ $parent_id ];

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1295,9 +1295,7 @@ class WC_Subscription extends WC_Order {
 	 * @param string $date_type 'date_created', 'trial_end', 'next_payment', 'last_order_date_created', 'end' or 'end_of_prepaid_term'
 	 */
 	public function get_date_to_display( $date_type = 'next_payment' ) {
-
-		$date_type = wcs_normalise_date_type_key( $date_type, true );
-
+		$date_type     = wcs_normalise_date_type_key( $date_type, true );
 		$timestamp_gmt = $this->get_time( $date_type, 'gmt' );
 
 		// Don't display next payment date when the subscription is inactive
@@ -1305,18 +1303,30 @@ class WC_Subscription extends WC_Order {
 			$timestamp_gmt = 0;
 		}
 
-		if ( $timestamp_gmt > 0 ) {
+		return $this->format_date_to_display( $timestamp_gmt, $date_type );
+	}
 
-			$time_diff = $timestamp_gmt - current_time( 'timestamp', true );
+	/**
+	 * Undocumented function
+	 *
+	 * @param int    $timestamp The subscription date in a timestamp format.
+	 * @param string $date_type The subscription date type to display. @see WC_Subscription::get_valid_date_types()
+	 *
+	 *  @return string The formatted date to display.
+	 */
+	public function format_date_to_display( $timestamp, $date_type ) {
+
+		if ( $timestamp > 0 ) {
+			$time_diff = $timestamp - current_time( 'timestamp', true );
 
 			if ( $time_diff > 0 && $time_diff < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
+				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
 			} elseif ( $time_diff < 0 && absint( $time_diff ) < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
+				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
 			} else {
-				$date_to_display = date_i18n( wc_date_format(), $this->get_time( $date_type, 'site' ) );
+				$date_to_display = date_i18n( wc_date_format(), $timestamp + wc_timezone_offset() );
 			}
 		} else {
 			switch ( $date_type ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2136,7 +2136,7 @@ class WC_Subscription extends WC_Order {
 		if ( in_array( 'parent', $order_types, true ) ) {
 			// Remove the parent order type from the list of order types.
 			$relation_types = array_diff( $order_types, [ 'parent' ] );
-			$parent_id = $this->get_parent_id();
+			$parent_id      = $this->get_parent_id();
 
 			if ( $parent_id ) {
 				$related_order_ids['parent'] = [ $parent_id ];

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2124,13 +2124,20 @@ class WC_Subscription extends WC_Order {
 	 */
 	protected function get_related_order_ids( $order_type = 'any', $return_type = 'flat' ) {
 		$related_order_ids = [];
+		$any_order_types   = [ 'parent', 'renewal', 'resubscribe', 'switch' ];
 
 		if ( 'any' === $order_type ) {
-			$order_types = array( 'parent', 'renewal', 'resubscribe', 'switch' );
+			$order_types = $any_order_types;
 		} elseif ( is_array( $order_type ) ) {
-			$order_types = $order_type;
+			if ( in_array( 'any', $order_type, true ) ) {
+				// Replace 'any' with the actual order types.
+				$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'
+				$order_types = array_merge( $order_types, $any_order_types ); // Add replacements
+			} else {
+				$order_types = $order_type;
+			}
 		} else {
-			$order_types = array( $order_type );
+			$order_types = [ $order_type ];
 		}
 
 		// Get the parent order ID first.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2143,7 +2143,7 @@ class WC_Subscription extends WC_Order {
 		}
 
 		// Remove the parent order type from the list of order types.
-		$relation_types = array_diff( $order_types, [ 'parent' ] );
+		$relation_types     = array_diff( $order_types, [ 'parent' ] );
 		$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $relation_types );
 
 		if ( 'flat' === $return_type ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2140,10 +2140,10 @@ class WC_Subscription extends WC_Order {
 
 		// Get the parent order ID first.
 		if ( in_array( 'parent', $order_types, true ) ) {
-			$parent_id = [ $this->get_parent_id() ];
+			$parent_id = $this->get_parent_id();
 
 			if ( $parent_id ) {
-				$related_order_ids['parent'] = $parent_id;
+				$related_order_ids['parent'] = [ $parent_id ];
 			}
 		}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2128,7 +2128,7 @@ class WC_Subscription extends WC_Order {
 
 		// For backwards compatibility, replace 'any' with the actual order types.
 		if ( in_array( 'any', $order_types, true ) ) {
-			$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'.
+			$order_types = array_diff( $order_types, [ 'any' ] ); // Remove 'any'.
 			$order_types = array_unique( array_merge( $order_types, [ 'parent', 'renewal', 'resubscribe', 'switch' ] ) ); // Add the 'any' order types.
 		}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2128,7 +2128,7 @@ class WC_Subscription extends WC_Order {
 
 		if ( 'any' === $order_type ) {
 			$order_types = $any_order_types;
-		} elseif ( in_array( 'any', $order_type, true ) ) {
+		} elseif ( is_array( $order_type ) && in_array( 'any', $order_type, true ) ) {
 			// For backwards compatibility, replace 'any' with the actual order types.
 			$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'
 			$order_types = array_unique( array_merge( $order_types, $any_order_types ) ); // Add replacements

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2118,7 +2118,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Get the related order IDs for a subscription based on an order type.
 	 *
-	 * @param string $order_type Can include 'any', 'parent', 'renewal', 'resubscribe' and/or 'switch'. Defaults to 'any'.
+	 * @param string|array $order_type Can include 'any', 'parent', 'renewal', 'resubscribe' and/or 'switch'. Defaults to 'any'.
 	 * @return array List of related order IDs.
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
 	 */
@@ -2128,14 +2128,12 @@ class WC_Subscription extends WC_Order {
 
 		if ( 'any' === $order_type ) {
 			$order_types = $any_order_types;
+		} elseif ( in_array( 'any', $order_type, true ) ) {
+			// For backwards compatibility, replace 'any' with the actual order types.
+			$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'
+			$order_types = array_unique( array_merge( $order_types, $any_order_types ) ); // Add replacements
 		} elseif ( is_array( $order_type ) ) {
-			if ( in_array( 'any', $order_type, true ) ) {
-				// Replace 'any' with the actual order types.
-				$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'
-				$order_types = array_merge( $order_types, $any_order_types ); // Add replacements
-			} else {
-				$order_types = $order_type;
-			}
+			$order_types = $order_type;
 		} else {
 			$order_types = [ $order_type ];
 		}

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2124,22 +2124,18 @@ class WC_Subscription extends WC_Order {
 	 */
 	protected function get_related_order_ids( $order_type = 'any', $return_type = 'flat' ) {
 		$related_order_ids = [];
-		$any_order_types   = [ 'parent', 'renewal', 'resubscribe', 'switch' ];
+		$order_types       = is_array( $order_type ) ? $order_type : [ $order_type ];
 
-		if ( 'any' === $order_type ) {
-			$order_types = $any_order_types;
-		} elseif ( is_array( $order_type ) && in_array( 'any', $order_type, true ) ) {
-			// For backwards compatibility, replace 'any' with the actual order types.
-			$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'
-			$order_types = array_unique( array_merge( $order_types, $any_order_types ) ); // Add replacements
-		} elseif ( is_array( $order_type ) ) {
-			$order_types = $order_type;
-		} else {
-			$order_types = [ $order_type ];
+		// For backwards compatibility, replace 'any' with the actual order types.
+		if ( in_array( 'any', $order_types, true ) ) {
+			$order_types = array_diff( $order_type, [ 'any' ] ); // Remove 'any'.
+			$order_types = array_unique( array_merge( $order_types, [ 'parent', 'renewal', 'resubscribe', 'switch' ] ) ); // Add the 'any' order types.
 		}
 
 		// Get the parent order ID first.
 		if ( in_array( 'parent', $order_types, true ) ) {
+			// Remove the parent order type from the list of order types.
+			$relation_types = array_diff( $order_types, [ 'parent' ] );
 			$parent_id = $this->get_parent_id();
 
 			if ( $parent_id ) {
@@ -2147,11 +2143,12 @@ class WC_Subscription extends WC_Order {
 			}
 		}
 
-		// Remove the parent order type from the list of order types.
-		$relation_types     = array_diff( $order_types, [ 'parent' ] );
-		$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $relation_types );
+		if ( ! empty( $relation_types ) ) {
+			// Get the related order IDs based on the remaining order types.
+			$related_order_ids += WCS_Related_Order_Store::instance()->get_related_order_ids_by_types( $this, $relation_types );
+		}
 
-		if ( 'flat' === $return_type ) {
+		if ( 'flat' === $return_type && ! empty( $related_order_ids ) ) {
 			// Flatten the array, remove duplicates and return in the [order_id] => order_id format.
 			$flattened         = array_merge( ...array_values( $related_order_ids ) );
 			$related_order_ids = array_combine( $flattened, $flattened );

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -47,6 +47,22 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	private static $override_ignored_props = false;
 
 	/**
+	 * A list of subscription IDs that are requesting multiple related order caches to be read.
+	 *
+	 * This is used by @see get_related_order_ids_by_types() to enable fetching multiple related order caches without reading the subscriptions meta query multiple times.
+	 *
+	 * @var array $batch_processing_subscriptions An array of subscription IDs.
+	 */
+	private static $batch_processing_related_orders = [];
+
+	/**
+	 * A cache of subscription meta data. Used when fetching multiple related order caches for a subscription to avoid multiple database queries.
+	 *
+	 * @var array $subscription_meta_cache An array of subscription meta data.
+	 */
+	private static $subscription_meta_cache = [];
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -645,20 +661,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$cache_meta_key = $this->get_cache_meta_key( $relation_type );
 		$data_store     = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
 
-		/**
-		 * Bypass the related order cache keys being ignored when fetching subscription meta.
-		 *
-		 * By default the related order cache keys are ignored via $this->add_related_order_cache_props(). In order to fetch the subscription's
-		 * meta with those keys, we need to bypass that function.
-		 *
-		 * We use a static variable because it is possible to have multiple instances of this class in memory, and we want to make sure we bypass
-		 * the function in all instances.
-		 */
-		self::$override_ignored_props = true;
-		$subscription_meta            = $data_store->read_meta( $subscription );
-		self::$override_ignored_props = false;
-
-		foreach ( $subscription_meta as $meta ) {
+		foreach ( $this->get_subscription_meta( $subscription, $data_store ) as $meta ) {
 			if ( isset( $meta->meta_key ) && $cache_meta_key === $meta->meta_key ) {
 				return $meta;
 			}
@@ -689,5 +692,72 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			$subscription->set_date_modified( time() );
 			$subscription->save();
 		}
+	}
+
+	/**
+	 * Gets the subscription's meta data.
+	 *
+	 * @param WC_Subscription $subscription The subscription to get the meta for.
+     * @param mixed           $data_store   The data store to use to get the meta. Defaults to the current subscription's data store.
+	 *
+	 * @return array The subscription's meta data.
+	 */
+	private function get_subscription_meta( $subscription, $data_store ) {
+		$is_batch_processing = isset( self::$batch_processing_related_orders[ $subscription->get_id() ] );
+
+		// If we are in batch processing mode, return the cached meta data.
+		if ( $is_batch_processing && isset( self::$subscription_meta_cache[ $subscription->get_id() ] ) ) {
+			return self::$subscription_meta_cache[ $subscription->get_id() ];
+		}
+
+		/**
+		 * Bypass the related order cache keys being ignored when fetching subscription meta.
+		 *
+		 * By default the related order cache keys are ignored via $this->add_related_order_cache_props(). In order to fetch the subscription's
+		 * meta with those keys, we need to bypass that function.
+		 *
+		 * We use a static variable because it is possible to have multiple instances of this class in memory, and we want to make sure we bypass
+		 * the function in all instances.
+		 */
+		self::$override_ignored_props = true;
+		$subscription_meta            = $data_store->read_meta( $subscription );
+		self::$override_ignored_props = false;
+
+		// If we are in batch processing mode, cache the meta data.
+		if ( $is_batch_processing ) {
+			self::$subscription_meta_cache[ $subscription->get_id() ] = $subscription_meta;
+		}
+
+		return $subscription_meta;
+	}
+
+	/**
+	 * Gets the related order IDs for a subscription by multiple relation types.
+	 *
+	 * This function is a more efficient way to get related order IDs for multiple relation types at once.
+	 * It will only query the database once for all cache data, and then return the related order IDs for each relation type.
+	 *
+	 * The alternative of calling the get_related_order_ids() function for each relation type will result in a full subscription meta read for each relation type.
+	 *
+	 * @param WC_Order $subscription        The subscription to get related order IDs for.
+	 * @param array    $related_order_types The related order types to get IDs for. Must be an array of supported relation types.
+	 *
+	 * @return array An array of related order IDs for each relation type.
+	 */
+	public function get_related_order_ids_by_types( WC_Order $subscription, $related_order_types ) {
+		$related_order_ids = [];
+
+		// Declare batch processing mode for this subscription.
+		self::$batch_processing_related_orders[ $subscription->get_id() ] = true;
+
+		foreach ( $related_order_types as $relation_type ) {
+			$related_order_ids[ $relation_type ] = $this->get_related_order_ids( $subscription, $relation_type );
+		}
+
+		// Unset the batch processing mode for this subscription.
+		unset( self::$batch_processing_related_orders[ $subscription->get_id() ] );
+		unset( self::$subscription_meta_cache[ $subscription->get_id() ] );
+
+		return $related_order_ids;
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -698,7 +698,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 * Gets the subscription's meta data.
 	 *
 	 * @param WC_Subscription $subscription The subscription to get the meta for.
-     * @param mixed           $data_store   The data store to use to get the meta. Defaults to the current subscription's data store.
+	 * @param mixed           $data_store   The data store to use to get the meta. Defaults to the current subscription's data store.
 	 *
 	 * @return array The subscription's meta data.
 	 */

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -1067,7 +1067,7 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 
 		$related_orders = $subscription->get_related_orders();
 
-		$this->assertEquals( 1, count( $related_orders ), '[FAILED]: Should only be one related order. Got: ' . print_r( $related_orders, true ) );
+		$this->assertEquals( 1, count( $related_orders ) );
 		$this->assertEquals( wcs_get_objects_property( $order, 'id' ), reset( $related_orders ) );
 
 		$related_orders = $subscription->get_related_orders( 'all' );
@@ -1108,7 +1108,7 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 
 		// test no param
 		$related_order_ids = $subscription->get_related_orders();
-		$this->assertCount( 3, $related_order_ids, '[FAILED]: Should only be three related order. Got: ' . print_r( $related_order_ids, true ) );
+		$this->assertCount( 3, $related_order_ids );
 		$this->assertEquals( wcs_get_objects_property( $orders[0], 'id' ), array_pop( $related_order_ids ) );
 
 		// test with 'ids' param

--- a/tests/unit/test-class-wc-subscriptions.php
+++ b/tests/unit/test-class-wc-subscriptions.php
@@ -1067,7 +1067,7 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 
 		$related_orders = $subscription->get_related_orders();
 
-		$this->assertEquals( 1, count( $related_orders ) );
+		$this->assertEquals( 1, count( $related_orders ), '[FAILED]: Should only be one related order. Got: ' . print_r( $related_orders, true ) );
 		$this->assertEquals( wcs_get_objects_property( $order, 'id' ), reset( $related_orders ) );
 
 		$related_orders = $subscription->get_related_orders( 'all' );
@@ -1108,7 +1108,7 @@ class WC_Subscriptions_Test extends WP_UnitTestCase {
 
 		// test no param
 		$related_order_ids = $subscription->get_related_orders();
-		$this->assertCount( 3, $related_order_ids );
+		$this->assertCount( 3, $related_order_ids, '[FAILED]: Should only be three related order. Got: ' . print_r( $related_order_ids, true ) );
 		$this->assertEquals( wcs_get_objects_property( $orders[0], 'id' ), array_pop( $related_order_ids ) );
 
 		// test with 'ids' param

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -342,7 +342,7 @@ function wcs_get_date_meta_key( $date_type ) {
  * deprecated date type key.
  *
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.0
- * @param string $date_type_key String referring to a valid date type, can be: 'date_created', 'trial_end', 'next_payment', 'last_order_date_created' or 'end', or any other value returned by @see this->get_valid_date_types()
+ * @param string $date_type_key String referring to a valid date type, can be: 'date_created', 'trial_end', 'next_payment', 'last_order_date_created' or 'end', or any other value returned by @see WC_Subscription::get_valid_date_types()
  * @return string
  */
 function wcs_normalise_date_type_key( $date_type_key, $display_deprecated_notice = false ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4795

## Description

This PR reduces the number of duplicate queries running on the **WooCommerce → Subscriptions** list table, decreasing them from **137 to 60**. This PR focuses on two key functions:

#### 1. Optimizing `get_date_column_content()`
- Previously, this function called `get_time()` multiple times. When rendering the **Last Order Date** column, each call triggered a `get_related_orders()` query, resulting in redundant database reads.
- The changes in this PR minimize unnecessary `get_time()` calls when generating date columns.

#### 2. Improving `WC_Subscription::get_related_orders()`
- When `get_related_orders()` was called with multiple order types, it triggered separate `get_related_order_ids()` queries for each type.
- That would then subsequently result in a call to `WCS_Related_Order_Store::instance()->get_related_order_ids()` for each type and therefore a full read from the subscription meta table.
**Example:**  
  ```php
  $subscription->get_related_orders( ..., [ 'renewal', 'switch' ] );

- Previously, this resulted in two database reads. Now, the related order caches have been updated to allow that to be 1 database read.

### Summary of Changes
- Reduced unnecessary `get_time()` calls in `get_date_column_content()`.
- Updated `WC_Subscription::get_related_order_ids()` and `WCS_Related_Order_Store` to allow fetching multiple related orders caches with a single database read.

## How to test this PR

1. Install Query Monitor.
2. Go to **WooCommerce → Subscriptions**
3. Open the Query Monitor window and go to **Database Queries → Duplicate Queries**
4. Note the number of duplicate queries.
    -  Each subscription in the list table is causing 6 calls to `get_related_order_metadata()`

<p align="center">
<img width="2164" alt="Screenshot 2025-02-19 at 3 29 56 pm" src="https://github.com/user-attachments/assets/cda480f0-b52e-41ff-a83d-9b5ac6cbb233" />
</br>
<sup>137 duplicate queries.</sup>
</p> 

5. Checkout this branch and repeat the steps above.
6. The number of duplicate queries should drop by roughly 4 x the number of subscriptions you have in the list table (20). 
7. There should be no difference in content or functionality on the list table. 



## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
