### PR TITLE
Cache subscription last order date

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Fix - Ensure the order_awaiting_payment session arg is restored when loading a renewal cart from the session to prevent duplicate orders.
 * Fix - Ensure custom placeholders (time_until_renewal, customers_first_name) are included in customer notification email previews.
 * Fix - Correctly load product names with HTML on the cart and checkout shipping rates.
+* Fix - Improve performance of the subscription listing page.
 * Dev - Fix Node version mismatch between package.json and .nvmrc (both are now set to v16.17.1).
 
 = 8.0.1 - 2025-02-13 =

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -686,7 +686,23 @@ class WCS_Admin_Post_Types {
 	public static function get_date_column_content( $subscription, $column ) {
 		$date_type_map  = array( 'last_payment_date' => 'last_order_date_created' );
 		$date_type      = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
-		$date_timestamp = $subscription->get_time( $date_type );
+
+		if ( $column === 'last_payment_date' ) {
+			// Get last order date created from subscription metadata if it exists.
+			$last_order_date_created = $subscription->get_last_order_date_created();
+
+			if ( ! empty( $last_order_date_created ) ) {
+				$date_timestamp = $last_order_date_created;
+			} else {
+				// If not exists, get the last order date created from the orders and update the metadata.
+				$date_timestamp = $subscription->get_time( $date_type );
+
+				$subscription->set_last_order_date_created( $date_timestamp );
+				$subscription->save();
+			}
+		} else {
+			$date_timestamp = $subscription->get_time( $date_type );
+		}
 
 		if ( 0 === $date_timestamp ) {
 			return '-';

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -688,18 +688,7 @@ class WCS_Admin_Post_Types {
 		$date_type     = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
 
 		if ( 'last_payment_date' === $column ) {
-			// Get last order date created from subscription metadata if it exists.
-			$last_order_date_created = $subscription->get_last_order_date_created();
-
-			if ( ! empty( $last_order_date_created ) ) {
-				$date_timestamp = $last_order_date_created;
-			} else {
-				// If not exists, get the last order date created from the orders and update the metadata.
-				$date_timestamp = $subscription->get_time( $date_type );
-
-				$subscription->set_last_order_date_created( $date_timestamp );
-				$subscription->save();
-			}
+			$date_timestamp = self::get_last_payment_date( $subscription );
 		} else {
 			$date_timestamp = $subscription->get_time( $date_type );
 		}
@@ -1848,6 +1837,26 @@ class WCS_Admin_Post_Types {
 		$pieces['orderby'] = "COALESCE(lp.last_payment, parent_order.date_created_gmt, 0) {$query_order}";
 
 		return $pieces;
+	}
+
+	/**
+	 * Get the last payment date for a subscription.
+	 *
+	 * @param WC_Subscription $subscription The subscription object.
+	 * @return int The last payment date timestamp.
+	 */
+	private static function get_last_payment_date( $subscription ) {
+		$last_order_date_created = $subscription->get_last_order_date_created();
+
+		if ( ! empty( $last_order_date_created ) ) {
+			return $last_order_date_created;
+		}
+
+		$date_timestamp = $subscription->get_time( 'last_order_date_created' );
+		$subscription->set_last_order_date_created( $date_timestamp );
+		$subscription->save();
+
+		return $date_timestamp;
 	}
 
 	/**

--- a/includes/admin/class-wcs-admin-post-types.php
+++ b/includes/admin/class-wcs-admin-post-types.php
@@ -684,10 +684,10 @@ class WCS_Admin_Post_Types {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0
 	 */
 	public static function get_date_column_content( $subscription, $column ) {
-		$date_type_map  = array( 'last_payment_date' => 'last_order_date_created' );
-		$date_type      = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
+		$date_type_map = array( 'last_payment_date' => 'last_order_date_created' );
+		$date_type     = array_key_exists( $column, $date_type_map ) ? $date_type_map[ $column ] : $column;
 
-		if ( $column === 'last_payment_date' ) {
+		if ( 'last_payment_date' === $column ) {
 			// Get last order date created from subscription metadata if it exists.
 			$last_order_date_created = $subscription->get_last_order_date_created();
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -1116,8 +1116,9 @@ class WC_Subscription extends WC_Order {
 	 *
 	 * @param string $date_type 'date_created', 'trial_end', 'next_payment', 'last_order_date_created' or 'end'
 	 * @param string $timezone The timezone of the $datetime param, either 'gmt' or 'site'. Default 'gmt'.
+	 * @param array $exclude_statuses An array of subscription statuses to exclude from the date calculation.
 	 */
-	public function get_date( $date_type, $timezone = 'gmt' ) {
+	public function get_date( $date_type, $timezone = 'gmt', $exclude_statuses = array() ) {
 
 		$date_type = wcs_normalise_date_type_key( $date_type, true );
 
@@ -1139,13 +1140,13 @@ class WC_Subscription extends WC_Order {
 					$date = $this->get_date_completed();
 					break;
 				case 'last_order_date_created':
-					$date = $this->get_related_orders_date( 'date_created', 'last' );
+					$date = $this->get_related_orders_date( 'date_created', 'last', $exclude_statuses );
 					break;
 				case 'last_order_date_paid':
-					$date = $this->get_related_orders_date( 'date_paid', 'last' );
+					$date = $this->get_related_orders_date( 'date_paid', 'last', $exclude_statuses );
 					break;
 				case 'last_order_date_completed':
-					$date = $this->get_related_orders_date( 'date_completed', 'last' );
+					$date = $this->get_related_orders_date( 'date_completed', 'last', $exclude_statuses );
 					break;
 				default:
 					$date = $this->get_date_prop( $date_type );
@@ -1263,14 +1264,15 @@ class WC_Subscription extends WC_Order {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.0
 	 * @param string $date_type Any valid WC 3.0 date property, including 'date_paid', 'date_completed', 'date_created', or 'date_modified'
 	 * @param string $order_type The type of orders to return, can be 'last', 'parent', 'switch', 'renewal' or 'any'. Default 'any'. Use 'last' to only check the last order.
+	 * @param array  $exclude_statuses An array of subscription statuses to exclude from the date calculation.
 	 * @return WC_DateTime|NULL object if the date is set or null if there is no date.
 	 */
-	protected function get_related_orders_date( $date_type, $order_type = 'any' ) {
+	protected function get_related_orders_date( $date_type, $order_type = 'any', $exclude_statuses = array() ) {
 
 		$date = null;
 
 		if ( 'last' === $order_type ) {
-			$last_order = $this->get_last_order( 'all' );
+			$last_order = $this->get_last_order( 'all', [ 'parent', 'renewal' ], $exclude_statuses );
 			$date       = ( ! $last_order ) ? null : wcs_get_objects_property( $last_order, $date_type );
 		} else {
 			// Loop over orders until we find a valid date of this type or run out of related orders
@@ -1370,10 +1372,11 @@ class WC_Subscription extends WC_Order {
 	 *
 	 * @param string $date_type 'date_created', 'trial_end', 'next_payment', 'last_order_date_created', 'end' or 'end_of_prepaid_term'
 	 * @param string $timezone The timezone of the $datetime param. Default 'gmt'.
+	 * @param array $exclude_statuses An array of subscription statuses to exclude from the date calculation.
 	 */
-	public function get_time( $date_type, $timezone = 'gmt' ) {
+	public function get_time( $date_type, $timezone = 'gmt', $exclude_statuses = array() ) {
 
-		$datetime = $this->get_date( $date_type, $timezone );
+		$datetime = $this->get_date( $date_type, $timezone, $exclude_statuses );
 		$datetime = wcs_date_to_time( $datetime );
 
 		return $datetime;

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -60,6 +60,7 @@ class WC_Subscription extends WC_Order {
 		'requires_manual_renewal' => true,
 		'cancelled_email_sent'    => false,
 		'trial_period'            => '',
+		'last_order_date_created' => null,
 
 		// Extra data that requires manual getting/setting because we don't define getters/setters for it
 		'schedule_trial_end'      => null,
@@ -908,6 +909,15 @@ class WC_Subscription extends WC_Order {
 		return $this->get_prop( 'cancelled_email_sent', $context );
 	}
 
+	/**
+	 * The subscription last order created date.
+	 *
+	 * @return string
+	 */
+	public function get_last_order_date_created( $context = 'view' ) {
+		return $this->get_prop( 'last_order_date_created', $context );
+	}
+
 	/*** Setters *****************************************************/
 
 	/**
@@ -1090,6 +1100,13 @@ class WC_Subscription extends WC_Order {
 	 */
 	public function set_cancelled_email_sent( $value ) {
 		$this->set_prop( 'cancelled_email_sent', $value );
+	}
+
+	/**
+	 * Set the subscription last order created date.
+	 */
+	public function set_last_order_date_created( $value ) {
+		$this->set_prop( 'last_order_date_created', $value );
 	}
 
 	/*** Date methods *****************************************************/

--- a/includes/class-wc-subscriptions-data-copier.php
+++ b/includes/class-wc-subscriptions-data-copier.php
@@ -38,6 +38,7 @@ class WC_Subscriptions_Data_Copier {
 		'_suspension_count',
 		'_requires_manual_renewal',
 		'_cancelled_email_sent',
+		'_last_order_date_created',
 		'_trial_period',
 		'_created_via',
 		'_order_stock_reduced',

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2445,10 +2445,7 @@ class WC_Subscriptions_Order {
 	 * @param string   $relation_type The relationship between the subscription and the order. Must be 'renewal', 'switch' or 'resubscribe' unless custom relationships are implemented.
 	 */
 	public static function delete_relation_update_order_related_subscriptions_last_order_date_created( $order, $subscription, $relation_type ) {
-		$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt' );
-
-		$subscription->set_last_order_date_created( $last_order_date_created );
-		$subscription->save();
+		self::update_subscription_last_order_date_created( $subscription );
 
 		self::update_order_related_subscriptions_last_order_date_created( $order );
 	}
@@ -2463,11 +2460,9 @@ class WC_Subscriptions_Order {
 		$subscription_ids = wcs_get_subscription_ids_for_order( $order );
 
 		foreach ( $subscription_ids as $subscription_id ) {
-			$subscription            = wcs_get_subscription( $subscription_id );
-			$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt', $exclude_statuses );
+			$subscription = wcs_get_subscription( $subscription_id );
 
-			$subscription->set_last_order_date_created( $last_order_date_created );
-			$subscription->save();
+			self::update_subscription_last_order_date_created( $subscription, $exclude_statuses );
 		}
 	}
 
@@ -2476,31 +2471,31 @@ class WC_Subscriptions_Order {
 	 *
 	 * @param string $type The type of update to check. Only 'add' or 'delete' should be used.
 	 * @param int $object_id The object the meta is being changed on.
-	 * @param string $meta_key The object meta key being changed.
-	 * @param mixed $meta_value The meta value.
-	 * @param mixed $prev_value The previous value stored in the database. Optional.
+	 * @param string $key The object meta key being changed.
+	 * @param mixed $new_value The meta value.
+	 * @param mixed $previous_value The previous value stored in the database. Optional.
 	 */
 	public static function update_subscription_last_order_date_parent_id_changes( $type, $object_id, $key, $new_value, $previous_value ) {
-		if ( 'parent_id' !== $key || empty( $previous_value ) || empty( $new_value ) ) {
+		if ( 'parent_id' !== $key || empty( $new_value ) ) {
 			return;
 		}
 
-		$previous_subscription = wcs_get_subscription( $previous_value );
-		$new_subscription      = wcs_get_subscription( $new_value );
+		$subscription = wcs_get_subscription( $object_id );
 
-		if ( ! $previous_subscription || ! $new_subscription ) {
-			return;
-		}
+		self::update_subscription_last_order_date_created( $subscription );
+	}
 
-		// Switch last order date on both subscriptions.
-		$previous_last_order_date_created = $previous_subscription->get_time( 'last_order_date_created' );
-		$new_last_order_date_created      = $new_subscription->get_time( 'last_order_date_created' );
+	/**
+	 * Update subscription cached last_order_date_created metadata.
+	 *
+	 * @param WC_Subscription $subscription The subscription object.
+	 * @param array           $exclude_statuses The order statuses to exclude.
+	 */
+	private static function update_subscription_last_order_date_created( $subscription, $exclude_statuses = [] ) {
+		$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt' );
 
-		$new_subscription->set_last_order_date_created( $previous_last_order_date_created );
-		$new_subscription->save();
-
-		$previous_subscription->set_last_order_date_created( $new_last_order_date_created );
-		$previous_subscription->save();
+		$subscription->set_last_order_date_created( $last_order_date_created );
+		$subscription->save();
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -78,7 +78,17 @@ class WC_Subscriptions_Order {
 
 		add_filter( 'woocommerce_orders_table_query_clauses', [ __CLASS__, 'filter_orders_query_by_parent_orders' ], 10, 2 );
 
-		add_action( 'woocommerce_before_delete_order', __CLASS__ . '::delete_order_update_subscription_last_order_date_created', 10, 2 );
+		add_action( 'woocommerce_before_delete_order', [ __CLASS__, 'delete_order_update_subscription_last_order_date_created' ], 10, 2 );
+
+		$cache_manager = new WCS_Object_Data_Cache_Manager(
+			'subscription',
+			[
+				'parent_id',
+			]
+		);
+		$cache_manager->init();
+
+		add_action( 'wcs_update_post_meta_caches', [ __CLASS__, 'update_subscription_last_order_date_parent_id_changes' ], 10, 5 );
 	}
 
 	/*
@@ -2417,6 +2427,31 @@ class WC_Subscriptions_Order {
 
 			$subscription->set_last_order_date_created( $last_order_date_created );
 			$subscription->save();
+		}
+	}
+
+	/**
+	 * Update subscription cached last_order_date_created metadata when manually updating parent id.
+	 *
+	 * @param string $type The type of update to check. Only 'add' or 'delete' should be used.
+	 * @param int $object_id The object the meta is being changed on.
+	 * @param string $meta_key The object meta key being changed.
+	 * @param mixed $meta_value The meta value.
+	 * @param mixed $prev_value The previous value stored in the database. Optional.
+	 */
+	public static function update_subscription_last_order_date_parent_id_changes( $type, $object_id, $key, $new_value, $previous_value ) {
+		if ( 'parent_id' === $key ) {
+			$previous_subscription            = wcs_get_subscription( $previous_value );
+			$previous_last_order_date_created = $previous_subscription->get_time( 'last_order_date_created' );
+
+			$new_subscription            = wcs_get_subscription( $new_value );
+			$new_last_order_date_created = $new_subscription->get_time( 'last_order_date_created' );
+
+			$new_subscription->set_last_order_date_created( $previous_last_order_date_created );
+			$new_subscription->save();
+
+			$previous_subscription->set_last_order_date_created( $new_last_order_date_created );
+			$previous_subscription->save();
 		}
 	}
 

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2423,7 +2423,7 @@ class WC_Subscriptions_Order {
 
 		foreach ( $subscription_ids as $subscription_id ) {
 			$subscription            = wcs_get_subscription( $subscription_id );
-			$last_order_date_created = $subscription->get_time( 'last_order_date_created' );
+			$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt', [ 'trash' ] );
 
 			$subscription->set_last_order_date_created( $last_order_date_created );
 			$subscription->save();

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2492,7 +2492,7 @@ class WC_Subscriptions_Order {
 	 * @param array           $exclude_statuses The order statuses to exclude.
 	 */
 	private static function update_subscription_last_order_date_created( $subscription, $exclude_statuses = [] ) {
-		$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt' );
+		$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt', $exclude_statuses );
 
 		$subscription->set_last_order_date_created( $last_order_date_created );
 		$subscription->save();

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2440,12 +2440,16 @@ class WC_Subscriptions_Order {
 	 * @param mixed $prev_value The previous value stored in the database. Optional.
 	 */
 	public static function update_subscription_last_order_date_parent_id_changes( $type, $object_id, $key, $new_value, $previous_value ) {
-		if ( 'parent_id' === $key ) {
-			$previous_subscription            = wcs_get_subscription( $previous_value );
-			$previous_last_order_date_created = $previous_subscription->get_time( 'last_order_date_created' );
+		if ( 'parent_id' === $key && ! empty( $previous_value ) && ! empty( $new_value ) ) {
+			$previous_subscription = wcs_get_subscription( $previous_value );
+			$new_subscription      = wcs_get_subscription( $new_value );
 
-			$new_subscription            = wcs_get_subscription( $new_value );
-			$new_last_order_date_created = $new_subscription->get_time( 'last_order_date_created' );
+			if ( ! $previous_subscription || ! $new_subscription ) {
+				return;
+			}
+
+			$previous_last_order_date_created = $previous_subscription->get_time( 'last_order_date_created' );
+			$new_last_order_date_created      = $new_subscription->get_time( 'last_order_date_created' );
 
 			$new_subscription->set_last_order_date_created( $previous_last_order_date_created );
 			$new_subscription->save();

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2440,23 +2440,26 @@ class WC_Subscriptions_Order {
 	 * @param mixed $prev_value The previous value stored in the database. Optional.
 	 */
 	public static function update_subscription_last_order_date_parent_id_changes( $type, $object_id, $key, $new_value, $previous_value ) {
-		if ( 'parent_id' === $key && ! empty( $previous_value ) && ! empty( $new_value ) ) {
-			$previous_subscription = wcs_get_subscription( $previous_value );
-			$new_subscription      = wcs_get_subscription( $new_value );
-
-			if ( ! $previous_subscription || ! $new_subscription ) {
-				return;
-			}
-
-			$previous_last_order_date_created = $previous_subscription->get_time( 'last_order_date_created' );
-			$new_last_order_date_created      = $new_subscription->get_time( 'last_order_date_created' );
-
-			$new_subscription->set_last_order_date_created( $previous_last_order_date_created );
-			$new_subscription->save();
-
-			$previous_subscription->set_last_order_date_created( $new_last_order_date_created );
-			$previous_subscription->save();
+		if ( 'parent_id' !== $key || empty( $previous_value ) || empty( $new_value ) ) {
+			return;
 		}
+
+		$previous_subscription = wcs_get_subscription( $previous_value );
+		$new_subscription      = wcs_get_subscription( $new_value );
+
+		if ( ! $previous_subscription || ! $new_subscription ) {
+			return;
+		}
+
+		// Switch last order date on both subscriptions.
+		$previous_last_order_date_created = $previous_subscription->get_time( 'last_order_date_created' );
+		$new_last_order_date_created      = $new_subscription->get_time( 'last_order_date_created' );
+
+		$new_subscription->set_last_order_date_created( $previous_last_order_date_created );
+		$new_subscription->save();
+
+		$previous_subscription->set_last_order_date_created( $new_last_order_date_created );
+		$previous_subscription->save();
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -78,7 +78,7 @@ class WC_Subscriptions_Order {
 
 		add_filter( 'woocommerce_orders_table_query_clauses', [ __CLASS__, 'filter_orders_query_by_parent_orders' ], 10, 2 );
 
-		add_action( 'woocommerce_before_delete_order', [ __CLASS__, 'delete_order_update_subscription_last_order_date_created' ], 10, 2 );
+		add_action( 'woocommerce_before_delete_order', [ __CLASS__, 'delete_order_update_order_related_subscriptions_last_order_date_created' ], 10, 2 );
 
 		$cache_manager = new WCS_Object_Data_Cache_Manager(
 			'subscription',
@@ -89,6 +89,10 @@ class WC_Subscriptions_Order {
 		$cache_manager->init();
 
 		add_action( 'wcs_update_post_meta_caches', [ __CLASS__, 'update_subscription_last_order_date_parent_id_changes' ], 10, 5 );
+
+		add_action( 'wcs_orders_add_relation', [ __CLASS__, 'add_relation_update_order_related_subscriptions_last_order_date_created' ], 10, 3 );
+
+		add_action( 'wcs_orders_delete_relation', [ __CLASS__, 'delete_relation_update_order_related_subscriptions_last_order_date_created' ], 10, 3 );
 	}
 
 	/*
@@ -2414,16 +2418,53 @@ class WC_Subscriptions_Order {
 	 * @param int      $id    The deleted order ID.
 	 * @param WC_Order $order The deleted order object.
 	 */
-	public static function delete_order_update_subscription_last_order_date_created( $id, $order ) {
+	public static function delete_order_update_order_related_subscriptions_last_order_date_created( $id, $order ) {
 		if ( $order->get_created_via() !== 'subscription' ) {
 			return;
 		}
 
+		self::update_order_related_subscriptions_last_order_date_created( $order, [ 'trash' ] );
+	}
+
+	/**
+	 * Update subscription cached last_order_date_created metadata when deleting a child order.
+	 *
+	 * @param WC_Order $order         The order to link with the subscription.
+	 * @param WC_Order $subscription  The order or subscription to link the order to.
+	 * @param string   $relation_type The relationship between the subscription and the order. Must be 'renewal', 'switch' or 'resubscribe' unless custom relationships are implemented.
+	 */
+	public static function add_relation_update_order_related_subscriptions_last_order_date_created( $order, $subscription, $relation_type ) {
+		self::update_order_related_subscriptions_last_order_date_created( $order );
+	}
+
+	/**
+	 * Update subscription cached last_order_date_created metadata when deleting a child order relation.
+	 *
+	 * @param WC_Order $order         An order that may be linked with subscriptions.
+	 * @param WC_Order $subscription  A subscription or order to unlink the order with, if a relation exists.
+	 * @param string   $relation_type The relationship between the subscription and the order. Must be 'renewal', 'switch' or 'resubscribe' unless custom relationships are implemented.
+	 */
+	public static function delete_relation_update_order_related_subscriptions_last_order_date_created( $order, $subscription, $relation_type ) {
+		$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt' );
+
+		$subscription->set_last_order_date_created( $last_order_date_created );
+		$subscription->save();
+
+		self::update_order_related_subscriptions_last_order_date_created( $order );
+	}
+
+	/**
+	 * Update all subscription cached last_order_date_created metadata related to the order.
+	 *
+	 * @param WC_Order $order The order object.
+	 * @param array    $exclude_statuses The order statuses to exclude.
+	 */
+	private static function update_order_related_subscriptions_last_order_date_created( $order, $exclude_statuses = [] ) {
 		$subscription_ids = wcs_get_subscription_ids_for_order( $order );
 
 		foreach ( $subscription_ids as $subscription_id ) {
 			$subscription            = wcs_get_subscription( $subscription_id );
-			$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt', [ 'trash' ] );
+			$last_order_date_created = $subscription->get_time( 'last_order_date_created', 'gmt', $exclude_statuses );
 
 			$subscription->set_last_order_date_created( $last_order_date_created );
 			$subscription->save();

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2427,7 +2427,7 @@ class WC_Subscriptions_Order {
 	}
 
 	/**
-	 * Update subscription cached last_order_date_created metadata when deleting a child order.
+	 * Update subscription cached last_order_date_created metadata when adding a child order.
 	 *
 	 * @param WC_Order $order         The order to link with the subscription.
 	 * @param WC_Order $subscription  The order or subscription to link the order to.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -77,6 +77,8 @@ class WC_Subscriptions_Order {
 		add_filter( 'woocommerce_order_query_args', array( __CLASS__, 'map_order_query_args_for_subscriptions' ) );
 
 		add_filter( 'woocommerce_orders_table_query_clauses', [ __CLASS__, 'filter_orders_query_by_parent_orders' ], 10, 2 );
+
+		add_action( 'woocommerce_before_delete_order', __CLASS__ . '::delete_order_update_subscription_last_order_date_created', 10, 2 );
 	}
 
 	/*
@@ -2394,6 +2396,28 @@ class WC_Subscriptions_Order {
 		}
 
 		return $meta_value;
+	}
+
+	/**
+	 * Update subscription cached last_order_date_created metadata when deleting a child order.
+	 *
+	 * @param int      $id    The deleted order ID.
+	 * @param WC_Order $order The deleted order object.
+	 */
+	public static function delete_order_update_subscription_last_order_date_created( $id, $order ) {
+		if ( $order->get_created_via() !== 'subscription' ) {
+			return;
+		}
+
+		$subscription_ids = wcs_get_subscription_ids_for_order( $order );
+
+		foreach ( $subscription_ids as $subscription_id ) {
+			$subscription            = wcs_get_subscription( $subscription_id );
+			$last_order_date_created = $subscription->get_time( 'last_order_date_created' );
+
+			$subscription->set_last_order_date_created( $last_order_date_created );
+			$subscription->save();
+		}
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
+++ b/includes/data-stores/class-wcs-orders-table-subscription-data-store.php
@@ -41,6 +41,7 @@ class WCS_Orders_Table_Subscription_Data_Store extends \Automattic\WooCommerce\I
 		'_cancelled_email_sent'     => 'cancelled_email_sent',
 		'_requires_manual_renewal'  => 'requires_manual_renewal',
 		'_trial_period'             => 'trial_period',
+		'_last_order_date_created'  => 'last_order_date_created',
 
 		'_schedule_trial_end'       => 'schedule_trial_end',
 		'_schedule_next_payment'    => 'schedule_next_payment',

--- a/includes/data-stores/class-wcs-related-order-store-cpt.php
+++ b/includes/data-stores/class-wcs-related-order-store-cpt.php
@@ -103,6 +103,8 @@ class WCS_Related_Order_Store_CPT extends WCS_Related_Order_Store {
 			$order->add_meta_data( $related_order_meta_key, $subscription_id, false );
 			$order->save();
 		}
+
+		do_action( 'wcs_orders_add_relation', $order, $subscription, $relation_type );
 	}
 
 	/**
@@ -124,6 +126,8 @@ class WCS_Related_Order_Store_CPT extends WCS_Related_Order_Store {
 		}
 
 		$order->save();
+
+		do_action( 'wcs_orders_delete_relation', $order, $subscription, $relation_type );
 	}
 
 	/**

--- a/includes/data-stores/class-wcs-subscription-data-store-cpt.php
+++ b/includes/data-stores/class-wcs-subscription-data-store-cpt.php
@@ -49,6 +49,7 @@ class WCS_Subscription_Data_Store_CPT extends WC_Order_Data_Store_CPT implements
 		'_cancelled_email_sent'     => 'cancelled_email_sent',
 		'_requires_manual_renewal'  => 'requires_manual_renewal',
 		'_trial_period'             => 'trial_period',
+		'_last_order_date_created'  => 'last_order_date_created',
 
 		'_schedule_trial_end'       => 'schedule_trial_end',
 		'_schedule_next_payment'    => 'schedule_next_payment',

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -277,8 +277,7 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 			throw new Exception( sprintf( __( 'There was an error fetching the new order (%1$s) for subscription %2$d.', 'woocommerce-subscriptions' ), $type, $subscription->get_id() ) );
 		}
 
-		// Update the subscription last_order_date_created on every time
-		// a child order is created.
+		// Update the subscription last_order_date_created on every time a child order is created.
 		$subscription->set_last_order_date_created( $new_order->get_date_created()->getTimestamp() );
 		$subscription->save();
 

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -277,6 +277,9 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 			throw new Exception( sprintf( __( 'There was an error fetching the new order (%1$s) for subscription %2$d.', 'woocommerce-subscriptions' ), $type, $subscription->get_id() ) );
 		}
 
+		$subscription->set_last_order_date_created( $new_order->get_date_created()->getTimestamp() );
+		$subscription->save();
+
 		/**
 		 * Filters the new order created from the subscription.
 		 *

--- a/includes/wcs-order-functions.php
+++ b/includes/wcs-order-functions.php
@@ -277,6 +277,8 @@ function wcs_create_order_from_subscription( $subscription, $type ) {
 			throw new Exception( sprintf( __( 'There was an error fetching the new order (%1$s) for subscription %2$d.', 'woocommerce-subscriptions' ), $type, $subscription->get_id() ) );
 		}
 
+		// Update the subscription last_order_date_created on every time
+		// a child order is created.
 		$subscription->set_last_order_date_created( $new_order->get_date_created()->getTimestamp() );
 		$subscription->save();
 


### PR DESCRIPTION
Fixes #782

## Description

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->
This PR improves the subscription list performance by caching the subscription last order date when new renewals are created or when the last order is deleted. 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Subscriptions list (existing subscription handling)

1. Open phpMyAdmin.
2. Run the following SQL Query:

```
SELECT * FROM `wp_wc_orders_meta` WHERE `meta_key` LIKE '%_last_order_date_created%'
```

3. There should be no results.
4. Open wp-admin and access `WooCommerce > Subscriptions`.
5. Refresh the query on wp-admin, there should be a `_last_order_date_created` item for every loaded subscription on the subscriptions page.
6. Add a breakpoint [here](https://github.com/Automattic/woocommerce-subscriptions-core/blob/2838dff0fd840db6ea03b9e20d6fc0f20f4f0ee8/includes/admin/class-wcs-admin-post-types.php#L695) and start the debugger.
7. Reload the subscription page.
8. If the debugger stops at the breakpoint, it means the data is being loaded from the cached metadata (`_last_order_date_created`) and it's not loading the all subscription orders as before.
9. The `Last Order Date` column should be correctly rendered.

### Subscription renewal

1. Open any subscription.
2. Look the `_last_order_date_created` value for the chosen subscription on phpMyAdmin.
3. On `Order actions`, run `Process renewal`.
4. The `_last_order_date_created` value for the chosen subscription should be updated.
5. Open the subscriptions page.
6. The `Last Order Date` column for the chosen subscription should show the correct date.

### Subscription order deletion

1. Open any subscription with renewal orders.
2. Look the `_last_order_date_created` value for the chosen subscription on phpMyAdmin.
3. Move to trash the subscription latest order.
4. Permanently delete the order on the trashed order list.
5. The `_last_order_date_created` value for the chosen subscription should be updated to the new latest order.
6. The `Last Order Date` column for the chosen subscription should show the correct date.

## Manual parent ID changes

1. Open any subscription.
2. On [this line](https://github.com/Automattic/woocommerce-subscriptions-core/blob/af8d2c4825e3b79bcb89cef0fa04893edba16a75/includes/class-wc-subscriptions-order.php#L95), add the following code:

```
add_action(
	'woocommerce_admin_order_data_after_order_details',
		function () {
			$subscription = wcs_get_subscription( 259 ); // Choose any subscription
			$subscription->set_parent_id( 256 ); // Choose any subscription order from another subscription
			$subscription->save();
		},
	10
);
```

3. Open the chosen subscription.
4. Open the Subscriptions page.
5. If the new subscription parent order id is higher than the other others, its date should show up on the `Last Order Date` column.
6. The `Last Order Date` column for the old parent id should also be updated.

## Add order relation

1. Open any subscription.
2. On [this line](https://github.com/Automattic/woocommerce-subscriptions-core/blob/af8d2c4825e3b79bcb89cef0fa04893edba16a75/includes/class-wc-subscriptions-order.php#L95), add the following code:

```
add_action(
	'woocommerce_admin_order_data_after_order_details',
		function () {
			$order = wc_get_order( 282 ); // Choose any child order
			$subscription = wcs_get_subscription( 259 ); // Choose any subscription

			WCS_Related_Order_Store::instance()->add_relation( $order, $subscription, 'renewal' );
		},
	10
);
```

3. Open the chosen subscription.
4. Open the Subscriptions page.
5. If the new subscription related order id is higher than the other others, its date should show up on the `Last Order Date` column.

## Delete order relation

1. Open any subscription.
2. On [this line](https://github.com/Automattic/woocommerce-subscriptions-core/blob/af8d2c4825e3b79bcb89cef0fa04893edba16a75/includes/class-wc-subscriptions-order.php#L95), add the following code:

```
add_action(
	'woocommerce_admin_order_data_after_order_details',
		function () {
			$subscription = wcs_get_subscription( 259 ); // Choose any subscription
			$order = wc_get_order( 282 ); // Choose the latest child order

			WCS_Related_Order_Store::instance()->delete_relation( $order, $subscription, 'renewal' );
		},
	10
);
```

3. Open the chosen subscription.
4. Open the Subscriptions page.
5. The `Last Order Date` column should show the date of the new latest order.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
