### PR TITLE
Add support for retry payment emails previews

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Reduced duplicate queries when fetching multiple subscription related orders types.
 * Update - Removed unnecessary get_time() calls to reduce redundant get_last_order() queries in the Subscriptions list table.
 * Update - Improved performance on the Orders list table when rendering the Subscription Relationship column.
+* Fix - Added support for previewing payment retry emails in WooCommerce email settings.
 * Fix - Updated subscription email item table template to align with WooCommerce 9.7 email improvements.
 * Fix - Prevent PHP warning on cart page shipping method updates by removing unused method: maybe_restore_shipping_methods.
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -49,6 +49,10 @@ class WC_Subscriptions_Email_Preview {
 			case 'WCS_Email_Customer_Notification_Auto_Renewal':
 				$email->set_object( $this->get_dummy_subscription() );
 				break;
+			case 'WCS_Email_Customer_Payment_Retry':
+			case 'WCS_Email_Payment_Retry':
+				$email->retry = $this->get_dummy_retry( $email->object );
+				break;
 		}
 
 		add_filter( 'woocommerce_mail_content', [ $this, 'clean_up_filters' ] );
@@ -140,12 +144,50 @@ class WC_Subscriptions_Email_Preview {
 	}
 
 	/**
+	 * Creates a dummy retry for use when previewing failed subscription payment retry emails.
+	 *
+	 * @param WC_Order $order The order object to create a dummy retry for.
+	 * @return WCS_Retry The dummy retry object.
+	 */
+	private function get_dummy_retry( $order ) {
+
+		if ( ! class_exists( 'WCS_Retry_Manager' ) ) {
+			return null;
+		}
+
+		$retry_number = 1;
+		$retry_rule   = WCS_Retry_Manager::rules()->get_rule( $retry_number, $order->get_id() );
+
+		return new WCS_Retry(
+			[
+				'status'   => 'pending',
+				'order_id' => $order->get_id(),
+				'date_gmt' => gmdate( 'Y-m-d H:i:s', time() + $retry_rule->get_retry_interval() ),
+				'rule_raw' => $retry_rule->get_raw_data(),
+			]
+		);
+	}
+
+	/**
 	 * Check if the email being previewed is a subscription email.
 	 *
 	 * @return bool
 	 */
 	private function is_subscription_email() {
-		return isset( WC_Subscriptions_Email::$email_classes[ $this->email_type ] ) || isset( WC_Subscriptions_Email_Notifications::$email_classes[ $this->email_type ] );
+
+		if ( isset( WC_Subscriptions_Email::$email_classes[ $this->email_type ] ) ) {
+			return true;
+		}
+
+		if ( isset( WC_Subscriptions_Email_Notifications::$email_classes[ $this->email_type ] ) ) {
+			return true;
+		}
+
+		if ( in_array( $this->email_type, [ 'WCS_Email_Customer_Payment_Retry', 'WCS_Email_Payment_Retry' ], true ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -153,19 +153,28 @@ class WC_Subscriptions_Email_Preview {
 	 */
 	private function get_dummy_retry( $order ) {
 
-		if ( ! class_exists( 'WCS_Retry_Manager' ) || ! is_a( $order, 'WC_Order' ) ) {
+		if ( ! class_exists( 'WCS_Retry_Manager' ) ) {
 			return null;
 		}
 
-		$retry_number = 1;
-		$retry_rule   = WCS_Retry_Manager::rules()->get_rule( $retry_number, $order->get_id() );
+		$order_id   = is_a( $order, 'WC_Order' ) ? $order->get_id() : 12345;
+		$retry_rule = WCS_Retry_Manager::rules()->get_rule( 1, $order_id );
+
+		if ( is_a( $retry_rule, 'WCS_Retry_Rule' ) ) {
+			$interval       = $retry_rule->get_retry_interval();
+			$raw_retry_rule = $retry_rule->get_raw_data();
+		} else {
+			// If the retry rule is not found, use a default interval of 12 hours and an empty raw rule.
+			$interval       = 12 * HOUR_IN_SECONDS;
+			$raw_retry_rule = [];
+		}
 
 		return new WCS_Retry(
 			[
 				'status'   => 'pending',
-				'order_id' => $order->get_id(),
-				'date_gmt' => gmdate( 'Y-m-d H:i:s', time() + $retry_rule->get_retry_interval() ),
-				'rule_raw' => $retry_rule->get_raw_data(),
+				'order_id' => $order_id,
+				'date_gmt' => gmdate( 'Y-m-d H:i:s', time() + $interval ),
+				'rule_raw' => $raw_retry_rule,
 			]
 		);
 	}

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -254,20 +254,36 @@ class WC_Subscriptions_Email_Preview {
 			return;
 		}
 
-		$placeholders = [
-			'{time_until_renewal}'   => human_time_diff( time(), time() + WEEK_IN_SECONDS ),
-			'{customers_first_name}' => 'John',
-		];
+		$placeholders = [];
 
-		// Pull the real values from the email object (Order or Subscription) if available.
-		if ( is_a( $email->object, 'WC_Subscription' ) ) {
-			$placeholders['{time_until_renewal}'] = human_time_diff( time(), $email->object->get_time( 'next_payment' ) );
+		switch ( $this->email_type ) {
+			case 'WCS_Email_Customer_Notification_Manual_Trial_Expiration':
+			case 'WCS_Email_Customer_Notification_Auto_Trial_Expiration':
+			case 'WCS_Email_Customer_Notification_Manual_Renewal':
+			case 'WCS_Email_Customer_Notification_Auto_Renewal':
+			case 'WCS_Email_Customer_Notification_Subscription_Expiration':
+				if ( is_a( $email->object, 'WC_Subscription' ) ) {
+					$time_until_renewal  = $email->get_time_until_date( $email->object, 'next_payment' );
+					$customer_first_name = $email->object->get_billing_first_name();
+				} else {
+					$time_until_renewal  = human_time_diff( time(), time() + WEEK_IN_SECONDS );
+					$customer_first_name = 'John';
+				}
+
+				$placeholders['{time_until_renewal}']   = $time_until_renewal;
+				$placeholders['{customers_first_name}'] = $customer_first_name;
+				break;
+			case 'WCS_Email_Customer_Payment_Retry':
+			case 'WCS_Email_Payment_Retry':
+				$retry_time = is_a( $email->retry, 'WCS_Retry' )
+					? $email->retry->get_time()
+					: time() + ( 12 * HOUR_IN_SECONDS );
+
+				$placeholders['{retry_time}'] = wcs_get_human_time_diff( $retry_time );
+				break;
 		}
 
-		if ( is_a( $email->object, 'WC_Abstract_Order' ) ) {
-			$placeholders['{customers_first_name}'] = $email->object->get_billing_first_name();
-		}
-
+		// Merge placeholders without overriding existing ones, and only adding those in the email.
 		$email->placeholders = wp_parse_args(
 			$placeholders,
 			$email->placeholders

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -153,7 +153,7 @@ class WC_Subscriptions_Email_Preview {
 	 */
 	private function get_dummy_retry( $order ) {
 
-		if ( ! class_exists( 'WCS_Retry_Manager' ) ) {
+		if ( ! class_exists( 'WCS_Retry_Manager' ) || ! is_a( $order, 'WC_Order' ) ) {
 			return null;
 		}
 

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -171,23 +171,18 @@ class WC_Subscriptions_Email_Preview {
 	/**
 	 * Check if the email being previewed is a subscription email.
 	 *
-	 * @return bool
+	 * Subscription emails include:
+	 * - WC_Subscriptions_Email::$email_classes - core subscription emails.
+	 * - WC_Subscriptions_Email_Notifications::$email_classes - subscription notification emails (pre-renewal emails).
+	 * - WCS_Email_Customer_Payment_Retry - customer payment retry emails.
+	 * - WCS_Email_Payment_Retry - admin payment retry emails.
+	 *
+	 * @return bool Whether the email being previewed is a subscription email.
 	 */
 	private function is_subscription_email() {
-
-		if ( isset( WC_Subscriptions_Email::$email_classes[ $this->email_type ] ) ) {
-			return true;
-		}
-
-		if ( isset( WC_Subscriptions_Email_Notifications::$email_classes[ $this->email_type ] ) ) {
-			return true;
-		}
-
-		if ( in_array( $this->email_type, [ 'WCS_Email_Customer_Payment_Retry', 'WCS_Email_Payment_Retry' ], true ) ) {
-			return true;
-		}
-
-		return false;
+		return isset( WC_Subscriptions_Email::$email_classes[ $this->email_type ] )
+			|| isset( WC_Subscriptions_Email_Notifications::$email_classes[ $this->email_type ] )
+			|| in_array( $this->email_type, [ 'WCS_Email_Customer_Payment_Retry', 'WCS_Email_Payment_Retry' ], true );
 	}
 
 	/**

--- a/includes/emails/class-wc-subscriptions-email-preview.php
+++ b/includes/emails/class-wc-subscriptions-email-preview.php
@@ -257,11 +257,12 @@ class WC_Subscriptions_Email_Preview {
 		$placeholders = [];
 
 		switch ( $this->email_type ) {
+			case 'WCS_Email_Customer_Notification_Subscription_Expiration':
 			case 'WCS_Email_Customer_Notification_Manual_Trial_Expiration':
 			case 'WCS_Email_Customer_Notification_Auto_Trial_Expiration':
 			case 'WCS_Email_Customer_Notification_Manual_Renewal':
 			case 'WCS_Email_Customer_Notification_Auto_Renewal':
-			case 'WCS_Email_Customer_Notification_Subscription_Expiration':
+				// Pull the real values from the email object (Order or Subscription) if available.
 				if ( is_a( $email->object, 'WC_Subscription' ) ) {
 					$time_until_renewal  = $email->get_time_until_date( $email->object, 'next_payment' );
 					$customer_first_name = $email->object->get_billing_first_name();


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4813

## Description

This PR adds support for using the email preview feature in WooCommerce to view payment retry emails. 

| Before | After |
|--------|--------|
| <img width="709" alt="Screenshot 2025-03-14 at 2 24 51 pm" src="https://github.com/user-attachments/assets/34a1b9ff-8205-4f92-98c0-eb465dd1313b" /> | <img width="707" alt="Screenshot 2025-03-14 at 3 32 27 pm" src="https://github.com/user-attachments/assets/a2c7602e-53ad-4dfc-82c8-eaa8dca270f8" /> | 


## How to test this PR

1. Go to **WooCommerce → Settings → Subscriptions**.
2. Enable **Retry Failed Payments**.
3. Go to **WooCommerce → Settings → Emails**
4. Select **Customer Payment Retry** or **Payment Retry**
5. The preview should render and look correct.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
