### PR TITLE
Load HTML in product name on shipping rates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Updated subscription email item table template to align with WooCommerce 9.7 email improvements.
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.
+* Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 
 = 8.0.1 - 2025-02-13 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,6 @@
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.
 * Fix - Ensure custom placeholders (time_until_renewal, customers_first_name) are included in customer notification email previews.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
-
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 
 = 8.0.1 - 2025-02-13 =

--- a/includes/wcs-cart-functions.php
+++ b/includes/wcs-cart-functions.php
@@ -108,7 +108,7 @@ function wcs_cart_totals_shipping_html() {
 							<?php wcs_cart_print_shipping_input( $recurring_cart_package_key, $shipping_method ); ?>
 							<?php do_action( 'woocommerce_after_shipping_rate', $shipping_method, $recurring_cart_package_key ); ?>
 							<?php if ( ! empty( $show_package_details ) ) : ?>
-								<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
+								<?php echo '<p class="woocommerce-shipping-contents"><small>' . wp_kses_post( $package_details ) . '</small></p>'; ?>
 							<?php endif; ?>
 							<?php if ( $recurring_rates_match_initial_rates ) : ?>
 								<?php wcs_cart_print_inherit_shipping_flag( $recurring_cart_package_key ); ?>

--- a/templates/cart/cart-recurring-shipping.php
+++ b/templates/cart/cart-recurring-shipping.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endif; ?>
 
 		<?php if ( $show_package_details ) : ?>
-			<?php echo '<p class="woocommerce-shipping-contents"><small>' . esc_html( $package_details ) . '</small></p>'; ?>
+			<?php echo '<p class="woocommerce-shipping-contents"><small>' . wp_kses_post( $package_details ) . '</small></p>'; ?>
 		<?php endif; ?>
 	</td>
 </tr>


### PR DESCRIPTION
Fixes woocommerce/woocommerce-subscriptions#4128

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
> This PR fixes the #762 reverted PR by not using the `woocommerce_cart_item_name` filter, I chose to only remove it because `wp_kses_post` already removes any unsafe HTML tag.

This PR fixes raw HTML being shown to the user on the shipping rates section of the classic cart and checkout page when the product name contains HTML.

| Before | After |
|-|-|
| <img width="348" alt="Screenshot 2025-01-10 at 9 48 11 PM" src="https://github.com/user-attachments/assets/c8a314f2-428e-4520-a60a-fd56399ad2d0" /> | <img width="348" alt="Screenshot 2025-01-10 at 9 48 28 PM" src="https://github.com/user-attachments/assets/801e2c6f-78e3-49ca-8aea-b8470262a560" /> |

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a subscription with HTML in the name.
2. Add this subscription to the cart.
3. Add a normal product to the cart.
4. Access the classic cart or checkout page.
5. The HTML in the product name for the shipping rate is not loaded.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
