### PR TITLE
Always pass the object ID as the second param to the 'get_edit_post_link' filter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.2.0 - 2025-xx-xx =
+* Fix - Ensure the second parameter passed to the 'get_edit_post_link' filter is an integer.
+
 = 8.1.0 - 2025-03-24 =
 * Update - Improved subscription search performance for WP Post stores by removing unnecessary _order_key and _billing_email meta queries.
 * Update - Make it possible to dispatch the Cancelled Subscription email more than once (when initially set to pending-cancellation, and again when it reaches final cancellation).

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,10 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
 = 8.2.0 - 2025-xx-xx =
-* Fix - Ensure the second parameter passed to the 'get_edit_post_link' filter is an integer.
 * Update - Increase the number of args accepted by wcs_get_subscriptions(), to bring about parity with wc_get_orders().
 * Dev - Update wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys.
 * Fix - Prevent sending renewal reminders for orders with a 0 total.
+* Fix - Ensure the second parameter passed to the 'get_edit_post_link' filter is an integer.
 
 = 8.1.1 - 2025-03-30 =
 * Update - Display the subscriptions parent order icon in the WooCommerce Orders list table by default

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -61,14 +61,14 @@ function wcs_date_input( $timestamp = 0, $args = array() ) {
  * @param int $post_id
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
  */
-function wcs_get_edit_post_link( $post_id ) {
-	$object = wc_get_order( $post_id ); // works for both WC Order and WC Subscription objects.
+function wcs_get_edit_post_link( $order ) {
+	$order = is_a( $order, 'WC_Abstract_Order' ) ? $order : wc_get_order( $order );
 
-	if ( ! $object || ! in_array( $object->get_type(), array( 'shop_order', 'shop_subscription' ), true ) ) {
+	if ( ! $order || ! in_array( $order->get_type(), array( 'shop_order', 'shop_subscription' ), true ) ) {
 		return '';
 	}
 
-	return apply_filters( 'get_edit_post_link', $object->get_edit_order_url(), $object->get_id(), '' );
+	return apply_filters( 'get_edit_post_link', $order->get_edit_order_url(), $order->get_id(), '' );
 }
 
 /**

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -56,10 +56,15 @@ function wcs_date_input( $timestamp = 0, $args = array() ) {
 }
 
 /**
- * Get the edit post link without checking if the user can edit that post or not.
+ * Get the admin edit link for an order.
  *
- * @param int $post_id
+ * Note: this function does not check if the user has permission to edit the order.
+ *
  * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+ * @since 7.4.0 - Added official support for WC_Order objects as the first parameter.
+ *
+ * @param int|WC_Order $order The order ID or WC_Order object.
+ * @return string The edit order URL or an empty string if the order is not found or is not a valid order type.
  */
 function wcs_get_edit_post_link( $order ) {
 	$order = is_a( $order, 'WC_Abstract_Order' ) ? $order : wc_get_order( $order );

--- a/includes/wcs-helper-functions.php
+++ b/includes/wcs-helper-functions.php
@@ -68,7 +68,7 @@ function wcs_get_edit_post_link( $post_id ) {
 		return '';
 	}
 
-	return apply_filters( 'get_edit_post_link', $object->get_edit_order_url(), $post_id, '' );
+	return apply_filters( 'get_edit_post_link', $object->get_edit_order_url(), $object->get_id(), '' );
 }
 
 /**


### PR DESCRIPTION
Fixes #822 

## Description

The `wcs_get_edit_post_link()` helper function is designed to get the URL for the edit screen of an order/subscription. 

It's designed to take an order or subscription ID as the parameter, however there are cases where we pass the full order/subscription object.

If you're a 3rd party hooking onto the `'get_edit_post_link'` filter, this means you'd sometimes get a whole order/subscription object - not just an ID. 

**This PR fixes that by making sure we always pass the ID as the second parameter to the [`get_edit_post_link` filter](https://developer.wordpress.org/reference/hooks/get_edit_post_link/)** in line with it's intended design. 

This also appears to fix warnings like this:

```
PHP Deprecated:  Creation of dynamic property WC_Subscription::$ID is deprecated in /plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php on line 211
PHP Deprecated:  Creation of dynamic property WC_Subscription::$filter is deprecated in /plugins/woocommerce-subscriptions-core/includes/class-wc-subscription.php on line 211
```

🗒️ I was curious where these dynamic property errors were coming from so I logged the stack trace. I've included it below for completeness. 

<details><summary>Details</summary>
<p>
<pre>
#0 app/public/wp-includes/post.php(2830): WC_Subscription->__set('ID', 0)
#1 app/public/wp-includes/post.php(1101): sanitize_post(Object(WC_Subscription), 'raw')
#2 app/public/wp-includes/post.php(1571): get_post(Object(WC_Subscription))
#3 app/public/wp-content/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php(798): get_post_type(Object(WC_Subscription))
#4 app/public/wp-includes/class-wp-hook.php(326): Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController->maybe_rewrite_order_edit_link('http://wcsubscr...', Object(WC_Subscription))
#5 app/public/wp-includes/plugin.php(205): WP_Hook->apply_filters('http://wcsubscr...', Array)
#6 app/public/wp-content/plugins/woocommerce-subscriptions-core/includes/wcs-helper-functions.php(71): apply_filters('get_edit_post_l...', 'http://wcsubscr...', Object(WC_Subscription), '')
#7 app/public/wp-content/plugins/woocommerce-subscriptions-core/includes/admin/class-wc-subscriptions-admin.php(1595): wcs_get_edit_post_link(Object(WC_Subscription))
#8 app/public/wp-includes/class-wp-hook.php(324): WC_Subscriptions_Admin::display_renewal_filter_notice('')
#9 app/public/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#10 app/public/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#11 app/public/wp-admin/admin-header.php(303): do_action('admin_notices')
#12 app/public/wp-admin/admin.php(239): require_once('/Users/...')
</pre>

Essentially:
1. we're doing this: `apply_filters( 'get_edit_post_l...', 'http://...', Object(WC_Subscription), '' )`
2. WooCommerce core hooks onto that filter and attempts to rewrite it to the new HPOS link.
3. In the process of doing that they call `get_post_type(Object(WC_Subscription))` which WP eventually tries to set the ID. 😨 

As far as I can tell this doesn't actually lead to any issues.
</p>
</details> 

## How to test this PR

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
Use the testing instructions from the linked issue as a starting point.
-->

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure HPOS is enabled.
4. Go to WooCommerce → Subscriptions
5. Click on one of the Orders columns to filter the order list by that subscriptions orders.

<p align="center">
<img width="1010" alt="Screenshot 2025-03-27 at 3 31 33 pm" src="https://github.com/user-attachments/assets/2d08f6e9-30f5-4e8c-a9f6-0b9bf25ad7f8" />
</p> 

6. Observe the warnings I mentioned above about dynamic variables. 
7. You can also use the example code snippet below to illustrate the inconsistent second param type. 

```php
add_filter( 'get_edit_post_link', function( $url, $post_id ) {
	error_log( '$post_id type: ' . gettype( $post_id ) );
	return $url;
}, 10, 2 );
```

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
