### PR TITLE
Update  wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 8.2.0 - 2025-xx-xx =
-* Dev - Introduced a `wcs_prefix_order_status()` helper function to prefix order statuses for database storage.
+* Dev - Update wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys.
 
 = 8.1.0 - 2025-03-24 =
 * Update - Improved subscription search performance for WP Post stores by removing unnecessary _order_key and _billing_email meta queries.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.2.0 - 2025-xx-xx =
+* Dev - Introduced a `wcs_prefix_order_status()` helper function to prefix order statuses for database storage.
+
 = 8.1.0 - 2025-03-24 =
 * Update - Improved subscription search performance for WP Post stores by removing unnecessary _order_key and _billing_email meta queries.
 * Update - Make it possible to dispatch the Cancelled Subscription email more than once (when initially set to pending-cancellation, and again when it reaches final cancellation).

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -170,7 +170,7 @@ function wcs_get_rounding_precision() {
  * @return string
  */
 function wcs_maybe_prefix_key( $key, $prefix = '_' ) {
-	return ( substr( $key, 0, strlen( $prefix ) ) != $prefix ) ? $prefix . $key : $key;
+	return ( substr( $key, 0, strlen( $prefix ) ) !== $prefix ) ? $prefix . $key : $key;
 }
 
 /**
@@ -348,4 +348,16 @@ function wcs_compare_order_billing_shipping_address( $order ) {
 	$addresses_are_equal = $shipping_address == $billing_address;
 
 	return $addresses_are_equal;
+}
+
+/**
+ * Prefixes an order status with "wc-" if it is not already prefixed.
+ *
+ * @param string $order_status The order status
+ * @param string $prefix       The order status prefix.
+ *
+ * @return string The order status prefixed with "wc-".
+ */
+function wcs_prefix_order_status( $order_status, $prefix = 'wc-' ) {
+	return wcs_maybe_prefix_key( $order_status, $prefix );
 }

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -354,7 +354,7 @@ function wcs_compare_order_billing_shipping_address( $order ) {
  * Prefixes an order status with "wc-" if it is not already prefixed.
  *
  * @param string $order_status The order status
- * @param string $prefix       The order status prefix.
+ * @param string $prefix       The order status prefix. Optional. Default is "wc-".
  *
  * @return string The order status prefixed with "wc-".
  */

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -162,26 +162,36 @@ function wcs_get_rounding_precision() {
 }
 
 /**
- * Add a prefix to a string if it doesn't already have it
+ * Add a prefix to a string or array of strings if it doesn't already have it
  *
- * @param string
- * @param string
+ * @param string|array $key    The key or array of keys to add the prefix to.
+ * @param string       $prefix The prefix to add.
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.0
- * @return string
+ *
+ * @return string|array The key or array of keys with the prefix added.
  */
 function wcs_maybe_prefix_key( $key, $prefix = '_' ) {
+	if ( is_array( $key ) ) {
+		return array_map( __FUNCTION__, $key, array_fill( 0, count( $key ), $prefix ) );
+	}
+
 	return ( substr( $key, 0, strlen( $prefix ) ) !== $prefix ) ? $prefix . $key : $key;
 }
 
 /**
- * Remove a prefix from a string if has it
+ * Remove a prefix from a string or array of strings if it has it.
  *
- * @param string $key
- * @param string $prefix
+ * @param string|array $key    The key or array of keys to remove the prefix from.
+ * @param string       $prefix The prefix to remove.
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.2.0
- * @return string
+ *
+ * @return string|array The key or array of keys with the prefix removed.
  */
 function wcs_maybe_unprefix_key( $key, $prefix = '_' ) {
+	if ( is_array( $key ) ) {
+		return array_map( __FUNCTION__, $key, array_fill( 0, count( $key ), $prefix ) );
+	}
+
 	return ( substr( $key, 0, strlen( $prefix ) ) === $prefix ) ? substr( $key, strlen( $prefix ) ) : $key;
 }
 
@@ -348,16 +358,4 @@ function wcs_compare_order_billing_shipping_address( $order ) {
 	$addresses_are_equal = $shipping_address == $billing_address;
 
 	return $addresses_are_equal;
-}
-
-/**
- * Prefixes an order status with "wc-" if it is not already prefixed.
- *
- * @param string $order_status The order status
- * @param string $prefix       The order status prefix. Optional. Default is "wc-".
- *
- * @return string The order status prefixed with "wc-".
- */
-function wcs_prefix_order_status( $order_status, $prefix = 'wc-' ) {
-	return wcs_maybe_prefix_key( $order_status, $prefix );
 }

--- a/tests/unit/test-wcs-helper-functions.php
+++ b/tests/unit/test-wcs-helper-functions.php
@@ -149,19 +149,23 @@ class WCS_Helper_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test @see wcs_prefix_order_status() to make sure it returns the correct prefixed order status for a specific input.
+	 * Test @see wcs_maybe_prefix_key() to make sure it returns the correct prefixed key.
 	 */
-	public function test_wcs_prefix_order_status() {
+	public function test_wcs_maybe_prefix_key() {
 		// Basic prefixing.
-		$this->assertEquals( 'wc-pending', wcs_prefix_order_status( 'pending' ) );
-		$this->assertEquals( 'wc-processing', wcs_prefix_order_status( 'processing' ) );
+		$this->assertEquals( '_sale_price', wcs_maybe_prefix_key( 'sale_price' ) );
+		$this->assertEquals( 'wc-pending', wcs_maybe_prefix_key( 'pending', 'wc-' ) );
 
-		// Custom prefix.
-		$this->assertEquals( '_completed', wcs_prefix_order_status( 'completed', '_' ) );
-		$this->assertEquals( '_active', wcs_prefix_order_status( 'active', '_' ) );
+		// Array of keys.
+		$this->assertEquals( [ 'wc-completed', 'wc-active' ], wcs_maybe_prefix_key( [ 'completed', 'active' ], 'wc-' ) );
+		$this->assertEquals( [ '_sale_price', '_subscription_period' ], wcs_maybe_prefix_key( [ 'sale_price', 'subscription_period' ] ) );
 
 		// Already prefixed.
-		$this->assertEquals( 'wc-pending', wcs_prefix_order_status( 'wc-pending' ) );
-		$this->assertEquals( '_completed', wcs_prefix_order_status( '_completed', '_' ) );
+		$this->assertEquals( 'wc-pending', wcs_maybe_prefix_key( 'wc-pending', 'wc-' ) );
+		$this->assertEquals( '_completed', wcs_maybe_prefix_key( '_completed' ) );
+		$this->assertEquals( [ '_completed', '_active' ], wcs_maybe_prefix_key( [ '_completed', 'active' ] ) );
+
+		// Empty array.
+		$this->assertEquals( [], wcs_maybe_prefix_key( [] ) );
 	}
 }

--- a/tests/unit/test-wcs-helper-functions.php
+++ b/tests/unit/test-wcs-helper-functions.php
@@ -147,4 +147,21 @@ class WCS_Helper_Functions_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( wcs_compare_order_billing_shipping_address( $order ) );
 	}
+
+	/**
+	 * Test @see wcs_prefix_order_status() to make sure it returns the correct prefixed order status for a specific input.
+	 */
+	public function test_wcs_prefix_order_status() {
+		// Basic prefixing.
+		$this->assertEquals( 'wc-pending', wcs_prefix_order_status( 'pending' ) );
+		$this->assertEquals( 'wc-processing', wcs_prefix_order_status( 'processing' ) );
+
+		// Custom prefix.
+		$this->assertEquals( '_completed', wcs_prefix_order_status( 'completed', '_' ) );
+		$this->assertEquals( '_active', wcs_prefix_order_status( 'active', '_' ) );
+
+		// Already prefixed.
+		$this->assertEquals( 'wc-pending', wcs_prefix_order_status( 'wc-pending' ) );
+		$this->assertEquals( '_completed', wcs_prefix_order_status( '_completed', '_' ) );
+	}
 }

--- a/tests/unit/test-wcs-helper-functions.php
+++ b/tests/unit/test-wcs-helper-functions.php
@@ -23,6 +23,9 @@ class WCS_Helper_Functions_Test extends WP_UnitTestCase {
 			array( 'subscription_renewal', '_subscription_renewal', null ),
 			array( 'key', '_foo_key', '_foo_' ),
 			array( 'foo_key', 'foo_key', null ),
+			array( [ 'foo_key', 'foo_key' ], [ '_foo_key', '_foo_key' ], null ),
+			array( [ 'active', 'processing' ], [ 'wc-active', 'wc-processing' ], 'wc-' ),
+			array( [ 'sale_price', 'wc-processing' ], [ '_sale_price', 'wc-processing' ], null ),
 		);
 	}
 
@@ -149,7 +152,7 @@ class WCS_Helper_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test @see wcs_maybe_prefix_key() to make sure it returns the correct prefixed key.
+	 * Test @see wcs_maybe_prefix_key() to make sure it returns the correct prefixed keys.
 	 */
 	public function test_wcs_maybe_prefix_key() {
 		// Basic prefixing.


### PR DESCRIPTION
## Description

> ✏️ **Note:** PR description updated to reflect recent changes.

This is a simple PR which updates the helper functions `wcs_maybe_prefix_key()` and `wcs_maybe_unprefix_key()` to prefix an array of keys or statuses for database storage. 

Example uses:

```php
wcs_maybe_prefix_key( 'active', 'wc-' ); // wc-active
wcs_maybe_prefix_key( [ 'active', 'processing' ], 'wc-' ); // [ 'wc-active', 'wc-processing' ] );
```

This feature of this function isn't used anywhere yet but it is useful for our report classes which need to prefix multiple statuses. See the PR here: https://github.com/woocommerce/woocommerce-subscriptions/pull/4837


## How to test this PR

1. Test as part of https://github.com/woocommerce/woocommerce-subscriptions/pull/4837.
2. General code review. 

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
