### PR TITLE
Fix HPOS Sync duplicating related meta caches caused by incorrect handling of batch related order cache requests

### DIFF
--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -807,8 +807,9 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 *
 	 * @return string The cache key for the subscription.
 	 */
-	private function get_batch_processing_cache_key( $subscription, $data_store = false ) {
-		$data_store = $data_store ?? $subscription->get_data_store();
+	private function get_batch_processing_cache_key( $subscription, $data_store = null ) {
+		// If no data store is provided, use the subscription object's data store or load the default data store if no subscription data store is found.
+		$data_store = $data_store ?? $subscription->get_data_store() ?? DataStore::load( 'subscriptions' );
 		return get_class( $data_store ) . '-' . $subscription->get_id();
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -306,7 +306,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 			}
 		}
 
-		$subscription_data_store = WC_Data_Store::load( 'subscription' );
+		$subscription_data_store = $subscription->get_data_store();
 		$current_metadata        = $this->get_related_order_metadata( $subscription, $relation_type );
 		$new_metadata            = array(
 			'key'   => $this->get_cache_meta_key( $relation_type ),
@@ -390,7 +390,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 				$metadata = $this->get_related_order_metadata( $subscription, $possible_relation_type );
 
 				if ( $metadata ) {
-					WC_Data_Store::load( 'subscription' )->delete_meta( $subscription, (object) [ 'id' => $metadata->meta_id ] );
+					$subscription->get_data_store()->delete_meta( $subscription, (object) [ 'id' => $metadata->meta_id ] );
 				}
 			}
 		}
@@ -659,7 +659,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	protected function get_related_order_metadata( WC_Subscription $subscription, $relation_type, $data_store = null ) {
 		$cache_meta_key = $this->get_cache_meta_key( $relation_type );
-		$data_store     = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
+		$data_store     = $data_store ?? $subscription->get_data_store();
 
 		foreach ( $this->get_subscription_meta( $subscription, $data_store ) as $meta ) {
 			if ( isset( $meta->meta_key ) && $cache_meta_key === $meta->meta_key ) {
@@ -704,7 +704,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	private function get_subscription_meta( WC_Subscription $subscription, $data_store ) {
 		$subscription_id     = $subscription->get_id();
-		$cache_key           = $this->get_batch_processing_cache_key( $subscription_id, $data_store );
+		$cache_key           = $this->get_batch_processing_cache_key( $subscription, $data_store );
 		$is_batch_processing = $this->is_batch_processing( $cache_key );
 
 		// If we are in batch processing mode, and there are cached results return the cached meta data.
@@ -751,7 +751,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$related_order_ids = [];
 
 		// Declare batch processing mode for this subscription.
-		$cache_key = $this->start_batch_processing_mode( $subscription_id );
+		$cache_key = $this->start_batch_processing_mode( $subscription );
 
 		foreach ( $related_order_types as $relation_type ) {
 			$related_order_ids[ $relation_type ] = $this->get_related_order_ids( $subscription, $relation_type );
@@ -765,11 +765,11 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	/**
 	 * Starts batch processing mode for a subscription.
 	 *
-	 * @param int $subscription_id The subscription ID to start batch processing mode for.
+	 * @param WC_Subscription $subscription The subscription to start batch processing mode for.
 	 * @return string The cache key for the subscription.
 	 */
-	private function start_batch_processing_mode( $subscription_id ) {
-		$cache_key = $this->get_batch_processing_cache_key( $subscription_id );
+	private function start_batch_processing_mode( $subscription ) {
+		$cache_key = $this->get_batch_processing_cache_key( $subscription );
 
 		self::$batch_processing_related_orders[ $cache_key ] = true;
 		return $cache_key;
@@ -802,13 +802,13 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 *
 	 * The cache key is a unique combination of the subscription ID and the data store class name.
 	 *
-	 * @param int         $subscription_id The subscription ID to get the cache key for.
-	 * @param bool|object $data_store      The data store which will be used to read the subscription meta. Defaults to the current subscription's data store.
+	 * @param WC_Subscription $subscription The subscription to get the cache key for.
+	 * @param bool|object     $data_store   The data store which will be used to read the subscription meta. Defaults to the current subscription's data store.
 	 *
 	 * @return string The cache key for the subscription.
 	 */
-	private function get_batch_processing_cache_key( $subscription_id, $data_store = false ) {
-		$data_store = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
-		return get_class( $data_store ) . '-' . $subscription_id;
+	private function get_batch_processing_cache_key( $subscription, $data_store = false ) {
+		$data_store = $data_store ?? $subscription->get_data_store();
+		return get_class( $data_store ) . '-' . $subscription->get_id();
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -809,7 +809,7 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	private function get_batch_processing_cache_key( $subscription, $data_store = null ) {
 		// If no data store is provided, use the subscription object's data store or load the default data store if no subscription data store is found.
-		$data_store = $data_store ?? $subscription->get_data_store() ?? DataStore::load( 'subscriptions' );
+		$data_store = $data_store ?? $subscription->get_data_store() ?? WC_Data_Store::load( 'subscriptions' );
 		return get_class( $data_store ) . '-' . $subscription->get_id();
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -703,13 +703,11 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 * @return array The subscription's meta data.
 	 */
 	private function get_subscription_meta( WC_Subscription $subscription, $data_store ) {
-		$subscription_id = $subscription->get_id();
-
-		// Generate a unique key for the subscription and data store combination.
+		$subscription_id     = $subscription->get_id();
 		$cache_key           = $this->get_batch_processing_cache_key( $subscription_id, $data_store );
 		$is_batch_processing = $this->is_batch_processing( $cache_key );
 
-		// If we are in batch processing mode, return the cached meta data.
+		// If we are in batch processing mode, and there are cached results return the cached meta data.
 		if ( $is_batch_processing && isset( self::$subscription_meta_cache[ $cache_key ] ) ) {
 			return self::$subscription_meta_cache[ $cache_key ];
 		}
@@ -811,6 +809,6 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	private function get_batch_processing_cache_key( $subscription_id, $data_store = false ) {
 		$data_store = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
-		return $subscription_id . get_class( $data_store );
+		return get_class( $data_store ) . '-' . $subscription_id;
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -809,7 +809,8 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 */
 	private function get_batch_processing_cache_key( $subscription, $data_store = null ) {
 		// If no data store is provided, use the subscription object's data store or load the default data store if no subscription data store is found.
-		$data_store = $data_store ?? $subscription->get_data_store() ?? WC_Data_Store::load( 'subscriptions' );
-		return get_class( $data_store ) . '-' . $subscription->get_id();
+		$data_store       = $data_store ?? $subscription->get_data_store() ?? WC_Data_Store::load( 'subscriptions' );
+		$data_store_class = is_a( $data_store, 'WC_Data_Store' ) ? $data_store->get_current_class_name() : '';
+		return $data_store_class . '-' . $subscription->get_id();
 	}
 }

--- a/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cached-cpt.php
@@ -703,12 +703,15 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 	 * @return array The subscription's meta data.
 	 */
 	private function get_subscription_meta( WC_Subscription $subscription, $data_store ) {
-		$subscription_id     = $subscription->get_id();
-		$is_batch_processing = isset( self::$batch_processing_related_orders[ $subscription_id ] );
+		$subscription_id = $subscription->get_id();
+
+		// Generate a unique key for the subscription and data store combination.
+		$cache_key           = $this->get_batch_processing_cache_key( $subscription_id, $data_store );
+		$is_batch_processing = $this->is_batch_processing( $cache_key );
 
 		// If we are in batch processing mode, return the cached meta data.
-		if ( $is_batch_processing && isset( self::$subscription_meta_cache[ $subscription_id ] ) ) {
-			return self::$subscription_meta_cache[ $subscription_id ];
+		if ( $is_batch_processing && isset( self::$subscription_meta_cache[ $cache_key ] ) ) {
+			return self::$subscription_meta_cache[ $cache_key ];
 		}
 
 		/**
@@ -724,9 +727,9 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$subscription_meta            = $data_store->read_meta( $subscription );
 		self::$override_ignored_props = false;
 
-		// If we are in batch processing mode, cache the meta data.
+		// If we are in batch processing mode, cache the meta data so it can be returned for subsequent calls.
 		if ( $is_batch_processing ) {
-			self::$subscription_meta_cache[ $subscription_id ] = $subscription_meta;
+			self::$subscription_meta_cache[ $cache_key ] = $subscription_meta;
 		}
 
 		return $subscription_meta;
@@ -750,16 +753,64 @@ class WCS_Related_Order_Store_Cached_CPT extends WCS_Related_Order_Store_CPT imp
 		$related_order_ids = [];
 
 		// Declare batch processing mode for this subscription.
-		self::$batch_processing_related_orders[ $subscription_id ] = true;
+		$cache_key = $this->start_batch_processing_mode( $subscription_id );
 
 		foreach ( $related_order_types as $relation_type ) {
 			$related_order_ids[ $relation_type ] = $this->get_related_order_ids( $subscription, $relation_type );
 		}
 
-		// Unset the batch processing mode for this subscription.
-		unset( self::$batch_processing_related_orders[ $subscription_id ] );
-		unset( self::$subscription_meta_cache[ $subscription_id ] );
+		$this->stop_batch_processing_mode( $cache_key );
 
 		return $related_order_ids;
+	}
+
+	/**
+	 * Starts batch processing mode for a subscription.
+	 *
+	 * @param int $subscription_id The subscription ID to start batch processing mode for.
+	 * @return string The cache key for the subscription.
+	 */
+	private function start_batch_processing_mode( $subscription_id ) {
+		$cache_key = $this->get_batch_processing_cache_key( $subscription_id );
+
+		self::$batch_processing_related_orders[ $cache_key ] = true;
+		return $cache_key;
+	}
+
+	/**
+	 * Stops batch processing mode for a subscription.
+	 *
+	 * Destroys the cache and removes the cache key.
+	 *
+	 * @param string $cache_key The batch processing cache key.
+	 */
+	private function stop_batch_processing_mode( $cache_key ) {
+		unset( self::$batch_processing_related_orders[ $cache_key ] );
+		unset( self::$subscription_meta_cache[ $cache_key ] );
+	}
+
+	/**
+	 * Checks if batch processing mode is active for a subscription.
+	 *
+	 * @param string $cache_key The batch processing cache key.
+	 * @return bool True if batch processing mode is active, false otherwise.
+	 */
+	private function is_batch_processing( $cache_key ) {
+		return isset( self::$batch_processing_related_orders[ $cache_key ] );
+	}
+
+	/**
+	 * Gets the batch processing cache key for a subscription.
+	 *
+	 * The cache key is a unique combination of the subscription ID and the data store class name.
+	 *
+	 * @param int         $subscription_id The subscription ID to get the cache key for.
+	 * @param bool|object $data_store      The data store which will be used to read the subscription meta. Defaults to the current subscription's data store.
+	 *
+	 * @return string The cache key for the subscription.
+	 */
+	private function get_batch_processing_cache_key( $subscription_id, $data_store = false ) {
+		$data_store = empty( $data_store ) ? WC_Data_Store::load( 'subscription' ) : $data_store;
+		return $subscription_id . get_class( $data_store );
 	}
 }


### PR DESCRIPTION
## Description

> [!important]
> **This PR is dependant on https://github.com/Automattic/woocommerce-subscriptions-core/pull/800**. It is being merged into that Branch and will be reviewed as a block. 

In https://github.com/Automattic/woocommerce-subscriptions-core/pull/790 I introduced batch reading of subscription related order caches to avoid unnessessarily fetching subscription meta multiple times. 

In that PR I introduced a batch processing concept that enabled the subscription meta to be cached and returned on subsequent calls rather than reading the meta each time. 

There was a bug in that code which only arose when you have HPOS enabled, Data Syncing enabled, and you clear the related order caches. 

In short, when data syncing is enabled, populating an empty related order cache would call `$subscription->add_meta()`. That would trigger data backfilling of the post record to occur and it would attempt to pull the related order cache meta from the WP Post datastore. 

Because my caching approach taken in #790 didn't take into account the different datastore, it would return the results it pulled from the HPOS datastore even though it was requesting the results from the WP Post table.

**This PR fixes that by making sure the subscription meta is cached against a key which takes into account the datastore being used.** 



## How to test this PR


1. Go to **WooCommerce → Settings → Advanced → Features**
2. Enable HPOS and compatibility mode


<img width="1092" alt="Screenshot 2025-03-04 at 6 52 30 pm" src="https://github.com/user-attachments/assets/a6a7fd9a-4469-4ee4-93d0-5c7099bf9991" />


3. Go to **WooCommerce → Status → Tools**
4. Run the **Delete Related Order Cache** tool
5. Go to **WooCommerce → Subscriptions**
6. Look in the postmeta table search for a subscription ID.
   - On `trunk` you should see duplicate meta (see screenshot below).
   - On this branch there should be no duplicate meta keys.

<p align="center">
<img width="980" alt="Screenshot 2025-03-04 at 7 06 46 pm" src="https://github.com/user-attachments/assets/a52d4ff0-0a66-4b6b-8136-f698a8a74507" />
</p> 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
    - No Changelog is necessary because this change was unreleased.
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
