### PR TITLE
Added a filter to add more columns to the related orders table

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 * Update - Improved performance on the Orders list table when rendering the Subscription Relationship column.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
+* Add - Hooks to add more columns to the Related Orders table on admin
 
 = 8.0.1 - 2025-02-13 =
 * Fix - Revert a change released in 7.2.0 which triggered the "woocommerce_cart_item_name" filter with the wrong number of parameters.

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -12,7 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Order number column
 // translators: placeholder is an order number.
 $order_number = '<a href="' . esc_url( $order->get_edit_order_url() ) . '" aria-label="' . esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) . '">' .
-			sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ) . // translators: placeholder is an order number.
+			// translators: placeholder is an order number.
+			sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ) . 
 		'</a>';
 
 // Relationship column
@@ -50,16 +51,26 @@ if ( wcs_is_subscription( $order ) ) {
 	$status_name = wc_get_order_status_name( $order->get_status() );
 }
 
-$status = '<mark class="' . esc_attr( implode( ' ', $classes ) ) . '"><span>' . esc_html( $status_name ) . '</span></mark>';
+$status_html = '<mark class="' . esc_attr( implode( ' ', $classes ) ) . '"><span>' . esc_html( $status_name ) . '</span></mark>';
 
 // Total column
-$total = '<span class="amount">' . wp_kses( $order->get_formatted_order_total(), array( 'small' => array(), 'span' => array( 'class' => array() ), 'del' => array(), 'ins' => array() ) ) . '</span>';
+$total = '<span class="amount">' . wp_kses( 
+	$order->get_formatted_order_total(), 
+	array( 
+		'small' => array(), 
+		'span' => array( 
+			'class' => array() 
+		), 
+		'del' => array(), 
+		'ins' => array() 
+	) 
+) . '</span>';
 
 $columns = array(
 	$order_number,
 	$relationship,
 	$date_created,
-	$status,
+	$status_html,
 	$total,
 );
 
@@ -69,7 +80,7 @@ $columns = apply_filters( 'wcs_related_orders_table_row_columns', $columns );
 <tr>
 	<?php foreach ( $columns as $column ) { ?>
 		<td>
-			<?php echo $column; ?>
+			<?php echo wp_kses_post( $column ); ?>
 		</td>
 	<?php } ?>
 </tr>

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // translators: placeholder is an order number.
 $order_number = '<a href="' . esc_url( $order->get_edit_order_url() ) . '" aria-label="' . esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) . '">' .
 			// translators: placeholder is an order number.
-			sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ) . 
+			sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ) .
 		'</a>';
 
 // Relationship column
@@ -58,11 +58,11 @@ $total = '<span class="amount">' . wp_kses(
 	$order->get_formatted_order_total(),
 	array(
 		'small' => array(),
-		'span' => array(
-			'class' => array()
+		'span'  => array(
+			'class' => array(),
 		),
-		'del' => array(),
-		'ins' => array()
+		'del'   => array(),
+		'ins'   => array(),
 	)
 ) . '</span>';
 

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -54,16 +54,16 @@ if ( wcs_is_subscription( $order ) ) {
 $status_html = '<mark class="' . esc_attr( implode( ' ', $classes ) ) . '"><span>' . esc_html( $status_name ) . '</span></mark>';
 
 // Total column
-$total = '<span class="amount">' . wp_kses( 
-	$order->get_formatted_order_total(), 
-	array( 
-		'small' => array(), 
-		'span' => array( 
-			'class' => array() 
-		), 
-		'del' => array(), 
-		'ins' => array() 
-	) 
+$total = '<span class="amount">' . wp_kses(
+	$order->get_formatted_order_total(),
+	array(
+		'small' => array(),
+		'span' => array(
+			'class' => array()
+		),
+		'del' => array(),
+		'ins' => array()
+	)
 ) . '</span>';
 
 $columns = array(

--- a/includes/admin/meta-boxes/views/html-related-orders-row.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-row.php
@@ -8,61 +8,68 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
+
+// Order number column
+// translators: placeholder is an order number.
+$order_number = '<a href="' . esc_url( $order->get_edit_order_url() ) . '" aria-label="' . esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ) . '">' .
+			sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) ) . // translators: placeholder is an order number.
+		'</a>';
+
+// Relationship column
+$relationship = esc_html( $order->get_meta( '_relationship' ) );
+
+// Date created column
+$date_created = $order->get_date_created();
+
+if ( $date_created ) {
+	$t_time          = $order->get_date_created()->date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) );
+	$date_to_display = ucfirst( wcs_get_human_time_diff( $date_created->getTimestamp() ) );
+} else {
+	$t_time          = __( 'Unpublished', 'woocommerce-subscriptions' );
+	$date_to_display = $t_time;
+}
+
+if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
+	// Backwards compatibility for third-parties using the generic WP post time filter.
+	// Only apply this filter if HPOS is not enabled, as the filter is not compatible with HPOS.
+	$date_to_display = apply_filters( 'post_date_column_time', $date_to_display, get_post( $order->get_id() ) );
+}
+
+$date_created = '<abbr title="' . esc_attr( $t_time ) . '">' . esc_html( apply_filters( 'wc_subscriptions_related_order_date_column', $date_to_display, $order ) ) . '</abbr>';
+
+// Status column
+$classes = array(
+	'order-status',
+	sanitize_html_class( 'status-' . $order->get_status() ),
+);
+
+if ( wcs_is_subscription( $order ) ) {
+	$status_name = wcs_get_subscription_status_name( $order->get_status() );
+	$classes[]   = 'subscription-status';
+} else {
+	$status_name = wc_get_order_status_name( $order->get_status() );
+}
+
+$status = '<mark class="' . esc_attr( implode( ' ', $classes ) ) . '"><span>' . esc_html( $status_name ) . '</span></mark>';
+
+// Total column
+$total = '<span class="amount">' . wp_kses( $order->get_formatted_order_total(), array( 'small' => array(), 'span' => array( 'class' => array() ), 'del' => array(), 'ins' => array() ) ) . '</span>';
+
+$columns = array(
+	$order_number,
+	$relationship,
+	$date_created,
+	$status,
+	$total,
+);
+
+$columns = apply_filters( 'wcs_related_orders_table_row_columns', $columns );
+
 ?>
 <tr>
-	<td>
-		<?php // translators: placeholder is an order number. ?>
-		<a href="<?php echo esc_url( $order->get_edit_order_url() ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Edit order number %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) ); ?>">
-			<?php
-			// translators: placeholder is an order number.
-			echo sprintf( esc_html_x( '#%s', 'hash before order number', 'woocommerce-subscriptions' ), esc_html( $order->get_order_number() ) );
-			?>
-		</a>
-	</td>
-	<td>
-		<?php echo esc_html( $order->get_meta( '_relationship' ) ); ?>
-	</td>
-	<td>
-		<?php
-		$date_created = $order->get_date_created();
-
-		if ( $date_created ) {
-			$t_time          = $order->get_date_created()->date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) );
-			$date_to_display = ucfirst( wcs_get_human_time_diff( $date_created->getTimestamp() ) );
-		} else {
-			$t_time          = __( 'Unpublished', 'woocommerce-subscriptions' );
-			$date_to_display = $t_time;
-		}
-
-		if ( ! wcs_is_custom_order_tables_usage_enabled() ) {
-			// Backwards compatibility for third-parties using the generic WP post time filter.
-			// Only apply this filter if HPOS is not enabled, as the filter is not compatible with HPOS.
-			$date_to_display = apply_filters( 'post_date_column_time', $date_to_display, get_post( $order->get_id() ) );
-		}
-
-		?>
-		<abbr title="<?php echo esc_attr( $t_time ); ?>">
-			<?php echo esc_html( apply_filters( 'wc_subscriptions_related_order_date_column', $date_to_display, $order ) ); ?>
-		</abbr>
-	</td>
-	<td>
-		<?php
-		$classes = array(
-			'order-status',
-			sanitize_html_class( 'status-' . $order->get_status() ),
-		);
-
-		if ( wcs_is_subscription( $order ) ) {
-			$status_name = wcs_get_subscription_status_name( $order->get_status() );
-			$classes[]   = 'subscription-status';
-		} else {
-			$status_name = wc_get_order_status_name( $order->get_status() );
-		}
-
-		printf( '<mark class="%s"><span>%s</span></mark>', esc_attr( implode( ' ', $classes ) ), esc_html( $status_name ) );
-		?>
-	</td>
-	<td>
-		<span class="amount"><?php echo wp_kses( $order->get_formatted_order_total(), array( 'small' => array(), 'span' => array( 'class' => array() ), 'del' => array(), 'ins' => array() ) ); // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound ?></span>
-	</td>
+	<?php foreach ( $columns as $column ) { ?>
+		<td>
+			<?php echo $column; ?>
+		</td>
+	<?php } ?>
 </tr>

--- a/includes/admin/meta-boxes/views/html-related-orders-table.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-table.php
@@ -10,16 +10,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+$columns = array(
+	esc_html( 'Order Number', 'woocommerce-subscriptions' ),
+	esc_html( 'Relationship', 'woocommerce-subscriptions' ),
+	esc_html( 'Date', 'woocommerce-subscriptions' ),
+	esc_html( 'Status', 'woocommerce-subscriptions' ),
+	esc_html_x( 'Total', 'table heading', 'woocommerce-subscriptions' ),
+);
+
+$columns = apply_filters( 'wcs_related_orders_table_header_columns', $columns );
+
 ?>
 <div class="woocommerce_subscriptions_related_orders">
 	<table>
 		<thead>
 			<tr>
-				<th><?php esc_html_e( 'Order Number', 'woocommerce-subscriptions' ); ?></th>
-				<th><?php esc_html_e( 'Relationship', 'woocommerce-subscriptions' ); ?></th>
-				<th><?php esc_html_e( 'Date', 'woocommerce-subscriptions' ); ?></th>
-				<th><?php esc_html_e( 'Status', 'woocommerce-subscriptions' ); ?></th>
-				<th><?php echo esc_html_x( 'Total', 'table heading', 'woocommerce-subscriptions' ); ?></th>
+				<?php foreach ( $columns as $row ) { ?>
+					<th><?php echo $row ?></th>
+				<?php } ?>	
 			</tr>
 		</thead>
 		<tbody>

--- a/includes/admin/meta-boxes/views/html-related-orders-table.php
+++ b/includes/admin/meta-boxes/views/html-related-orders-table.php
@@ -11,10 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $columns = array(
-	esc_html( 'Order Number', 'woocommerce-subscriptions' ),
-	esc_html( 'Relationship', 'woocommerce-subscriptions' ),
-	esc_html( 'Date', 'woocommerce-subscriptions' ),
-	esc_html( 'Status', 'woocommerce-subscriptions' ),
+	esc_html__( 'Order Number', 'woocommerce-subscriptions' ),
+	esc_html__( 'Relationship', 'woocommerce-subscriptions' ),
+	esc_html__( 'Date', 'woocommerce-subscriptions' ),
+	esc_html__( 'Status', 'woocommerce-subscriptions' ),
 	esc_html_x( 'Total', 'table heading', 'woocommerce-subscriptions' ),
 );
 
@@ -26,7 +26,7 @@ $columns = apply_filters( 'wcs_related_orders_table_header_columns', $columns );
 		<thead>
 			<tr>
 				<?php foreach ( $columns as $row ) { ?>
-					<th><?php echo $row ?></th>
+					<th><?php echo wp_kses_post( $row ); ?></th>
 				<?php } ?>	
 			</tr>
 		</thead>


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4763

## Description
This PR adds filters to allow developers to include more columns to the Related Orders on the subscription edit order page on /wp-admin

## How to test this PR
- Checkout to this PR branch
- Add the following hooks to your functions.php file
```
function wcs_related_orders_table_header_columns( $columns ) {
	$columns[] = esc_html( 'test', 'woocommerce-subscriptions' );
	return $columns;
}
add_filter( 'wcs_related_orders_table_header_columns', 'wcs_related_orders_table_header_columns' );

function wcs_related_orders_table_row_columns( $columns ) {
	$columns[] = esc_html( 'test', 'woocommerce-subscriptions' );
	return $columns;
}
add_filter( 'wcs_related_orders_table_row_columns', 'wcs_related_orders_table_row_columns' );
```

- Edit a subscription
- Scroll down to the Related Orders section
- Make sure a test column was added

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
