### PR TITLE
Prevent WooCommerce Subscriptions buttons from overflowing on the View subscription page

### DIFF
--- a/assets/css/view-subscription.css
+++ b/assets/css/view-subscription.css
@@ -1,6 +1,9 @@
 @media only screen and ( max-width: 768px ) {
 	.subscription_details .button {
+		box-sizing: border-box;
 		margin-bottom: 2px;
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
 		width: 100%;
 		max-width: 200px;
 		text-align: center;

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update - Increase the number of args accepted by wcs_get_subscriptions(), to bring about parity with wc_get_orders().
 * Dev - Update wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys.
 * Fix - Prevent sending renewal reminders for orders with a 0 total.
+* Fix - Prevent WooCommerce Subscriptions buttons from overflowing in the View subscription page
 
 = 8.1.1 - 2025-03-30 =
 * Update - Display the subscriptions parent order icon in the WooCommerce Orders list table by default


### PR DESCRIPTION
Closes WOOPLUG-3523

## Description

In some themes, the buttons added by WooCommerce Subscriptions to the _View subscription_ page (under _My Account_) were overflowing the table. This issue fixes that by:

1. Setting `box-sizing` to `border-box`, otherwise the `100%` width was causing the button to overflow.
2. Set up a hard-coded left and right padding to prevent themes with large paddings causing the buttons to be too big, which makes the left column too narrow.

<img src="https://github.com/user-attachments/assets/7907e484-a37a-4fbc-a9e7-4878c05708ee" alt="" width="375" />

## How to test this PR

0. Enable the Twenty Twenty Five theme.
1. Create a Subscription product.
4. In the frontend, add it to your cart and purchase it.
5. Go to My Account > Subscriptions and open that individual subscription.
6. Verify the buttons don't overflow the table and don't make the left column too narrow:

Before | After
--- | ---
![Captura de pantalla feta el 2025-04-01 a les 11 44 39](https://github.com/user-attachments/assets/2ed08a70-a40f-47f6-8b5c-f3cd42dcb5bd) | ![Captura de pantalla feta el 2025-04-01 a les 11 44 37](https://github.com/user-attachments/assets/b4d290ee-c027-4aff-93f2-51d8575dd896)

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
