### PR TITLE
Set the order awaiting payment session arg when a renewal cart is loaded from the session

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 * Update - Improved performance on the Orders list table when rendering the Subscription Relationship column.
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
+* Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 
 = 8.0.1 - 2025-02-13 =

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -113,6 +113,7 @@ class WCS_Cart_Renewal {
 		// Make sure renewal meta data persists between sessions
 		add_filter( 'woocommerce_get_cart_item_from_session', array( &$this, 'get_cart_item_from_session' ), 10, 3 );
 		add_action( 'woocommerce_cart_loaded_from_session', array( &$this, 'cart_items_loaded_from_session' ), 10 );
+		add_action( 'woocommerce_cart_loaded_from_session', array( &$this, 'restore_order_awaiting_payment' ), 10, 1 );
 
 		// Make sure fees are added to the cart
 		add_action( 'woocommerce_cart_calculate_fees', array( &$this, 'maybe_add_fees' ), 10, 1 );
@@ -248,14 +249,16 @@ class WCS_Cart_Renewal {
 	 * @internal Core checkout uses order_awaiting_payment, Blocks checkout uses store_api_draft_order. Both validate the
 	 * cart hash to ensure the order matches the cart.
 	 *
-	 * @param int $order_id The order ID that is awaiting payment, or 0 to unset it.
+	 * @param int|WC_Order $order The order that is awaiting payment, or 0 to unset it.
 	 */
-	protected function set_order_awaiting_payment( $order_id ) {
+	protected function set_order_awaiting_payment( $order ) {
+		$order_id = is_object( $order ) ? $order->get_id() : $order;
+
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
-		if ( $order_id ) {
-			$this->set_cart_hash( $order_id );
+		if ( $order ) {
+			$this->set_cart_hash( $order );
 		}
 	}
 
@@ -1652,6 +1655,28 @@ class WCS_Cart_Renewal {
 		}
 
 		return $has_status;
+	}
+
+	/**
+	 * Restores the order awaiting payment session args if the cart contains a subscription-related order.
+	 *
+	 * It's possible the that order_awaiting_payment and store_api_draft_order session args are not set if those session args are lost due
+	 * to session destruction. This function checks the cart that is being loaded from the session and if the cart contains a
+	 * subscription-related order and if the current user has permission to pay for it. If so, it restores the order awaiting payment
+	 * session args.
+	 *
+	 * @param WC_Cart $cart The cart object.
+	 */
+	public function restore_order_awaiting_payment( $cart ) {
+
+		foreach ( $cart->get_cart() as $cart_item ) {
+			$order = $this->get_order( $cart_item );
+
+			if ( $order && $this->validate_current_user( $order ) ) {
+				$this->set_order_awaiting_payment( $order );
+				return;
+			}
+		}
 	}
 
 	/* Deprecated */

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -252,14 +252,19 @@ class WCS_Cart_Renewal {
 	 * @param int|WC_Order $order_id The order that is awaiting payment, or 0 to unset it.
 	 */
 	protected function set_order_awaiting_payment( $order_id ) {
-		$order_id = is_a( $order_id, 'WC_Abstract_Order' ) ? $order_id->get_id() : $order_id;
+		$order = null;
+
+		if ( is_a( $order_id, 'WC_Abstract_Order' ) ) {
+			$order    = $order_id;
+			$order_id = $order->get_id();
+		}
 
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
-		// Update the cart hash to ensure the order matches the cart.
 		if ( $order_id ) {
-			$this->set_cart_hash( $order_id );
+			// To avoid needing to load the order object, pass it if available, otherwise pass the order ID.
+			$this->set_cart_hash( $order ?? $order_id );
 		}
 	}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1661,9 +1661,10 @@ class WCS_Cart_Renewal {
 	 * Restores the order awaiting payment session args if the cart contains a subscription-related order.
 	 *
 	 * It's possible the that order_awaiting_payment and store_api_draft_order session args are not set if those session args are lost due
-	 * to session destruction. This function checks the cart that is being loaded from the session and if the cart contains a
-	 * subscription-related order and if the current user has permission to pay for it. If so, it restores the order awaiting payment
-	 * session args.
+	 * to session destruction.
+	 *
+	 * This function checks the cart that is being loaded from the session and if the cart contains a subscription-related order and if the
+	 * current user has permission to pay for it. If so, it restores the order awaiting payment session args.
 	 *
 	 * @param WC_Cart $cart The cart object.
 	 */
@@ -1672,8 +1673,12 @@ class WCS_Cart_Renewal {
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$order = $this->get_order( $cart_item );
 
-			if ( $order && $this->validate_current_user( $order ) ) {
-				$this->set_order_awaiting_payment( $order );
+			if ( $order ) {
+				if ( $this->validate_current_user( $order ) ) {
+					$this->set_order_awaiting_payment( $order );
+				}
+
+				// Once we found an order, exit even if the user doesn't have permission to pay for it.
 				return;
 			}
 		}

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -113,7 +113,7 @@ class WCS_Cart_Renewal {
 		// Make sure renewal meta data persists between sessions
 		add_filter( 'woocommerce_get_cart_item_from_session', array( &$this, 'get_cart_item_from_session' ), 10, 3 );
 		add_action( 'woocommerce_cart_loaded_from_session', array( &$this, 'cart_items_loaded_from_session' ), 10 );
-		add_action( 'woocommerce_cart_loaded_from_session', array( &$this, 'restore_order_awaiting_payment' ), 10, 1 );
+		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'restore_order_awaiting_payment' ), 10 );
 
 		// Make sure fees are added to the cart
 		add_action( 'woocommerce_cart_calculate_fees', array( &$this, 'maybe_add_fees' ), 10, 1 );

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -249,16 +249,17 @@ class WCS_Cart_Renewal {
 	 * @internal Core checkout uses order_awaiting_payment, Blocks checkout uses store_api_draft_order. Both validate the
 	 * cart hash to ensure the order matches the cart.
 	 *
-	 * @param int|WC_Order $order The order that is awaiting payment, or 0 to unset it.
+	 * @param int|WC_Order $order_id The order that is awaiting payment, or 0 to unset it.
 	 */
-	protected function set_order_awaiting_payment( $order ) {
-		$order_id = is_object( $order ) ? $order->get_id() : $order;
+	protected function set_order_awaiting_payment( $order_id ) {
+		$order_id = is_a( $order_id, 'WC_Abstract_Order' ) ? $order_id->get_id() : $order_id;
 
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
-		if ( $order ) {
-			$this->set_cart_hash( $order );
+		// Update the cart hash to ensure the order matches the cart.
+		if ( $order_id ) {
+			$this->set_cart_hash( $order_id );
 		}
 	}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1669,7 +1669,9 @@ class WCS_Cart_Renewal {
 	 * @param WC_Cart $cart The cart object.
 	 */
 	public function restore_order_awaiting_payment( $cart ) {
-
+		if ( ! is_a( $cart, WC_Cart::class ) ) {
+			return;
+		}
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$order = $this->get_order( $cart_item );
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1672,17 +1672,22 @@ class WCS_Cart_Renewal {
 		if ( ! is_a( $cart, WC_Cart::class ) ) {
 			return;
 		}
+
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$order = $this->get_order( $cart_item );
 
-			if ( $order ) {
-				if ( $this->validate_current_user( $order ) ) {
-					$this->set_order_awaiting_payment( $order );
-				}
-
-				// Once we found an order, exit even if the user doesn't have permission to pay for it.
-				return;
+			if ( ! $order ) {
+				continue;
 			}
+
+			// If the current user has permission to pay for the order, restore the order awaiting payment session arg.
+			if ( $this->validate_current_user( $order ) ) {
+				$this->set_order_awaiting_payment( $order );
+			}
+
+			// Once we found an order, exit even if the user doesn't have permission to pay for it.
+			return;
+
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4768
## Description

With WooPayments enabled (there are likely other ways to replicate too), paying for a failed/manual renewal order can lead to a new order being created. This new order is unlinked from the subscription. 

**Note:** I've only been able to replicate on JN site with WooPayments enabled.

This PR fixes this issue by making sure we restore the `order_awaiting_payment` and `store_api_draft_order` when a cart containing a renewal order is loaded out of the session.

## How to test this PR

1. Create a fresh JN site with WooCommerce and WooPayments enabled.
2. Onboard to WooPayments in staging mode. 
3. Install the WooCommerce Subscriptions plugin.
4. **Important.** Create a new customer to test on.
6. Create a subscription product. 
7. In an incognito window log into the customer you created at step 4. 
8. Purchase the subscription.
9. **Important.** Fully close the incognito window.
    - This kills the logged in session for the customer requiring them to log in.
11. In your admin window edit the newly purchased subscription. 
12. From the actions dropdown select the **Create pending renewal order** option.
13. Run that action. 
14. Edit the newly created order. 
15. Right click the pay for order link and choose to open the link in an incognito window. 
16. You should be prompted to log in.
17. Login and pay for the order. 
    - Note that the order received page records a different order ID, the original order is still unpaid and the subscription is on-hold. 
    - This new order is also unlinked from any subscription. 
20. Repeat the steps with this branch of subscriptions-core enabled. The order paid should match the original order ID

Video of me replicating it for reference:

https://github.com/user-attachments/assets/18bd8986-be03-4a77-a9e2-94a231cd1154


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
