### PR TITLE
Performance - Remove unnecessary get_time() calls to reduce redundant get_last_order() requests on admin Subscriptions list table

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 8.0.1 - 2025-02-13 =
 * Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.
+* Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 
 = 8.0.0 - 2025-02-13 =
 * Fix - Recommend WooPayments when there is no available payment gateway.

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -703,18 +703,16 @@ class WCS_Admin_Post_Types {
 		);
 
 		// Custom handling for `Next payment` date column.
-		if ( 'next_payment_date' === $column ) {
-			$subscription_is_active = $subscription->has_status( 'active' );
-
+		if ( 'next_payment_date' === $column && $subscription->has_status( 'active' ) ) {
 			$tooltip_message = '';
 			$tooltip_classes = 'woocommerce-help-tip';
 
-			if ( $subscription_is_active && $datetime->getTimestamp() < time() ) {
+			if ( $datetime->getTimestamp() < time() ) {
 				$tooltip_message .= __( '<b>Subscription payment overdue.</b></br>', 'woocommerce-subscriptions' );
 				$tooltip_classes .= ' wcs-payment-overdue';
 			}
 
-			if ( $subscription->payment_method_supports( 'gateway_scheduled_payments' ) && ! $subscription->is_manual() && $subscription_is_active ) {
+			if ( $subscription->payment_method_supports( 'gateway_scheduled_payments' ) && ! $subscription->is_manual() ) {
 				$tooltip_message .= __( 'This date should be treated as an estimate only. The payment gateway for this subscription controls when payments are processed.</br>', 'woocommerce-subscriptions' );
 				$tooltip_classes .= ' wcs-offsite-renewal';
 			}

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -684,43 +684,43 @@ class WCS_Admin_Post_Types {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
 	 */
 	public static function get_date_column_content( $subscription, $column ) {
+		$date_type_map  = array( 'last_payment_date' => 'last_order_date_created' );
+		$date_type      = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
+		$date_timestamp = $subscription->get_time( $date_type );
 
-		$date_type_map = array( 'last_payment_date' => 'last_order_date_created' );
-		$date_type     = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
-		$datetime      = wcs_get_datetime_from( $subscription->get_time( $date_type ) );
+		if ( 0 === $date_timestamp ) {
+			return '-';
+		}
 
-		if ( 0 == $subscription->get_time( $date_type, 'gmt' ) ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-			$column_content = '-';
-		} else {
-			$accurate_date    = $datetime->date_i18n( __( 'Y/m/d g:i:s A', 'woocommerce-subscriptions' ) );
-			$fuzzy_human_date = $subscription->get_date_to_display( $date_type );
-			$column_content   = sprintf(
-				'<time class="%s" title="%s">%s</time>',
-				esc_attr( $column ),
-				esc_attr( $accurate_date ),
-				esc_html( $fuzzy_human_date )
-			);
+		$datetime         = wcs_get_datetime_from( $date_timestamp );
+		$accurate_date    = $datetime->date_i18n( __( 'Y/m/d g:i:s A', 'woocommerce-subscriptions' ) );
+		$fuzzy_human_date = $subscription->format_date_to_display( $date_timestamp, $date_type );
+		$column_content   = sprintf(
+			'<time class="%s" title="%s">%s</time>',
+			esc_attr( $column ),
+			esc_attr( $accurate_date ),
+			esc_html( $fuzzy_human_date )
+		);
 
-			// Custom handling for `Next payment` date column.
-			if ( 'next_payment_date' === $column ) {
-				$subscription_is_active = $subscription->has_status( 'active' );
+		// Custom handling for `Next payment` date column.
+		if ( 'next_payment_date' === $column ) {
+			$subscription_is_active = $subscription->has_status( 'active' );
 
-				$tooltip_message = '';
-				$tooltip_classes = 'woocommerce-help-tip';
+			$tooltip_message = '';
+			$tooltip_classes = 'woocommerce-help-tip';
 
-				if ( $subscription_is_active && $datetime->getTimestamp() < time() ) {
-					$tooltip_message .= __( '<b>Subscription payment overdue.</b></br>', 'woocommerce-subscriptions' );
-					$tooltip_classes .= ' wcs-payment-overdue';
-				}
+			if ( $subscription_is_active && $datetime->getTimestamp() < time() ) {
+				$tooltip_message .= __( '<b>Subscription payment overdue.</b></br>', 'woocommerce-subscriptions' );
+				$tooltip_classes .= ' wcs-payment-overdue';
+			}
 
-				if ( $subscription->payment_method_supports( 'gateway_scheduled_payments' ) && ! $subscription->is_manual() && $subscription_is_active ) {
-					$tooltip_message .= __( 'This date should be treated as an estimate only. The payment gateway for this subscription controls when payments are processed.</br>', 'woocommerce-subscriptions' );
-					$tooltip_classes .= ' wcs-offsite-renewal';
-				}
+			if ( $subscription->payment_method_supports( 'gateway_scheduled_payments' ) && ! $subscription->is_manual() && $subscription_is_active ) {
+				$tooltip_message .= __( 'This date should be treated as an estimate only. The payment gateway for this subscription controls when payments are processed.</br>', 'woocommerce-subscriptions' );
+				$tooltip_classes .= ' wcs-offsite-renewal';
+			}
 
-				if ( $tooltip_message ) {
-					$column_content .= '<div class="' . esc_attr( $tooltip_classes ) . '" data-tip="' . esc_attr( $tooltip_message ) . '"></div>';
-				}
+			if ( $tooltip_message ) {
+				$column_content .= '<div class="' . esc_attr( $tooltip_classes ) . '" data-tip="' . esc_attr( $tooltip_message ) . '"></div>';
 			}
 		}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1307,26 +1307,26 @@ class WC_Subscription extends WC_Order {
 	}
 
 	/**
-	 * Undocumented function
+	 * Formats a subscription date timestamp for display.
 	 *
 	 * @param int    $timestamp The subscription date in a timestamp format.
 	 * @param string $date_type The subscription date type to display. @see WC_Subscription::get_valid_date_types()
 	 *
 	 *  @return string The formatted date to display.
 	 */
-	public function format_date_to_display( $timestamp, $date_type ) {
+	public function format_date_to_display( $timestamp_gmt, $date_type ) {
 
-		if ( $timestamp > 0 ) {
-			$time_diff = $timestamp - current_time( 'timestamp', true );
+		if ( $timestamp_gmt > 0 ) {
+			$time_diff = $timestamp_gmt - current_time( 'timestamp', true );
 
 			if ( $time_diff > 0 && $time_diff < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
+				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
 			} elseif ( $time_diff < 0 && absint( $time_diff ) < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
+				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
 			} else {
-				$date_to_display = date_i18n( wc_date_format(), $timestamp + wc_timezone_offset() );
+				$date_to_display = date_i18n( wc_date_format(), $timestamp_gmt + wc_timezone_offset() );
 			}
 		} else {
 			switch ( $date_type ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1295,9 +1295,7 @@ class WC_Subscription extends WC_Order {
 	 * @param string $date_type 'date_created', 'trial_end', 'next_payment', 'last_order_date_created', 'end' or 'end_of_prepaid_term'
 	 */
 	public function get_date_to_display( $date_type = 'next_payment' ) {
-
-		$date_type = wcs_normalise_date_type_key( $date_type, true );
-
+		$date_type     = wcs_normalise_date_type_key( $date_type, true );
 		$timestamp_gmt = $this->get_time( $date_type, 'gmt' );
 
 		// Don't display next payment date when the subscription is inactive
@@ -1305,18 +1303,30 @@ class WC_Subscription extends WC_Order {
 			$timestamp_gmt = 0;
 		}
 
-		if ( $timestamp_gmt > 0 ) {
+		return $this->format_date_to_display( $timestamp_gmt, $date_type );
+	}
 
-			$time_diff = $timestamp_gmt - current_time( 'timestamp', true );
+	/**
+	 * Undocumented function
+	 *
+	 * @param int    $timestamp The subscription date in a timestamp format.
+	 * @param string $date_type The subscription date type to display. @see WC_Subscription::get_valid_date_types()
+	 *
+	 *  @return string The formatted date to display.
+	 */
+	public function format_date_to_display( $timestamp, $date_type ) {
+
+		if ( $timestamp > 0 ) {
+			$time_diff = $timestamp - current_time( 'timestamp', true );
 
 			if ( $time_diff > 0 && $time_diff < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
+				$date_to_display = sprintf( __( 'In %s', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
 			} elseif ( $time_diff < 0 && absint( $time_diff ) < WEEK_IN_SECONDS ) {
 				// translators: placeholder is human time diff (e.g. "3 weeks")
-				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp_gmt ) );
+				$date_to_display = sprintf( __( '%s ago', 'woocommerce-subscriptions' ), human_time_diff( current_time( 'timestamp', true ), $timestamp ) );
 			} else {
-				$date_to_display = date_i18n( wc_date_format(), $this->get_time( $date_type, 'site' ) );
+				$date_to_display = date_i18n( wc_date_format(), $timestamp + wc_timezone_offset() );
 			}
 		} else {
 			switch ( $date_type ) {

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1307,7 +1307,7 @@ class WC_Subscription extends WC_Order {
 	 * @param int    $timestamp The subscription date in a timestamp format.
 	 * @param string $date_type The subscription date type to display. @see WC_Subscription::get_valid_date_types()
 	 *
-	 *  @return string The formatted date to display.
+	 * @return string The formatted date to display.
 	 */
 	public function format_date_to_display( $timestamp_gmt, $date_type ) {
 		$date_type = wcs_normalise_date_type_key( $date_type, true );

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1298,11 +1298,6 @@ class WC_Subscription extends WC_Order {
 		$date_type     = wcs_normalise_date_type_key( $date_type, true );
 		$timestamp_gmt = $this->get_time( $date_type, 'gmt' );
 
-		// Don't display next payment date when the subscription is inactive
-		if ( 'next_payment' == $date_type && ! $this->has_status( 'active' ) ) {
-			$timestamp_gmt = 0;
-		}
-
 		return $this->format_date_to_display( $timestamp_gmt, $date_type );
 	}
 
@@ -1315,6 +1310,12 @@ class WC_Subscription extends WC_Order {
 	 *  @return string The formatted date to display.
 	 */
 	public function format_date_to_display( $timestamp_gmt, $date_type ) {
+		$date_type = wcs_normalise_date_type_key( $date_type, true );
+
+		// Don't display next payment date when the subscription is inactive
+		if ( 'next_payment' === $date_type && ! $this->has_status( 'active' ) ) {
+			$timestamp_gmt = 0;
+		}
 
 		if ( $timestamp_gmt > 0 ) {
 			$time_diff = $timestamp_gmt - current_time( 'timestamp', true );

--- a/wcs-functions.php
+++ b/wcs-functions.php
@@ -342,7 +342,7 @@ function wcs_get_date_meta_key( $date_type ) {
  * deprecated date type key.
  *
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.0
- * @param string $date_type_key String referring to a valid date type, can be: 'date_created', 'trial_end', 'next_payment', 'last_order_date_created' or 'end', or any other value returned by @see this->get_valid_date_types()
+ * @param string $date_type_key String referring to a valid date type, can be: 'date_created', 'trial_end', 'next_payment', 'last_order_date_created' or 'end', or any other value returned by @see WC_Subscription::get_valid_date_types()
  * @return string
  */
 function wcs_normalise_date_type_key( $date_type_key, $display_deprecated_notice = false ) {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-subscriptions/issues/4795

## Description

This PR reduces the number of duplicate queries running on the WooCommerce → Subscriptions list table, decreasing them from 137 to 82. This PR focuses on one key function: **`get_date_column_content()`**. A subsequent PR will make further improvements. 

- Previously, this function called `get_time()` multiple times (up to 4 times). When rendering the Last Order Date column, each call triggered a `get_related_orders()` query, resulting in redundant database reads.
- The changes in this PR minimize unnecessary `get_time()` calls when generating date columns. 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install **Query Monitor**.
2. Go to **WooCommerce → Subscriptions**
3. Open the Query Monitor window and go to Database **Queries → Duplicate Queries**
4. Note the number of duplicate queries.
5. Each subscription in the list table is causing 6 calls to `get_related_order_metadata()`

<p align="center">
<img width="2164" alt="Screenshot 2025-02-19 at 3 29 56 pm" src="https://github.com/user-attachments/assets/cda480f0-b52e-41ff-a83d-9b5ac6cbb233" />
</br>
<sup>137 duplicate queries.</sup>
</p> 

6. Checkout this branch and repeat the steps above.
7. The number of duplicate queries should drop by roughly 3 x the number of subscriptions you have in the list table. 
    - _eg with 20 subscriptions in the list table this should remove ~60 duplicates._ 
    - _**Note:** numbers may vary based on the number of subscriptions with no dates in some_ columns. 
7. There should be no difference in content or functionality on the list table. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
