### PR TITLE
Fixes various issues related to bulk deleting/regenerating Related Orders cache with HPOS enabled + syncing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@
 * Update - Reduced duplicate queries when fetching multiple subscription related orders types.
 * Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 * Update - Improved performance on the Orders list table when rendering the Subscription Relationship column.
-* Update - Improved performance of the Create Related Orders Cache tool found under WooCommerce > Status > Tools.
+* Update - Improved performance of the Generate Related Order Cache tool found under WooCommerce > Status > Tools.
 * Fix - Updated subscription email item table template to align with WooCommerce 9.7 email improvements.
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,10 +6,13 @@
 * Update - Reduced duplicate queries when fetching multiple subscription related orders types.
 * Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 * Update - Improved performance on the Orders list table when rendering the Subscription Relationship column.
+* Update - Improved performance of the Create Related Orders Cache tool found under WooCommerce > Status > Tools.
 * Fix - Updated subscription email item table template to align with WooCommerce 9.7 email improvements.
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.
 * Fix - Ensure custom placeholders (time_until_renewal, customers_first_name) are included in customer notification email previews.
+* Fix - For stores with HPOS + compatibility mode enabled, using the bulk delete related orders cache tool was not correctly deleting the meta from the WP Posts table.
+* Fix - Prevent empty strings being saved in related orders cache ID meta when backfilling order data to the WP Posts table.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 
 = 8.0.1 - 2025-02-13 =

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -872,6 +872,10 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 		global $wpdb;
 
 		$wpdb->delete( self::get_meta_table_name(), [ 'meta_key' => $meta_key ], [ '%s' ] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+
+		if ( wcs_is_custom_order_tables_data_sync_enabled() ) {
+			$this->get_cpt_data_store_instance()->delete_all_metadata_by_key( $meta_key );
+		}
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -873,7 +873,8 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 
 		$wpdb->delete( self::get_meta_table_name(), [ 'meta_key' => $meta_key ], [ '%s' ] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 
-		if ( wcs_is_custom_order_tables_data_sync_enabled() ) {
+		// If custom order tables is enabled and data syncing is enabled, delete the meta from the custom order tables.
+		if ( wcs_is_custom_order_tables_usage_enabled() && wcs_is_custom_order_tables_data_sync_enabled() ) {
 			$this->get_cpt_data_store_instance()->delete_all_metadata_by_key( $meta_key );
 		}
 	}

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -318,9 +318,6 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			$this->update_modified_date_for_related_order_cache( $subscription, $related_order_ids, $current_metadata );
 		}
 
-		// Check if HPOS and data syncing is enabled then manually backfill the related orders cache values to WP Posts table.
-		$this->maybe_backfill_related_order_cache( $subscription, $relation_type, $new_metadata );
-
 		// If there is metadata for this key, update it, otherwise add it.
 		if ( $current_metadata ) {
 			$new_metadata['id'] = $current_metadata->meta_id;
@@ -344,8 +341,12 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 * @param WC_Subscription $subscription  The subscription object to backfill.
 	 * @param string          $relation_type The related order relationship type. Can be 'renewal', 'switch' or 'resubscribe'.
 	 * @param array           $metadata      The metadata to set update/add in the CPT data store. Should be an array with 'key' and 'value' keys.
+	 *
+	 * @deprecated 7.3.0 - Backfilling is already handled by the Order/Subscriptions Data Store.
 	 */
 	protected function maybe_backfill_related_order_cache( $subscription, $relation_type, $metadata ) {
+		wcs_deprecated_function( __METHOD__, '7.3.0' );
+
 		if ( ! wcs_is_custom_order_tables_usage_enabled() || ! wcs_is_custom_order_tables_data_sync_enabled() || empty( $metadata['key'] ) ) {
 			return;
 		}

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -555,7 +555,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			$ids   = wcs_get_orders_with_meta_query(
 				[
 					'limit'      => $limit,
-					'fields'     => 'ids',
+					'return'     => 'ids',
 					'orderby'    => 'ID',
 					'order'      => 'ASC',
 					'type'       => 'shop_subscription',

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -321,10 +321,15 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		// If there is metadata for this key, update it, otherwise add it.
 		if ( $current_metadata ) {
 			$new_metadata['id'] = $current_metadata->meta_id;
-			return $subscription_data_store->update_meta( $subscription, (object) $new_metadata );
+			$return             = $subscription_data_store->update_meta( $subscription, (object) $new_metadata );
 		} else {
-			return $subscription_data_store->add_meta( $subscription, (object) $new_metadata );
+			$return = $subscription_data_store->add_meta( $subscription, (object) $new_metadata );
 		}
+
+		do_action( 'woocommerce_update_order', $subscription->get_id(), $subscription );
+		do_action( 'woocommerce_update_subscription', $subscription->get_id(), $subscription );
+
+		return $return;
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -326,6 +326,12 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			$return = $subscription_data_store->add_meta( $subscription, (object) $new_metadata );
 		}
 
+		/**
+		 * Trigger update actions after modifying the subscription's related order cache metadata.
+		 *
+		 * This ensures that functions fired after a subscription update, such as webhooks and those in the DataSynchronizer,
+		 * which sync CPT post data to HPOS tables, are executed.
+		 */
 		do_action( 'woocommerce_update_order', $subscription->get_id(), $subscription );
 		do_action( 'woocommerce_update_subscription', $subscription->get_id(), $subscription );
 

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -633,12 +633,11 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	public function update_items_cache( $subscription_id ) {
 		$subscription = wcs_get_subscription( $subscription_id );
 
-		if ( $subscription ) {
-			foreach ( $this->get_relation_types() as $relation_type ) {
-				// Getting the related IDs also sets the cache when it's not already set
-				$this->get_related_order_ids( $subscription, $relation_type );
-			}
+		if ( ! $subscription ) {
+			return;
 		}
+
+		$this->get_related_order_ids_by_types( $subscription, $this->get_relation_types() );
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -306,7 +306,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			}
 		}
 
-		$subscription_data_store = WC_Data_Store::load( 'subscription' );
+		$subscription_data_store = $subscription->get_data_store();
 		$current_metadata        = $this->get_related_order_metadata( $subscription, $relation_type );
 		$new_metadata            = array(
 			'key'   => $this->get_cache_meta_key( $relation_type ),
@@ -390,7 +390,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 				$metadata = $this->get_related_order_metadata( $subscription, $possible_relation_type );
 
 				if ( $metadata ) {
-					WC_Data_Store::load( 'subscription' )->delete_meta( $subscription, (object) [ 'id' => $metadata->meta_id ] );
+					$subscription->get_data_store()->delete_meta( $subscription, (object) [ 'id' => $metadata->meta_id ] );
 				}
 			}
 		}
@@ -659,7 +659,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	protected function get_related_order_metadata( WC_Subscription $subscription, $relation_type, $data_store = null ) {
 		$cache_meta_key = $this->get_cache_meta_key( $relation_type );
-		$data_store     = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
+		$data_store     = $data_store ?? $subscription->get_data_store();
 
 		foreach ( $this->get_subscription_meta( $subscription, $data_store ) as $meta ) {
 			if ( isset( $meta->meta_key ) && $cache_meta_key === $meta->meta_key ) {
@@ -704,11 +704,12 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	private function get_subscription_meta( WC_Subscription $subscription, $data_store ) {
 		$subscription_id     = $subscription->get_id();
-		$is_batch_processing = isset( self::$batch_processing_related_orders[ $subscription_id ] );
+		$cache_key           = $this->get_batch_processing_cache_key( $subscription, $data_store );
+		$is_batch_processing = $this->is_batch_processing( $cache_key );
 
-		// If we are in batch processing mode, return the cached meta data.
-		if ( $is_batch_processing && isset( self::$subscription_meta_cache[ $subscription_id ] ) ) {
-			return self::$subscription_meta_cache[ $subscription_id ];
+		// If we are in batch processing mode, and there are cached results return the cached meta data.
+		if ( $is_batch_processing && isset( self::$subscription_meta_cache[ $cache_key ] ) ) {
+			return self::$subscription_meta_cache[ $cache_key ];
 		}
 
 		/**
@@ -724,9 +725,9 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$subscription_meta            = $data_store->read_meta( $subscription );
 		self::$override_ignored_props = false;
 
-		// If we are in batch processing mode, cache the meta data.
+		// If we are in batch processing mode, cache the meta data so it can be returned for subsequent calls.
 		if ( $is_batch_processing ) {
-			self::$subscription_meta_cache[ $subscription_id ] = $subscription_meta;
+			self::$subscription_meta_cache[ $cache_key ] = $subscription_meta;
 		}
 
 		return $subscription_meta;
@@ -750,16 +751,66 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$related_order_ids = [];
 
 		// Declare batch processing mode for this subscription.
-		self::$batch_processing_related_orders[ $subscription_id ] = true;
+		$cache_key = $this->start_batch_processing_mode( $subscription );
 
 		foreach ( $related_order_types as $relation_type ) {
 			$related_order_ids[ $relation_type ] = $this->get_related_order_ids( $subscription, $relation_type );
 		}
 
-		// Unset the batch processing mode for this subscription.
-		unset( self::$batch_processing_related_orders[ $subscription_id ] );
-		unset( self::$subscription_meta_cache[ $subscription_id ] );
+		$this->stop_batch_processing_mode( $cache_key );
 
 		return $related_order_ids;
+	}
+
+	/**
+	 * Starts batch processing mode for a subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription to start batch processing mode for.
+	 * @return string The cache key for the subscription.
+	 */
+	private function start_batch_processing_mode( $subscription ) {
+		$cache_key = $this->get_batch_processing_cache_key( $subscription );
+
+		self::$batch_processing_related_orders[ $cache_key ] = true;
+		return $cache_key;
+	}
+
+	/**
+	 * Stops batch processing mode for a subscription.
+	 *
+	 * Destroys the cache and removes the cache key.
+	 *
+	 * @param string $cache_key The batch processing cache key.
+	 */
+	private function stop_batch_processing_mode( $cache_key ) {
+		unset( self::$batch_processing_related_orders[ $cache_key ] );
+		unset( self::$subscription_meta_cache[ $cache_key ] );
+	}
+
+	/**
+	 * Checks if batch processing mode is active for a subscription.
+	 *
+	 * @param string $cache_key The batch processing cache key.
+	 * @return bool True if batch processing mode is active, false otherwise.
+	 */
+	private function is_batch_processing( $cache_key ) {
+		return isset( self::$batch_processing_related_orders[ $cache_key ] );
+	}
+
+	/**
+	 * Gets the batch processing cache key for a subscription.
+	 *
+	 * The cache key is a unique combination of the subscription ID and the data store class name.
+	 *
+	 * @param WC_Subscription $subscription The subscription to get the cache key for.
+	 * @param bool|object     $data_store   The data store which will be used to read the subscription meta. Defaults to the current subscription's data store.
+	 *
+	 * @return string The cache key for the subscription.
+	 */
+	private function get_batch_processing_cache_key( $subscription, $data_store = null ) {
+		// If no data store is provided, use the subscription object's data store or load the default data store if no subscription data store is found.
+		$data_store       = $data_store ?? $subscription->get_data_store() ?? WC_Data_Store::load( 'subscriptions' );
+		$data_store_class = is_a( $data_store, 'WC_Data_Store' ) ? $data_store->get_current_class_name() : '';
+		return $data_store_class . '-' . $subscription->get_id();
 	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -78,6 +78,13 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	);
 
 	/**
+	 * The data store instance for the custom order tables.
+	 *
+	 * @var WCS_Orders_Table_Subscription_Data_Store
+	 */
+	protected $orders_table_data_store;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -615,6 +622,11 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		$meta_value = null; // Delete any values.
 		$delete_all = true;
 		delete_metadata( 'post', $id, $meta_key, $meta_value, $delete_all );
+
+		// If custom order tables is not enabled, but Data Syncing is enabled, delete the meta from the custom order tables.
+		if ( ! wcs_is_custom_order_tables_usage_enabled() && wcs_is_custom_order_tables_data_sync_enabled() ) {
+			$this->get_cot_data_store_instance()->delete_all_metadata_by_key( $meta_key );
+		}
 	}
 
 	/**
@@ -775,5 +787,18 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		if ( ! wcs_is_woocommerce_pre( '8.1' ) && wcs_is_woocommerce_pre( '8.4' ) ) {
 			delete_post_meta( $subscription->get_id(), "_subscription_{$relationship_type}_order_ids_cache" );
 		}
+	}
+
+	/**
+	 * Get the data store instance for Order Tables data store.
+	 *
+	 * @return WCS_Orders_Table_Subscription_Data_Store
+	 */
+	public function get_cot_data_store_instance() {
+		if ( ! isset( $this->orders_table_data_store ) ) {
+			$this->orders_table_data_store = new WCS_Orders_Table_Subscription_Data_Store();
+		}
+
+		return $this->orders_table_data_store;
 	}
 }

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -715,7 +715,10 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 */
 	public function set_renewal_order_ids_cache( $subscription, $renewal_order_ids ) {
 		$this->cleanup_backfill_related_order_cache_duplicates( $subscription, 'renewal' );
-		update_post_meta( $subscription->get_id(), '_subscription_renewal_order_ids_cache', $renewal_order_ids );
+
+		if ( '' !== $renewal_order_ids ) {
+			update_post_meta( $subscription->get_id(), '_subscription_renewal_order_ids_cache', $renewal_order_ids );
+		}
 	}
 
 	/**
@@ -729,7 +732,10 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 */
 	public function set_resubscribe_order_ids_cache( $subscription, $resubscribe_order_ids ) {
 		$this->cleanup_backfill_related_order_cache_duplicates( $subscription, 'resubscribe' );
-		update_post_meta( $subscription->get_id(), '_subscription_resubscribe_order_ids_cache', $resubscribe_order_ids );
+
+		if ( '' !== $resubscribe_order_ids ) {
+			update_post_meta( $subscription->get_id(), '_subscription_resubscribe_order_ids_cache', $resubscribe_order_ids );
+		}
 	}
 
 	/**
@@ -743,7 +749,10 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 	 */
 	public function set_switch_order_ids_cache( $subscription, $switch_order_ids ) {
 		$this->cleanup_backfill_related_order_cache_duplicates( $subscription, 'switch' );
-		update_post_meta( $subscription->get_id(), '_subscription_switch_order_ids_cache', $switch_order_ids );
+
+		if ( '' !== $switch_order_ids ) {
+			update_post_meta( $subscription->get_id(), '_subscription_switch_order_ids_cache', $switch_order_ids );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

While testing a recent PR, I discovered an issue on my store with HPOS + Syncing enabled where my related orders cache meta was being duplicated in the postmeta table. This was resulting in failed attempts to process renewal payments due to `get_last_order()` returning the wrong order ID from the cache:

| Example of duplicated/empty meta | Order notes on renewal |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/05ac71b2-445d-4a1a-b885-f86c5d51ef55) | ![image](https://github.com/user-attachments/assets/1b2cdf49-3f5e-4da8-a84e-116db633c2e5) | 

From some initial investigation, I identified a couple of issues that we need to address:

- [x] Using our "Delete Related Order Cache" tool found under **WooCommerce > Status > Tools**. This tool was not backfilling the deletions from the postmeta table. When regenerating the cache meta, this leads to `add_post_meta()` calls resulting in new/duplicate rows being added to the postmeta table.
  - Fixed in eb8d24fe6e42d3cb592d3548a8c9f909b70cd6d3. This commit ensures we're deleting the data from postmeta table if syncing is enabled.

Even with this change, there are still other issues I noticed:

- Empty cache meta values being backfilled to the postmeta table
- Duplicate cache meta values being written to the postmeta table

I've been doing some debugging with @james-allan and found that duplicate `add_post_meta()` calls are being made back-to-back:

```
[28-Feb-2025 00:53:46 UTC] #0 /Users/matt/local/woo/wp-includes/class-wp-hook.php(324): {closure}(NULL, 66632, '_subscription_s...', '', false)
#1 /Users/matt/local/woo/wp-includes/plugin.php(205): WP_Hook->apply_filters(NULL, Array)
#2 /Users/matt/local/woo/wp-includes/meta.php(80): apply_filters('add_post_metada...', NULL, 66632, '_subscription_s...', '', false)
#3 /Users/matt/local/woo/wp-includes/meta.php(252): add_metadata('post', 66632, '_subscription_s...', '')
#4 /Users/matt/local/woo/wp-includes/post.php(2648): update_metadata('post', 66632, '_subscription_s...', '', '')
#5 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-subscription-data-store-cpt.php(746): update_post_meta(66632, '_subscription_s...', '')
#6 [internal function]: WCS_Subscription_Data_Store_CPT->set_switch_order_ids_cache(Object(WC_Subscription), '')
#7 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(702): call_user_func_array(Array, Array)
#8 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(2926): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->backfill_post_record(Object(WC_Subscription))
#9 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(2900): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->maybe_backfill_post_record(Object(WC_Subscription))
#10 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-orders-table-subscription-data-store.php(543): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->persist_updates(Object(WC_Subscription))
#11 /Users/matt/local/woo/wp-content/plugins/woocommerce/includes/class-wc-data-store.php(196): WCS_Orders_Table_Subscription_Data_Store->update(Object(WC_Subscription))
#12 /Users/matt/local/woo/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php(221): WC_Data_Store->update(Object(WC_Subscription))
#13 /Users/matt/local/woo/wp-content/plugins/woocommerce/includes/class-wc-order.php(271): WC_Abstract_Order->save()
#14 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(3321): WC_Order->save()
#15 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php(3275): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->after_meta_change(Object(WC_Subscription), Object(stdClass))
#16 /Users/matt/local/woo/wp-content/plugins/woocommerce/includes/class-wc-data-store.php(224): Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore->add_meta(Object(WC_Subscription), Object(stdClass))
#17 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(329): WC_Data_Store->__call('add_meta', Array)
#18 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(176): WCS_Related_Order_Store_Cached_CPT->update_related_order_id_cache(Object(WC_Subscription), Array, 'renewal')
#19 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(756): WCS_Related_Order_Store_Cached_CPT->get_related_order_ids(Object(WC_Subscription), 'renewal')
#20 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(2157): WCS_Related_Order_Store_Cached_CPT->get_related_order_ids_by_types(Object(WC_Subscription), Array)
#21 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(2190): WC_Subscription->get_related_order_ids('renewal')
#22 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(1256): WC_Subscription->get_last_order('all')
#23 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(1125): WC_Subscription->get_related_orders_date('date_created', 'last')
#24 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(1359): WC_Subscription->get_date('last_order_date...', 'gmt')
#25 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/admin/class-wcs-admin-post-types.php(689): WC_Subscription->get_time('last_order_date...')
#26 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/admin/class-wcs-admin-post-types.php(666): WCS_Admin_Post_Types::get_date_column_content(Object(WC_Subscription), 'last_payment_da...')
#27 /Users/matt/local/woo/wp-includes/class-wp-hook.php(324): WCS_Admin_Post_Types->render_shop_subscription_columns('last_payment_da...', Object(WC_Subscription))
#28 /Users/matt/local/woo/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#29 /Users/matt/local/woo/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#30 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php(184): do_action('woocommerce_sho...', 'last_payment_da...', Object(WC_Subscription))
#31 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1802): Automattic\WooCommerce\Internal\Admin\Orders\ListTable->column_default(Object(WC_Subscription), 'last_payment_da...')
#32 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php(148): WP_List_Table->single_row_columns(Object(WC_Subscription))
#33 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1727): Automattic\WooCommerce\Internal\Admin\Orders\ListTable->single_row(Object(WC_Subscription))
#34 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1712): WP_List_Table->display_rows()
#35 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1639): WP_List_Table->display_rows_or_placeholder()
#36 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php(267): WP_List_Table->display()
#37 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php(299): Automattic\WooCommerce\Internal\Admin\Orders\ListTable->display()
#38 /Users/matt/local/woo/wp-includes/class-wp-hook.php(324): Automattic\WooCommerce\Internal\Admin\Orders\PageController->output('')
#39 /Users/matt/local/woo/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#40 /Users/matt/local/woo/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#41 /Users/matt/local/woo/wp-admin/admin.php(259): do_action('woocommerce_pag...')
#42 /Users/matt/.composer/vendor/laravel/valet/server.php(110): require('/Users/matt/loc...')
#43 {main}
[28-Feb-2025 00:53:46 UTC] #0 /Users/matt/local/woo/wp-includes/class-wp-hook.php(324): {closure}(NULL, 66632, '_subscription_s...', Array, false)
#1 /Users/matt/local/woo/wp-includes/plugin.php(205): WP_Hook->apply_filters(NULL, Array)
#2 /Users/matt/local/woo/wp-includes/meta.php(80): apply_filters('add_post_metada...', NULL, 66632, '_subscription_s...', Array, false)
#3 /Users/matt/local/woo/wp-content/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php(144): add_metadata('post', 66632, '_subscription_s...', Array, false)
#4 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(360): WC_Data_Store_WP->add_meta(Object(WC_Subscription), Object(stdClass))
#5 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(322): WCS_Related_Order_Store_Cached_CPT->maybe_backfill_related_order_cache(Object(WC_Subscription), 'switch', Array)
#6 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(176): WCS_Related_Order_Store_Cached_CPT->update_related_order_id_cache(Object(WC_Subscription), Array, 'switch')
#7 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/data-stores/class-wcs-related-order-store-cached-cpt.php(756): WCS_Related_Order_Store_Cached_CPT->get_related_order_ids(Object(WC_Subscription), 'switch')
#8 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(2157): WCS_Related_Order_Store_Cached_CPT->get_related_order_ids_by_types(Object(WC_Subscription), Array)
#9 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php(2099): WC_Subscription->get_related_order_ids(Array, 'grouped')
#10 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/admin/class-wcs-admin-post-types.php(1141): WC_Subscription->get_related_orders()
#11 /Users/matt/local/woo/wp-content/plugins/woocommerce-subscriptions-core/includes/admin/class-wcs-admin-post-types.php(670): WCS_Admin_Post_Types->get_related_orders_link(Object(WC_Subscription))
#12 /Users/matt/local/woo/wp-includes/class-wp-hook.php(324): WCS_Admin_Post_Types->render_shop_subscription_columns('orders', Object(WC_Subscription))
#13 /Users/matt/local/woo/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#14 /Users/matt/local/woo/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#15 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php(184): do_action('woocommerce_sho...', 'orders', Object(WC_Subscription))
#16 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1802): Automattic\WooCommerce\Internal\Admin\Orders\ListTable->column_default(Object(WC_Subscription), 'orders')
#17 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php(148): WP_List_Table->single_row_columns(Object(WC_Subscription))
#18 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1727): Automattic\WooCommerce\Internal\Admin\Orders\ListTable->single_row(Object(WC_Subscription))
#19 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1712): WP_List_Table->display_rows()
#20 /Users/matt/local/woo/wp-admin/includes/class-wp-list-table.php(1639): WP_List_Table->display_rows_or_placeholder()
#21 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php(267): WP_List_Table->display()
#22 /Users/matt/local/woo/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php(299): Automattic\WooCommerce\Internal\Admin\Orders\ListTable->display()
#23 /Users/matt/local/woo/wp-includes/class-wp-hook.php(324): Automattic\WooCommerce\Internal\Admin\Orders\PageController->output('')
#24 /Users/matt/local/woo/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#25 /Users/matt/local/woo/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#26 /Users/matt/local/woo/wp-admin/admin.php(259): do_action('woocommerce_pag...')
#27 /Users/matt/.composer/vendor/laravel/valet/server.php(110): require('/Users/matt/loc...')
#28 {main}
```

There are multiple commits that aims to mitigate these issues:
- [560587a](https://github.com/Automattic/woocommerce-subscriptions-core/pull/800/commits/560587a26ca03980af0057b7082ec9057aa96a39) Don't manually backfill related order cache values. Since we're already calling the datastore `add_meta()` & `update_meta()` and these functions handle backfilling, we don't need to implement this ourselves.
- [5d49699](https://github.com/Automattic/woocommerce-subscriptions-core/pull/800/commits/5d496996181a60489021e043e46c05623a321da0) `backfill_post_record()` can result in calling our related order cache setters with empty string values, as this is the default value returned by our getters (i.e. `get_renewal_order_ids_cache()`) when no there's no related orders cache set. This change prevents empty string values being set.

But wait... there's more... While poking around and testing our related orders caching tools, I noticed our generator could be improved and so I've pushed up 2 commits to address these issues:

1. When fetching the list of subscriptions we expected only a list of subscription IDs but instead we were fetching the whole subscription object due to the incorrect param being used. Fixed in [cf47234](https://github.com/Automattic/woocommerce-subscriptions-core/pull/800/commits/cf472344b68b87ea5b69fb34e24964ae19f7589b)
2. When bulk generating the related order caches, we can now use the new batch processor approach to avoid reading the subscription every time. Fixed in [850c905](https://github.com/Automattic/woocommerce-subscriptions-core/pull/800/commits/850c905a47f040d0fd64d317362f5900a665b8e8)

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

These changes involves critical flows of subscriptions which are used throughout the renewal process, date calculations, switch calculations and displaying/calculating values all across the frontend/backend UIs.

While testing, look out for `_subscription_{type}_order_ids_cache` values that ahve:
- Empty string values
- Duplicate rows in postmeta/hpos tables
- Exist in HPOS tables but not in the other (when syncing is enabled)

HPOS enabled
 - [ ] Process a renewal order
 - [ ] Process a resubscribe :x: Will be fixed in https://github.com/woocommerce/woocommerce-subscriptions/issues/4816
 - [ ] Process a switch
 - [ ] Use the bulk delete/create related order caching tools

HPOS disabled
 - [x] Process renewal order
 - [ ] Process resubscribe
 - [x] Process switch
 - [ ] Use the bulk delete/create related order caching tools

HPOS enabled + syncing
 - [ ] Process renewal order
 - [ ] Process resubscribe :x: Will be fixed in https://github.com/woocommerce/woocommerce-subscriptions/issues/4816
 - [ ] Process switch
 - [ ] Use the bulk delete/create related order caching tools

HPOS disabled + syncing
 - [x] Process renewal order
 - [x] Process resubscribe
 - [x] Process switch
 - [x] Use the bulk delete/create related order caching tools

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
