### PR TITLE
Pass proper parameters to the wcs_get_edit_post_link function, hence …

### DIFF
--- a/includes/admin/class-wc-subscriptions-admin.php
+++ b/includes/admin/class-wc-subscriptions-admin.php
@@ -1592,7 +1592,7 @@ class WC_Subscriptions_Admin {
 
 			echo '<div class="updated dismiss-subscriptions-search"><p>';
 			// translators: placeholders are opening link tag, ID of sub, and closing link tag
-			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( wcs_get_edit_post_link( $subscription ) ) . '">', esc_html( $subscription->get_order_number() ), '</a>' );
+			printf( esc_html__( 'Showing orders for %1$sSubscription %2$s%3$s', 'woocommerce-subscriptions' ), '<a href="' . esc_url( wcs_get_edit_post_link( $subscription_id ) ) . '">', esc_html( $subscription->get_order_number() ), '</a>' );
 			echo '</p>';
 			printf(
 				'<a href="%1$s" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></a>',


### PR DESCRIPTION
…to the get_edit_post_link filter

Fixes #822 

## Description

Make sure that `wcs_get_edit_post_link ` is called with a proper ID instead of an object. This means that the native filter `get_edit_post_link ` will also get a proper integer as second parameter, as expected.

## How to test this PR

1. Create a callback for the `get_edit_post_link` using the `post_id` second parameter ina  way that will produce an error if the parameter is not an integer.
2. Install WooCommer Subscriptions, generate a subscription product and get a customer purchase it.
3. Head to the backend subscriptins list and click on the number of related orders.
4. This will get you to the orders list, filtered by the related subscription, with at least one item. The error expected in 1 should be produced.

## Product impact
<!-- What products will this PR ship in? -->

- [ ] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions?
- [ ] Will this PR affect WooCommerce Payments?
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)

Additionally, it affects WPML customers: https://wpml.org/forums/topic/error-when-viewing-wc-subscription-related-orders/