### PR TITLE
Fill placeholders for custom email placeholders our emails use

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Updated subscription email item table template to align with WooCommerce 9.7 email improvements.
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.
+* Fix - Ensure custom placeholders (time_until_renewal, customers_first_name) are included in customer notification email previews.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 
 = 8.0.1 - 2025-02-13 =

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -51,6 +51,8 @@ class WC_Subscriptions_Email_Preview {
 				break;
 		}
 
+		$this->add_placeholders( $email );
+
 		add_filter( 'woocommerce_mail_content', [ $this, 'clean_up_filters' ] );
 
 		return $email;
@@ -204,4 +206,35 @@ class WC_Subscriptions_Email_Preview {
 
 		return $can_renew_early;
 	}
+
+	/**
+	 * Adds custom placeholders for subscription emails.
+	 *
+	 * @param WC_Email $email The email object.
+	 */
+	private function add_placeholders( $email ) {
+		if ( ! isset( $email->placeholders ) ) {
+			return;
+		}
+
+		$placeholders = [
+			'{time_until_renewal}'   => human_time_diff( time(), time() + WEEK_IN_SECONDS ),
+			'{customers_first_name}' => 'John',
+		];
+
+		// Pull the real values from the email object (Order or Subscription) if available.
+		if ( is_a( $email->object, 'WC_Subscription' ) ) {
+			$placeholders['{time_until_renewal}'] = human_time_diff( time(), $email->object->get_time( 'next_payment' ) );
+		}
+
+		if ( is_a( $email->object, 'WC_Abstract_Order' ) ) {
+			$placeholders['{customers_first_name}'] = $email->object->get_billing_first_name();
+		}
+
+		$email->placeholders = wp_parse_args(
+			$placeholders,
+			$email->placeholders
+		);
+	}
 }
+


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4815

## Description

This PR ensures our custom placeholders are added when generating the email preview.

Our customer notification (eg pre renewal) emails include two custom placeholders (`time_until_renewal` and `customers_first_name`). Because these are custom and only normally get filled when the email is triggered, they were missing from the email.

This would cause blanks in the email subjects and additional content. 


This PR fixes that.

| Before | After |
|--------|--------|
| <img width="623" alt="Screenshot 2025-03-12 at 11 49 10 am" src="https://github.com/user-attachments/assets/fce47d3b-09e0-4ee9-bee3-de24d1b8b037" /> | <img width="648" alt="Screenshot 2025-03-12 at 11 48 06 am" src="https://github.com/user-attachments/assets/7ec72542-1de4-4d2a-96f3-cc759ab9eb70" /> | 

## How to test this PR

1. Enable the Customer notifications email feature from **WooCommerce → Settings → Subscriptions**.
2. Go to **WooCommerce → Settings → Emails**
3. Scroll to the bottom and from the dropdown preview the **Customer Notification: ...** emails.
   - On `trunk` each one is missing information either from the email subject or additional content. 
   - On this branch there should be no missing placeholders. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
