### PR TITLE
Display the parent order icon by default on the WooCommerce Orders list table

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.1.1 - 2025-xx-xx =
+* Update - Display the subscriptions parent order icon in the WooCommerce Orders list table by default.
+
 = 8.1.0 - 2025-03-24 =
 * Update - Improved subscription search performance for WP Post stores by removing unnecessary _order_key and _billing_email meta queries.
 * Update - Make it possible to dispatch the Cancelled Subscription email more than once (when initially set to pending-cancellation, and again when it reaches final cancellation).

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -2455,7 +2455,7 @@ class WC_Subscriptions_Order {
 			echo '<span class="subscription_renewal_order tips" data-tip="' . esc_attr__( 'Renewal Order', 'woocommerce-subscriptions' ) . '"></span>';
 		} elseif ( wcs_order_contains_resubscribe( $order ) ) {
 			echo '<span class="subscription_resubscribe_order tips" data-tip="' . esc_attr__( 'Resubscribe Order', 'woocommerce-subscriptions' ) . '"></span>';
-		} elseif ( apply_filters( 'woocommerce_subscriptions_orders_list_render_parent_order_relation', false, $order ) && wcs_order_contains_parent( $order ) ) {
+		} elseif ( apply_filters( 'woocommerce_subscriptions_orders_list_render_parent_order_relation', true, $order ) && wcs_order_contains_parent( $order ) ) {
 			echo '<span class="subscription_parent_order tips" data-tip="' . esc_attr__( 'Parent Order', 'woocommerce-subscriptions' ) . '"></span>';
 		} else {
 			echo '<span class="normal_order">&ndash;</span>';


### PR DESCRIPTION
In Subscriptions 7.3, we introduced a change that no longer displayed the parent order icon in the Order relation column on the WooCommerce > Orders list table.

This change was to increase performance of the WooCommerce > Orders list table, but it has impacted merchants ability to manage their store which we did not anticipate.

This PR returns the parent order icon by default, while still allowing stores to turn it off via a filter to improve the performance when loading the Orders table.

### Testing instructions
1. Purchase a subscription product on your store
2. Navigate to the WooCommerce > Orders table
3. In the Subscriptions Relation Column confirm you see the parent order icon
![image](https://github.com/user-attachments/assets/0485d5c4-8925-43bc-a631-c049e5ef755f)