### PR TITLE
Now zero dollar subscriptions won't trigger renawal emails anymore

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@
 * Fix - Prevent empty strings being saved in related orders cache ID meta when backfilling order data to the WP Posts table.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
-* Fix - Prevent sending renewal reminders for 0 dollar orders.
+* Fix - Prevent sending renewal reminders for orders with a 0 total.
 
 = 8.0.1 - 2025-02-13 =
 * Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.2.0 - 20xx-xx-xx =
+* Fix - Prevent sending renewal reminders for orders with a 0 total.
+
 = 8.1.0 - 2025-03-24 =
 * Update - Improved subscription search performance for WP Post stores by removing unnecessary _order_key and _billing_email meta queries.
 * Update - Make it possible to dispatch the Cancelled Subscription email more than once (when initially set to pending-cancellation, and again when it reaches final cancellation).
@@ -17,7 +20,6 @@
 * Fix - Prevent empty strings being saved in related orders cache ID meta when backfilling order data to the WP Posts table.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
-* Fix - Prevent sending renewal reminders for orders with a 0 total.
 
 = 8.0.1 - 2025-02-13 =
 * Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - Prevent empty strings being saved in related orders cache ID meta when backfilling order data to the WP Posts table.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
+* Fix - Prevent sending renewal reminders for 0 dollar orders.
 
 = 8.0.1 - 2025-02-13 =
 * Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -156,6 +156,9 @@ class WC_Subscriptions_Email_Notifications {
 		switch ( current_action() ) {
 			case 'woocommerce_scheduled_subscription_customer_notification_renewal':
 				$subscription = wcs_get_subscription( $subscription_id );
+				if ( $subscription->get_total() <= 0) {
+					break;
+				}
 				if ( $subscription->is_manual() ) {
 					$notification = $emails['WCS_Email_Customer_Notification_Manual_Renewal'];
 				} else {
@@ -248,7 +251,7 @@ class WC_Subscriptions_Email_Notifications {
 			$actions['wcs_customer_notification_subscription_expiration'] = esc_html__( 'Send upcoming subscription expiration notification', 'woocommerce-subscriptions' );
 		}
 
-		if ( in_array( 'next_payment', $valid_notifications, true ) ) {
+		if ( in_array( 'next_payment', $valid_notifications, true ) && $theorder->get_total() > 0 ) {
 			$actions['wcs_customer_notification_renewal'] = esc_html__( 'Send upcoming renewal notification', 'woocommerce-subscriptions' );
 		}
 

--- a/includes/class-wc-subscriptions-email-notifications.php
+++ b/includes/class-wc-subscriptions-email-notifications.php
@@ -156,7 +156,7 @@ class WC_Subscriptions_Email_Notifications {
 		switch ( current_action() ) {
 			case 'woocommerce_scheduled_subscription_customer_notification_renewal':
 				$subscription = wcs_get_subscription( $subscription_id );
-				if ( $subscription->get_total() <= 0) {
+				if ( $subscription->get_total() <= 0 ) {
 					break;
 				}
 				if ( $subscription->is_manual() ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4778

## Description
This PR adds a check to prevent sending renewal reminders for 0 dollar orders

## How to test this PR
- Checkout to this PR's branch
- Place a subscription order
- Go to /wp-admin > WooCommerce > Subscriptions > Edit
- Make sure the `Send upcoming renewal notification` option does not show up in the order actions select box
- Change the next renewal to happen in just a few minutes from now
- Wait until the renewal happens
- Make sure you don't receive a `Manual renewal notice` email but you do receive a `Thank you for your order` email


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
