### PR TITLE
Add Nightly Build Workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -6,9 +6,6 @@ on:
   schedule:
     # Every day at 10:00 UTC
     - cron: '0 10 * * *'
-  pull_request:
-    branches:
-      - trunk
 
 jobs:
   build:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -64,7 +64,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: Nightly
-          release_name: "Nightly Build"
+          name: "Nightly Build"
           prerelease: true
           draft: false
           body: ${{ steps.changelog.outputs.CHANGELOG }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -41,23 +41,25 @@ jobs:
 
       # Extract the latest changelog section
       # Pulls everything after the first version header like "= 8.1.0 - ... =" until the next "=" section header or end of file
-      - name: Extract latest changelog section
+      - name: Extract latest changelog section (without heading, wrapped in code block)
         id: changelog
         run: |
           version_line_found=0
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          echo '```' >> $GITHUB_OUTPUT
           while IFS= read -r line; do
             if [[ $line == =\ *\ = ]]; then
               if [[ $version_line_found -eq 1 ]]; then
                 break
               else
                 version_line_found=1
-                echo "$line" >> $GITHUB_OUTPUT
+                continue
               fi
             elif [[ $version_line_found -eq 1 ]]; then
               echo "$line" >> $GITHUB_OUTPUT
             fi
           done < changelog.txt
+          echo '```' >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create or Update GitHub Release

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: dev-drprasad/delete-older-releases@v0.3.3
         with:
           keep_latest: 1
-          delete_tag_pattern: Nightly
+          delete_tag_pattern: nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Extract the latest changelog section
       # Pulls everything after the first version header like "= 8.1.0 - ... =" until the next "=" section header or end of file
-      - name: Extract latest changelog section (without heading, wrapped in code block)
+      - name: Extract latest changelog section (cleaned + wrapped in code block)
         id: changelog
         run: |
           version_line_found=0
@@ -56,7 +56,10 @@ jobs:
                 continue
               fi
             elif [[ $version_line_found -eq 1 ]]; then
-              echo "$line" >> $GITHUB_OUTPUT
+              # Trim whitespace-only lines
+              if [[ ! "$line" =~ ^[[:space:]]*$ ]]; then
+                echo "$line" >> $GITHUB_OUTPUT
+              fi
             fi
           done < changelog.txt
           echo '```' >> $GITHUB_OUTPUT
@@ -65,7 +68,7 @@ jobs:
       - name: Create or Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: Nightly
+          tag_name: nightly
           name: "Nightly Build"
           prerelease: true
           draft: false

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,49 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 10 * * *'  # Every day at 10:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Plugin and Upload Nightly
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'  # Caches npm dependencies for faster builds
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Plugin
+        run: npm run build
+
+      - name: Verify Generated ZIP
+        run: ls -lah woocommerce-subscriptions-core.zip
+
+      - name: Delete Previous Nightly Release Assets
+        uses: dev-drprasad/delete-older-releases@v0.3.3
+        with:
+          keep_latest: 1
+          delete_tag_pattern: Nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or Update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: Nightly
+          release_name: "Nightly Build"
+          prerelease: true
+          draft: false
+          files: woocommerce-subscriptions-core.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     # Every day at 10:00 UTC
     - cron: '0 10 * * *'
+  pull_request:
+    branches:
+      - add/nightly-build-workflow
 
 jobs:
   build:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,6 +39,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract the latest changelog section
+      # Pulls everything after the first version header like "= 8.1.0 - ... =" until the next "=" section header or end of file
+      - name: Extract latest changelog section
+        id: changelog
+        run: |
+          version_line_found=0
+          echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
+          while IFS= read -r line; do
+            if [[ $line == =\ *\ = ]]; then
+              if [[ $version_line_found -eq 1 ]]; then
+                break
+              else
+                version_line_found=1
+                echo "$line" >> $GITHUB_OUTPUT
+              fi
+            elif [[ $version_line_found -eq 1 ]]; then
+              echo "$line" >> $GITHUB_OUTPUT
+            fi
+          done < changelog.txt
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create or Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -46,6 +67,7 @@ jobs:
           release_name: "Nightly Build"
           prerelease: true
           draft: false
+          body: ${{ steps.changelog.outputs.CHANGELOG }}
           files: woocommerce-subscriptions-core.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,9 +1,11 @@
 name: Nightly Build
 
 on:
-  schedule:
-    - cron: '0 10 * * *'  # Every day at 10:00 UTC
   workflow_dispatch:
+
+  schedule:
+    # Every day at 10:00 UTC
+    - cron: '0 10 * * *'
 
 jobs:
   build:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,7 +8,7 @@ on:
     - cron: '0 10 * * *'
   pull_request:
     branches:
-      - add/nightly-build-workflow
+      - trunk
 
 jobs:
   build:


### PR DESCRIPTION
### Summary
This PR adds a GitHub workflow that tags a nightly build every day at 10:00 AM UTC.

**Why 10:00 AM UTC?**
This time was chosen to best meet the current Subscriptions team:

**Brisbane** (UTC+10): 8:00 PM
**Vancouver** (UTC−7): 3:00 AM
**Brazil** (UTC−3): 7:00 AM

The goal is for everyone to start their workday with a fresh nightly build already available.

#### 📝 Notes
This is a temporary solution while subscriptions-core remains separate from the main repository. Once it is merged back in, this workflow will no longer be necessary.

This is needed so we can pull in the latest set of changes when running QIT tests on Subscriptions - see https://github.com/woocommerce/woocommerce-subscriptions/pull/4825

#### Testing steps:

1. Install the [GitHub CLI](https://cli.github.com/)
2. From the subscriptions-core directory run the following command:
    - `gh workflow run "Nightly Build" --ref add/nightly-build-workflow`
3. This should kick off the workflow. 
4. Go to https://github.com/Automattic/woocommerce-subscriptions-core/actions/workflows/nightly-build.yml
5. Once the nightly build job is finished go to https://github.com/Automattic/woocommerce-subscriptions-core/tags
6. You should see the `nightly` tag. 
7. View that tag. Confirm the changelog is attached and up to date with the latest `trunk` version. 

Closes https://github.com/woocommerce/woocommerce-subscriptions/issues/4832