### PR TITLE
Subscription product editor consistency tweaks

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -430,8 +430,13 @@ a.close-subscriptions-search {
 	max-width: 34%;
 	float: right;
 }
-.variable_subscription_pricing_2_3.variable_subscription_trial p.form-row {
+.variable_subscription_pricing_2_3.variable_subscription_pricing p.form-row {
 	margin-bottom: 0;
+}
+#variable_product_options
+  .variable_subscription_pricing_2_3
+  p._subscription_price_field {
+  margin-bottom: 0;
 }
 #variable_product_options
 	.variable_subscription_pricing_2_3
@@ -473,7 +478,6 @@ a.close-subscriptions-search {
 		.variable_subscription_pricing_2_3
 		p._subscription_price_field {
 		width: 100%;
-		margin-bottom: 0;
 	}
 	#variable_product_options
 		.variable_subscription_pricing_2_3
@@ -921,4 +925,7 @@ table.form-table input#woocommerce_subscriptions_customer_notifications_offset {
 }
 #wcs_order_price_lock > .woocommerce-help-tip {
 	margin: 0 8px 0 2px;
+}
+.show_if_subscription .select2-selection, .show_if_variable-subscription .select2-selection {
+	font-size: 14px;
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -465,6 +465,11 @@ a.close-subscriptions-search {
 	.wc_input_subscription_payment_sync_month {
 	max-width: 86%;
 }
+#variable_product_options
+	.variable_subscription_pricing_2_3 .multiple_fields .wrap {
+		display: flex;
+		gap: 12px;
+}
 @media screen and ( max-width: 1190px ) {
 	#variable_product_options
 		.variable_subscription_pricing_2_3

--- a/assets/js/admin/admin.js
+++ b/assets/js/admin/admin.js
@@ -396,7 +396,7 @@ jQuery( function ( $ ) {
 					// Add the subscription price fields above the standard price fields
 					$( this ).insertBefore( $regularPriceRow );
 
-					$trialSignUpRow.insertBefore( $( this ) );
+					$trialSignUpRow.insertAfter( $( this ) );
 
 					// Replace the regular price field with the trial period field
 					$regularPriceRow

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -317,7 +317,7 @@ class WC_Subscriptions_Admin {
 			</label>
 			<span class="wrap">
 				<?php // Translators: %s: formatted example price value. ?>
-				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php printf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), esc_attr( wc_format_localized_price( '5.90' ) ) ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
+				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php echo esc_attr( sprintf( _x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) ) ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>
@@ -356,7 +356,7 @@ class WC_Subscriptions_Admin {
 					// translators: %s is a currency symbol / code
 					'label'             => sprintf( __( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), get_woocommerce_currency_symbol() ),
 					'placeholder'       => // translators: %s the formatted example price value.
-						sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) ),
+						esc_attr( sprintf( _x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) ) ),
 					'description'       => __( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions' ),
 					'desc_tip'          => true,
 					'type'              => 'text',

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -316,10 +316,7 @@ class WC_Subscriptions_Admin {
 				?>
 			</label>
 			<span class="wrap">
-				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php
-					// translators: %s the formatted example price value.
-					echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) );
-				?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
+				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '5.90' ) ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -316,10 +316,12 @@ class WC_Subscriptions_Admin {
 				?>
 			</label>
 			<span class="wrap">
-				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php
-				  // translators: %s the formatted example price value.
-				  echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) );
-				?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
+				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="
+				<?php
+				// translators: %s the formatted example price value.
+				echo esc_attr( sprintf( 'e.g. %s', wc_format_localized_price( '5.90' ) ) );
+				?>
+				" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -316,7 +316,8 @@ class WC_Subscriptions_Admin {
 				?>
 			</label>
 			<span class="wrap">
-				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '5.90' ) ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
+				<?php // Translators: %s: formatted example price value. ?>
+				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php printf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), esc_attr( wc_format_localized_price( '5.90' ) ) ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -318,7 +318,7 @@ class WC_Subscriptions_Admin {
 			<span class="wrap">
 				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php
 				  // translators: %s the formatted example price value.
-				  echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 5.90 ) ) ) );
+				  echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) );
 				?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
@@ -358,7 +358,7 @@ class WC_Subscriptions_Admin {
 					// translators: %s is a currency symbol / code
 					'label'             => sprintf( __( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), get_woocommerce_currency_symbol() ),
 					'placeholder'       => // translators: %s the formatted example price value.
-						sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 9.90 ) ) ) ),
+						sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) ),
 					'description'       => __( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions' ),
 					'desc_tip'          => true,
 					'type'              => 'text',

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -316,12 +316,10 @@ class WC_Subscriptions_Admin {
 				?>
 			</label>
 			<span class="wrap">
-				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="
-				<?php
-				// translators: %s the formatted example price value.
-				echo esc_attr( sprintf( 'e.g. %s', wc_format_localized_price( '5.90' ) ) );
-				?>
-				" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
+				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php
+					// translators: %s the formatted example price value.
+					echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) );
+				?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>
@@ -360,7 +358,7 @@ class WC_Subscriptions_Admin {
 					// translators: %s is a currency symbol / code
 					'label'             => sprintf( __( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), get_woocommerce_currency_symbol() ),
 					'placeholder'       => // translators: %s the formatted example price value.
-						sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) ),
+						sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '5.90' ) ),
 					'description'       => __( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions' ),
 					'desc_tip'          => true,
 					'type'              => 'text',

--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -316,7 +316,10 @@ class WC_Subscriptions_Admin {
 				?>
 			</label>
 			<span class="wrap">
-				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php echo esc_attr_x( 'e.g. 5.90', 'example price', 'woocommerce-subscriptions' ); ?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
+				<input type="text" id="_subscription_price" name="_subscription_price" class="wc_input_price wc_input_subscription_price" placeholder="<?php
+				  // translators: %s the formatted example price value.
+				  echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 5.90 ) ) ) );
+				?>" step="any" min="0" value="<?php echo esc_attr( wc_format_localized_price( $chosen_price ) ); ?>" />
 				<label for="_subscription_period_interval" class="wcs_hidden_label"><?php esc_html_e( 'Subscription interval', 'woocommerce-subscriptions' ); ?></label>
 				<select id="_subscription_period_interval" name="_subscription_period_interval" class="wc_input_subscription_period_interval wc-enhanced-select">
 				<?php foreach ( wcs_get_subscription_period_interval_strings() as $value => $label ) { ?>
@@ -354,7 +357,8 @@ class WC_Subscriptions_Admin {
 					'class'             => 'wc_input_subscription_intial_price wc_input_subscription_initial_price wc_input_price  short',
 					// translators: %s is a currency symbol / code
 					'label'             => sprintf( __( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), get_woocommerce_currency_symbol() ),
-					'placeholder'       => _x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ),
+					'placeholder'       => // translators: %s the formatted example price value.
+						sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 9.90 ) ) ) ),
 					'description'       => __( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions' ),
 					'desc_tip'          => true,
 					'type'              => 'text',

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -15,50 +15,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<div class="variable_subscription_trial variable_subscription_pricing_2_3 show_if_variable-subscription variable_subscription_trial_sign_up" style="display: none">
-	<p class="form-row form-row-first form-field show_if_variable-subscription sign-up-fee-cell">
-		<label for="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]"><?php printf( esc_html__( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) ); ?></label>
-		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ); ?>">
-	</p>
-	<p class="form-row form-row-last show_if_variable-subscription">
-		<label for="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]">
-			<?php esc_html_e( 'Free trial', 'woocommerce-subscriptions' ); ?>
-			<?php // translators: placeholder is trial period validation message if passed an invalid value (e.g. "Trial period can not exceed 4 weeks") ?>
-			<?php echo wcs_help_tip( sprintf( _x( 'An optional period of time to wait before charging the first recurring payment. Any sign up fee will still be charged at the outset of the subscription. %s', 'Trial period dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ), self::get_trial_period_validation_message() ) ); ?>
-		</label>
-		<input type="text" class="wc_input_subscription_trial_length" name="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( WC_Subscriptions_Product::get_trial_length( $variation_product ) ); ?>">
-
-		<label for="variable_subscription_trial_period[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Subscription trial period:', 'woocommerce-subscriptions' ); ?></label>
-		<select name="variable_subscription_trial_period[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_trial_period wc-enhanced-select">
-		<?php foreach ( wcs_get_available_time_periods() as $key => $value ) : ?>
-			<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, WC_Subscriptions_Product::get_trial_period( $variation_product ) ); ?>><?php echo esc_html( $value ); ?></option>
-		<?php endforeach; ?>
-		</select>
-	</p>
-</div>
 <div class="variable_subscription_pricing variable_subscription_pricing_2_3 show_if_variable-subscription" style="display: none">
-	<p class="form-row form-row-first form-field show_if_variable-subscription _subscription_price_field">
+	<p class="form-row dimensions_field form-row-first form-field show_if_variable-subscription _subscription_price_field">
 		<label for="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]">
 			<?php
 			// translators: placeholder is a currency symbol / code
 			printf( esc_html__( 'Subscription price (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) );
 			?>
+			<?php echo wcs_help_tip( _x( 'Choose the subscription price, billing interval and period.', 'woocommerce-subscriptions' ) ); ?>
 		</label>
-		<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ); ?>">
 
-		<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
-		<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval wc-enhanced-select">
-		<?php foreach ( wcs_get_subscription_period_interval_strings() as $key => $value ) : ?>
-			<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, WC_Subscriptions_Product::get_interval( $variation_product ) ); ?>><?php echo esc_html( $value ); ?></option>
-		<?php endforeach; ?>
-		</select>
+		<span class="wrap">
+			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php
+				// translators: %s the formatted example price value.
+				echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 9.90 ) ) ) );
+			?>">
 
-		<label for="variable_subscription_period[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing Period:', 'woocommerce-subscriptions' ); ?></label>
-		<select name="variable_subscription_period[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period wc-enhanced-select">
-		<?php foreach ( wcs_get_subscription_period_strings() as $key => $value ) : ?>
-			<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $billing_period ); ?>><?php echo esc_html( $value ); ?></option>
-		<?php endforeach; ?>
-		</select>
+			<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
+			<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval wc-enhanced-select">
+			<?php foreach ( wcs_get_subscription_period_interval_strings() as $key => $value ) : ?>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, WC_Subscriptions_Product::get_interval( $variation_product ) ); ?>><?php echo esc_html( $value ); ?></option>
+			<?php endforeach; ?>
+			</select>
+
+			<label for="variable_subscription_period[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing Period:', 'woocommerce-subscriptions' ); ?></label>
+			<select name="variable_subscription_period[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period wc-enhanced-select">
+			<?php foreach ( wcs_get_subscription_period_strings() as $key => $value ) : ?>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $billing_period ); ?>><?php echo esc_html( $value ); ?></option>
+			<?php endforeach; ?>
+			</select>
+		</span>
 
 	</p>
 	<p class="form-row form-row-last show_if_variable-subscription _subscription_length_field" style="display: none">
@@ -71,5 +57,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, WC_Subscriptions_Product::get_length( $variation_product ) ); ?>> <?php echo esc_html( $value ); ?></option>
 		<?php endforeach; ?>
 		</select>
+	</p>
+</div>
+<div class="variable_subscription_trial variable_subscription_pricing_2_3 show_if_variable-subscription variable_subscription_trial_sign_up" style="display: none">
+	<p class="form-row form-row-first form-field show_if_variable-subscription sign-up-fee-cell">
+		<label for="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]">
+			<?php printf( esc_html__( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) ); ?>
+			<?php echo wcs_help_tip( _x( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions', 'woocommerce-subscriptions' ) ); ?>
+		</label>
+		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ); ?>">
+	</p>
+	<p class="form-row dimensions_field form-row-last show_if_variable-subscription">
+		<label for="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]">
+		<?php esc_html_e( 'Free trial', 'woocommerce-subscriptions' ); ?>
+			<?php // translators: placeholder is trial period validation message if passed an invalid value (e.g. "Trial period can not exceed 4 weeks") ?>
+			<?php echo wcs_help_tip( sprintf( _x( 'An optional period of time to wait before charging the first recurring payment. Any sign up fee will still be charged at the outset of the subscription. %s', 'Trial period dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ), self::get_trial_period_validation_message() ) ); ?>
+		</label>
+
+		<span class="wrap">
+			<input type="text" class="wc_input_subscription_trial_length" name="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( WC_Subscriptions_Product::get_trial_length( $variation_product ) ); ?>">
+
+			<label for="variable_subscription_trial_period[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Subscription trial period:', 'woocommerce-subscriptions' ); ?></label>
+			<select name="variable_subscription_trial_period[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_trial_period wc-enhanced-select">
+			<?php foreach ( wcs_get_available_time_periods() as $key => $value ) : ?>
+				<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, WC_Subscriptions_Product::get_trial_period( $variation_product ) ); ?>><?php echo esc_html( $value ); ?></option>
+			<?php endforeach; ?>
+			</select>
+		</span>
 	</p>
 </div>

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			// translators: placeholder is a currency symbol / code
 			printf( esc_html__( 'Subscription price (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) );
 			?>
-			<?php echo wcs_help_tip( _x( 'Choose the subscription price, billing interval and period.', 'woocommerce-subscriptions' ) ); ?>
+			<?php echo wcs_help_tip( __( 'Choose the subscription price, billing interval and period.', 'woocommerce-subscriptions' ) ); ?>
 		</label>
 
 		<span class="wrap">
@@ -60,7 +60,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<p class="form-row form-row-first form-field show_if_variable-subscription sign-up-fee-cell">
 		<label for="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]">
 			<?php printf( esc_html__( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) ); ?>
-			<?php echo wcs_help_tip( _x( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions', 'woocommerce-subscriptions' ) ); ?>
+			<?php echo wcs_help_tip( __( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions' ) ); ?>
 		</label>
 		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '9.90' ) ); ?>">
 	</p>

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -26,7 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 
 		<span class="wrap">
-			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '9.90' ) ); ?>">
+			<?php // Translators: %s: formatted example price value. ?>
+			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php printf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), esc_attr( wc_format_localized_price( '9.90' ) ) ); ?>">
 
 			<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
 			<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval wc-enhanced-select">

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -26,10 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 
 		<span class="wrap">
-			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php
-				// translators: %s the formatted example price value.
-				echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) );
-			?>">
+			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '9.90' ) ); ?>">
 
 			<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
 			<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval wc-enhanced-select">
@@ -65,10 +62,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php printf( esc_html__( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) ); ?>
 			<?php echo wcs_help_tip( _x( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions', 'woocommerce-subscriptions' ) ); ?>
 		</label>
-		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php
-			// translators: %s the formatted example price value.
-			echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) );
-		?>">
+		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '9.90' ) ); ?>">
 	</p>
 	<p class="form-row multiple_fields form-row-last show_if_variable-subscription">
 		<label for="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]">

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<span class="wrap">
 			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php
 				// translators: %s the formatted example price value.
-				echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 9.90 ) ) ) );
+				echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) );
 			?>">
 
 			<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
@@ -67,7 +67,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php
 			// translators: %s the formatted example price value.
-			echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 9.90 ) ) ) );
+			echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) );
 		?>">
 	</p>
 	<p class="form-row dimensions_field form-row-last show_if_variable-subscription">

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -45,7 +45,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</span>
 
 	</p>
-	<p class="form-row form-row-last show_if_variable-subscription _subscription_length_field" style="display: none">
+	<p class="form-row form-row-last form-field show_if_variable-subscription _subscription_length_field" style="display: none">
 		<label for="variable_subscription_length[<?php echo esc_attr( $loop ); ?>]">
 			<?php esc_html_e( 'Stop renewing after', 'woocommerce-subscriptions' ); ?>
 			<?php echo wcs_help_tip( _x( 'Automatically stop renewing the subscription after this length of time. This length is in addition to any free trial or amount of time provided before a synchronised first renewal date.', 'Subscription Length dropdown\'s description in pricing fields', 'woocommerce-subscriptions' ) ); ?>
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g.', 'example price', 'woocommerce-subscriptions' ); ?> <?php echo esc_attr( wc_format_localized_price( '9.90' ) ); ?>">
 	</p>
-	<p class="form-row multiple_fields form-row-last show_if_variable-subscription">
+	<p class="form-row multiple_fields form-field form-row-last show_if_variable-subscription">
 		<label for="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]">
 		<?php esc_html_e( 'Free trial', 'woocommerce-subscriptions' ); ?>
 			<?php // translators: placeholder is trial period validation message if passed an invalid value (e.g. "Trial period can not exceed 4 weeks") ?>

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="variable_subscription_pricing variable_subscription_pricing_2_3 show_if_variable-subscription" style="display: none">
-	<p class="form-row dimensions_field form-row-first form-field show_if_variable-subscription _subscription_price_field">
+	<p class="form-row multiple_fields form-row-first form-field show_if_variable-subscription _subscription_price_field">
 		<label for="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]">
 			<?php
 			// translators: placeholder is a currency symbol / code
@@ -70,7 +70,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), wc_format_localized_price( '9.90' ) );
 		?>">
 	</p>
-	<p class="form-row dimensions_field form-row-last show_if_variable-subscription">
+	<p class="form-row multiple_fields form-row-last show_if_variable-subscription">
 		<label for="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]">
 		<?php esc_html_e( 'Free trial', 'woocommerce-subscriptions' ); ?>
 			<?php // translators: placeholder is trial period validation message if passed an invalid value (e.g. "Trial period can not exceed 4 weeks") ?>

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -65,7 +65,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php printf( esc_html__( 'Sign-up fee (%s)', 'woocommerce-subscriptions' ), esc_html( get_woocommerce_currency_symbol() ) ); ?>
 			<?php echo wcs_help_tip( _x( 'Optionally include an amount to be charged at the outset of the subscription. The sign-up fee will be charged immediately, even if the product has a free trial or the payment dates are synced.', 'woocommerce-subscriptions', 'woocommerce-subscriptions' ) ); ?>
 		</label>
-		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr_x( 'e.g. 9.90', 'example price', 'woocommerce-subscriptions' ); ?>">
+		<input type="text" class="wc_input_price wc_input_subscription_intial_price wc_input_subscription_initial_price" name="variable_subscription_sign_up_fee[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_sign_up_fee( $variation_product ) ) ); ?>" placeholder="<?php
+			// translators: %s the formatted example price value.
+			echo sprintf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), str_replace( get_woocommerce_currency_symbol(), '', strip_tags( wc_price( 9.90 ) ) ) );
+		?>">
 	</p>
 	<p class="form-row dimensions_field form-row-last show_if_variable-subscription">
 		<label for="variable_subscription_trial_length[<?php echo esc_attr( $loop ); ?>]">

--- a/templates/admin/html-variation-price.php
+++ b/templates/admin/html-variation-price.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<span class="wrap">
 			<?php // Translators: %s: formatted example price value. ?>
-			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php printf( esc_attr_x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), esc_attr( wc_format_localized_price( '9.90' ) ) ); ?>">
+			<input type="text" class="wc_input_price wc_input_subscription_price" name="variable_subscription_price[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( wc_format_localized_price( WC_Subscriptions_Product::get_regular_price( $variation_product ) ) ); ?>" placeholder="<?php echo esc_attr( sprintf( _x( 'e.g. %s', 'example price', 'woocommerce-subscriptions' ), esc_attr( wc_format_localized_price( '9.90' ) ) ) ); ?>">
 
 			<label for="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wcs_hidden_label"><?php esc_html_e( 'Billing interval:', 'woocommerce-subscriptions' ); ?></label>
 			<select name="variable_subscription_period_interval[<?php echo esc_attr( $loop ); ?>]" class="wc_input_subscription_period_interval wc-enhanced-select">


### PR DESCRIPTION
Fixes woocommerce/woocommerce-subscriptions#4807

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
Fix visual inconsistencies in the subscription and variable subscription editor.

| Before | After |
|-|-|
| <img width="551" alt="Screenshot 2025-03-10 at 10 05 47 PM" src="https://github.com/user-attachments/assets/21be1a53-c5b4-48d2-94af-db5a5e50406e" /> | <img width="551" alt="Screenshot 2025-03-10 at 10 05 19 PM" src="https://github.com/user-attachments/assets/0c79df1c-c55a-4457-b31a-d431aac6d4ee" /> |

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Change the store currency to EUR or another one that do not dot as decimal separator.
2. Create a new simple subscription.
3. The subscription prices dropbox should have the correct font size (14px).
4. The sign-up fee placeholder should use the correct decimal separator.
5. Change to variable subscription.
6. Create variations.
7. Edit one variation.
8. The fields should match woocommerce/woocommerce-subscriptions#4807 requirements.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
