### PR TITLE
Fix early renewal order checkouts by checking the cart order is an WC order object

### DIFF
--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1682,7 +1682,7 @@ class WCS_Cart_Renewal {
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$order = $this->get_order( $cart_item );
 
-			if ( ! $order ) {
+			if ( ! wcs_is_order( $order ) ) {
 				continue;
 			}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -257,14 +257,20 @@ class WCS_Cart_Renewal {
 		if ( is_a( $order_id, 'WC_Abstract_Order' ) ) {
 			$order    = $order_id;
 			$order_id = $order->get_id();
+		} elseif ( ! empty( $order_id ) ) {
+			$order = wc_get_order( $order_id );
+		}
+
+		// Only ever set the order awaiting payment to 0 or an Order ID - not a subscription.
+		if ( $order && ! wcs_is_order( $order ) ) {
+			return;
 		}
 
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 		WC()->session->set( 'store_api_draft_order', $order_id );
 
 		if ( $order_id ) {
-			// To avoid needing to load the order object, pass it if available, otherwise pass the order ID.
-			$this->set_cart_hash( $order ?? $order_id );
+			$this->set_cart_hash( $order );
 		}
 	}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1688,12 +1688,12 @@ class WCS_Cart_Renewal {
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$order = $this->get_order( $cart_item );
 
-			if ( ! $order || ! wcs_is_order( $order ) ) {
+			if ( ! $order ) {
 				continue;
 			}
 
 			// If the current user has permission to pay for the order, restore the order awaiting payment session arg.
-			if ( $this->validate_current_user( $order ) ) {
+			if ( wcs_is_order( $order ) && $this->validate_current_user( $order ) ) {
 				$this->set_order_awaiting_payment( $order );
 			}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1682,7 +1682,7 @@ class WCS_Cart_Renewal {
 		foreach ( $cart->get_cart() as $cart_item ) {
 			$order = $this->get_order( $cart_item );
 
-			if ( ! wcs_is_order( $order ) ) {
+			if ( ! $order || ! wcs_is_order( $order ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4818

## Description

In PR #801, I fixed a bug where renewing a subscription would incorrectly create a new renewal order. The fix ensured that the order awaiting payment flag was set whenever the cart contained a renewal order item.

However, this introduced an unintended issue with early renewal orders. In this scenario, the cart contains a copy of a subscription, rather than an actual order. As a result, the fix mistakenly set the `order_awaiting_payment` flag to a subscription instead of an order.

This PR resolves the issue by ensuring that we only call `$this->set_order_awaiting_payment( $order );` if and only if we are dealing with an order - not a subscription.

## How to test this PR

1. Navigate to **My Account > Subscriptions** as a shopper.
2. Locate a subscription that is eligible for early renewal.
3. Click the **Renew Now** button.
   - If you have the early renewal via modal set up, click the [checkout link](https://github.com/user-attachments/assets/e6c1c9a8-e934-46e3-a6bf-a2afde82e3cf). 
4. On `trunk` you land on the checkout page but the checkout is empty.
5. On this branch the checkout should be populated with the renewal order.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
   - No changelog is needed
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
