### PR TITLE
Increase number of args supported by `wcs_get_subscriptions()`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Reduced duplicate queries when fetching multiple subscription related orders types.
 * Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 * Update - Improved performance on the Orders list table when rendering the Subscription Relationship column.
+* Update - Increase the number of args accepted by wcs_get_subscriptions(), to bring about parity with wc_get_orders().
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 

--- a/tests/unit/test-wcs-functions.php
+++ b/tests/unit/test-wcs-functions.php
@@ -824,9 +824,16 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Deals with cases where we're filtering for status
+	 * Deals with cases where we're querying by status.
+	 *
+	 * Status can be specified in two different ways. Traditionally, via the
+	 * 'subscription_status' argument, but 'status' can also be used directly
+	 * since 7.3.0.
+	 *
+	 * @testWith ["subscription_status"]
+	 *           ["status"]
 	 */
-	public function test_2_wcs_get_subscriptions() {
+	public function test_2_wcs_get_subscriptions( string $status_key ) {
 
 		$subscription_1 = WCS_Helper_Subscription::create_subscription(
 			array(
@@ -877,7 +884,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		);
 
 		// Check for on-hold
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'on-hold' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'on-hold' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -892,7 +899,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Pending
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'pending' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'pending' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 2, count( $subscriptions ) );
@@ -907,7 +914,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Switched
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'switched' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'switched' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -922,7 +929,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Any
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'any' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'any' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 8, count( $subscriptions ) );
@@ -937,14 +944,14 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Trash
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'trash' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'trash' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEmpty( $subscriptions );
 		unset( $subscriptions );
 
 		// Active
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'active' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'active' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -959,7 +966,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Cancelled
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'cancelled' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'cancelled' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -974,7 +981,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Expired
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'expired' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'expired' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -989,7 +996,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// Pending Cancellation
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'pending-cancel' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'pending-cancel' ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -1006,7 +1013,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		$is_hpos_enabled = wcs_is_custom_order_tables_usage_enabled();
 
 		// An invalid status
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => 'rubbish' ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => 'rubbish' ) );
 
 		if ( $is_hpos_enabled ) {
 			// No subscriptions should match the invalid status.
@@ -1029,7 +1036,7 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 		unset( $subscriptions );
 
 		// An invalid status is ignored and does not apply as a clause to the query, while the valid status still applies.
-		$subscriptions = wcs_get_subscriptions( array( 'subscription_status' => [ 'rubbish', 'active' ] ) );
+		$subscriptions = wcs_get_subscriptions( array( $status_key => [ 'rubbish', 'active' ] ) );
 
 		$this->assertIsArray( $subscriptions );
 		$this->assertEquals( 1, count( $subscriptions ) );
@@ -1115,6 +1122,52 @@ class WCS_Functions_Test extends WP_UnitTestCase {
 			$subscription_1->get_id() => $subscription_1,
 		);
 		$this->assertEquals( $subscriptions, $correct_order );
+	}
+
+	/**
+	 * Since 7.3.0, the number of queries accepted by wcs_get_subscriptions() has broadened,
+	 * and arbitrary arguments can be provided (chiefly to open up access to the features of
+	 * WooCommerce's own order queries).
+	 *
+	 * @return void
+	 */
+	public function test_wcs_get_subscriptions_wc_order_query_compat() {
+		$old_subscription = WCS_Helper_Subscription::create_subscription(
+			array(
+				'status'      => 'pending',
+				'start_date'  => '2024-12-31 00:00:00',
+				'customer_id' => wp_create_user( 'withnail', 'x', 'withnail@actorforhire.web' ),
+			)
+		);
+
+		$new_subscription = WCS_Helper_Subscription::create_subscription(
+			array(
+				'status'      => 'pending',
+				'start_date'  => '2025-12-31 00:00:00',
+				'customer_id' => wp_create_user( 'marwood', 'x', 'marwood@actorforhire.web' ),
+			)
+		);
+
+		$old_subscription->set_date_created( '2024-12-31 00:00:00' );
+		$new_subscription->set_date_created( '2025-12-31 00:00:00' );
+		$old_subscription->save();
+		$new_subscription->save();
+
+		$old_subscriptions = wcs_get_subscriptions( array( 'date_created' => '<=2025-06-01' ) );
+		$this->assertCount( 1, $old_subscriptions, '`WC_Order_Query` args such as `date_created` can be used when querying for subscriptions.' );
+		$this->assertEquals( $old_subscription->get_id(), current( $old_subscriptions )->get_id(), 'The correct subscription is returned.' );
+
+		// Watch for and capture the query arguments passed to WC_Order_Query.
+		$query_args        = array();
+		$query_arg_watcher = function ( $query, $args ) use ( &$query_args ) {
+			$query_args = $args;
+			return $query;
+		};
+
+		add_filter( 'woocommerce_order_query', $query_arg_watcher, 10, 2 );
+		wcs_get_subscriptions( array( 'foo_bar' => 'baz' ) );
+		$this->assertArrayHasKey( 'foo_bar', $query_args, 'When querying subscriptions, and additional or arbitrary arguments are also passed to `WC_Order_Query`.' );
+		remove_filter( 'woocommerce_order_query', $query_arg_watcher );
 	}
 
 	/**


### PR DESCRIPTION
To date, `wcs_get_subscriptions()` has supported only a limited set of arguments (some that are specific to Subscriptions queries, and others that map directly to their `WC_Order_Query` equivalents). In the linked issue, which this PR tries to satisfy, it was decided that we should pass any and all arguments across to WooCommerce. This should make it possible to:

- Take better advantage of current and future order query capabilities provided by WooCommerce Core
- Increase the potential to reuse code (reuse the same set of arguments)
- Allow extensions to enhance query capabilities for both orders *and* subscriptions

Fixes [#4678](https://github.com/woocommerce/woocommerce-subscriptions/issues/4678)

#### ⛑️ How can this code break?

Before now, passing something like `date_created` to `wcs_get_subscriptions()` would have had no effect by default, but it's not impossible that an extension/custom code implemented support. With this change, we are implicitly add support for `date_created` (and other order query args), and that *could* lead to a hard-to-predict conflict of some kind. My instinct is that this risk is low, however.

#### 🧪 What are we doing to make sure this code doesn't break?

There is already a pretty large battery of unit tests covering different `wcs_get_subscriptions()` queries. Those should provide us with some confidence, and this PR also increases the total number of assertions.

## How to test this PR

This is primarily a developer-facing change and so, beyond reviewing the change, some freestyle exploration (and comparison) of queries made via `wcs_get_subscriptions()`, with and without this change, will be valuable. 

Beyond that, you may wish to consider running through flows that involve subscription queries made using `wcs_get_subscriptions()`. I've detailed two such scenarios below, to help verify that we are not introducing any new breakages, though please feel free to look into others:

#### 🚏 Subscription Limitations

- Create a variable subscription product.
    - Via the **Advanced** tab (within the product meta box), set the **limit subscription** field to **limit to one active subscription**.
- As a customer, purchase a specific tier of that product.
- Still logged in as the same customer, revisit the product page. You should see a warning that, *"You have a subscription to this product. Choosing a new subscription will replace your existing subscription. "*
- Continue, selecting a different tier/variant and then checkout. As the message suggested, this should result in a switch to your existing subscription.

#### 🎭 Anonymizing Ended Subscriptions

> [!TIP]
> For this next test, enable HPOS but disable Compatibility Mode. You can also test without HPOS (though, you will need to modify the steps provided here), but again you should ensure Compatibility Mode (Sync) is disabled. This is to avoid some weird side-effects of the sync process impacting your tests.

- Visit the **WooCommerce ‣ Settings ‣ Accounts & Privacy** admin screen.
- Locate the **personal data retention** area, and set **retain ended subscriptions** to **1 year** then save your changes.
- Acting as a customer, purchase a new subscription.
- Then, as the merchant, locate the same subscription and cancel it.
- Via the database, update the end date (we want to set it to a past date, that makes it a valid target for the anonymization tool). You can use WP CLI to do this if you like. Example (assuming HPOS is enabled):

```sh
# Replace <SUB_ID> with the actual subscription ID
wp db query "UPDATE $(wp db prefix)wc_orders_meta SET meta_value = '2023-01-01 12:00:00' WHERE order_id = '<SUB_ID>' AND meta_key = '_schedule_end'"
```

- Again working with WP CLI, run the anonymization tool (normally this would happen via a sequence of scheduled actions but, for expediency, we'll invoke it directly):

```sh
wp eval "(new WCS_Privacy_Background_Updater)->anonymize_ended_subscriptions();"
```

- Still acting as the merchant, visit the subscription editor and verify that the subscription has been anonymized:

<div align="center"><img src="https://github.com/user-attachments/assets/30ad8770-e083-4a62-bd0c-582d6f8a2d82" width="600" alt="Anonymized subscription, as seen via the subscription editor screen" /></div>

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? ***Yes → https://github.com/woocommerce/woocommerce-subscriptions/issues/4678***
- [x] Will this PR affect WooCommerce Payments? ***No***
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) ***None***
