### PR TITLE
Pagination Controls for Frontend Subscriptions View

### DIFF
--- a/assets/css/view-subscription.css
+++ b/assets/css/view-subscription.css
@@ -103,8 +103,9 @@
 	display: inline-block;
 }
 
-.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a.disabled {
-	visibility: hidden;
+.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a.disabled:hover {
+	cursor: default;
+	text-decoration: none;
 }
 
 .woocommerce-subscriptions-related-orders-pagination-links .pagination-links a .symbol {
@@ -119,7 +120,7 @@
 	direction: rtl;
 }
 
-@media (max-width: 30em) {
+@media ( max-width: 30em ) {
 	.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a {
 		padding: 0.5em 1em;
 	}

--- a/assets/css/view-subscription.css
+++ b/assets/css/view-subscription.css
@@ -90,3 +90,22 @@
 	font-size: 1.4em;
 	text-align: center;
 }
+
+.woocommerce-subscriptions-related-orders-pagination-links {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-bottom: 1em;
+}
+
+.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a {
+	display: inline-block;
+}
+
+.rtl .woocommerce-subscriptions-related-orders-pagination-links {
+	flex-direction: row-reverse;
+}
+
+.rtl .woocommerce-subscriptions-related-orders-pagination-links .pagination-links {
+	direction: rtl;
+}

--- a/assets/css/view-subscription.css
+++ b/assets/css/view-subscription.css
@@ -91,7 +91,7 @@
 	text-align: center;
 }
 
-.woocommerce-subscriptions-related-orders-pagination-links {
+.woocommerce-subscriptions-related-orders-pagination-links.woocommerce-pagination {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;

--- a/assets/css/view-subscription.css
+++ b/assets/css/view-subscription.css
@@ -96,10 +96,19 @@
 	flex-direction: row;
 	justify-content: space-between;
 	margin-bottom: 1em;
+	width: 100%;
 }
 
 .woocommerce-subscriptions-related-orders-pagination-links .pagination-links a {
 	display: inline-block;
+}
+
+.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a.disabled {
+	visibility: hidden;
+}
+
+.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a .symbol {
+	display: none;
 }
 
 .rtl .woocommerce-subscriptions-related-orders-pagination-links {
@@ -108,4 +117,18 @@
 
 .rtl .woocommerce-subscriptions-related-orders-pagination-links .pagination-links {
 	direction: rtl;
+}
+
+@media (max-width: 30em) {
+	.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a {
+		padding: 0.5em 1em;
+	}
+
+	.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a .label {
+		display: none;
+	}
+
+	.woocommerce-subscriptions-related-orders-pagination-links .pagination-links a .symbol {
+		display: inherit;
+	}
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 8.2.0 - 2025-04-14 =
 * Update - Increase the number of args accepted by wcs_get_subscriptions(), to bring about parity with wc_get_orders().
+* Update - Add pagination to the related orders list in the My Account > View Subscription page.
 * Dev - Update wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys.
 * Fix - Prevent sending renewal reminders for orders with a 0 total.
 * Fix - Ensure the second parameter passed to the 'get_edit_post_link' filter is an integer.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,10 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.3.0 - 2025-xx-xx=
+* Update - Add pagination to the related orders list in the My Account > View Subscription page.
+
 = 8.2.0 - 2025-04-14 =
 * Update - Increase the number of args accepted by wcs_get_subscriptions(), to bring about parity with wc_get_orders().
-* Update - Add pagination to the related orders list in the My Account > View Subscription page.
 * Dev - Update wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys.
 * Fix - Prevent sending renewal reminders for orders with a 0 total.
 * Fix - Ensure the second parameter passed to the 'get_edit_post_link' filter is an integer.

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2151,13 +2151,13 @@ class WC_Subscription extends WC_Order {
 	 * @param int          $page          Optional. Can be used to specify which page of results is desired.
 	 * @param int          $limit         Optional. Can be used to specify how many results are desired per page. Defaults to -1, which is treated as meaning 'unlimited'.
 	 *
-	 * @return array {
+	 * @return object {
 	 *     array: orders,
 	 *     int:   total,
 	 *     int:   max_num_pages
 	 * }
 	 */
-	public function get_paginated_related_orders( string $return_fields = 'ids', $order_types = array( 'parent', 'renewal', 'switch' ), int $page = 1, int $limit = 10 ): array {
+	public function get_paginated_related_orders( string $return_fields = 'ids', $order_types = array( 'parent', 'renewal', 'switch' ), int $page = 1, int $limit = 10 ): object {
 		$order_types    = ! is_array( $order_types ) ? (array) $order_types : $order_types;
 		$related_orders = [];
 
@@ -2178,7 +2178,7 @@ class WC_Subscription extends WC_Order {
 
 		$order_ids     = array_unique( $this->get_related_order_ids( $order_types, 'flat' ) );
 		$total         = count( $order_ids );
-		$max_num_pages = (int) ceil( $total / $limit );
+		$max_num_pages = 0 === $limit ? 0 : (int) ceil( $total / $limit );
 		rsort( $order_ids );
 
 		if ( $limit >= 0 && $page > 0 ) {
@@ -2190,7 +2190,7 @@ class WC_Subscription extends WC_Order {
 			$related_orders[ $id ] = 'all' === $return_fields ? wc_get_order( $id ) : $id;
 		}
 
-		return array(
+		return (object) array(
 			'orders'        => $related_orders,
 			'total'         => $total,
 			'max_num_pages' => $max_num_pages,

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2144,7 +2144,7 @@ class WC_Subscription extends WC_Order {
 	/**
 	 * Offers a means of fetching paginated sets of related orders.
 	 *
-	 * @since 7.4.0
+	 * @since 7.5.0
 	 *
 	 * @param string       $return_fields The columns to return, either 'all' or 'ids'
 	 * @param array|string $order_types   Can include 'any', 'parent', 'renewal', 'resubscribe' and/or 'switch'. Custom types possible via the 'woocommerce_subscription_related_orders' filter. Defaults to array( 'parent', 'renewal', 'switch' ).
@@ -2162,17 +2162,17 @@ class WC_Subscription extends WC_Order {
 		$related_orders = [];
 
 		if ( ! in_array( $return_fields, array( 'all', 'ids' ), true ) ) {
-			wc_doing_it_wrong( __METHOD__, 'The $return_fields parameter must be either "all" or "ids".', '7.4.0' );
+			wc_doing_it_wrong( __METHOD__, 'The $return_fields parameter must be either "all" or "ids".', '7.5.0' );
 			$return_fields = 'ids';
 		}
 
 		if ( $page < 1 ) {
-			wc_doing_it_wrong( __METHOD__, 'The $page parameter must be a positive, non-zero integer.', '7.4.0' );
+			wc_doing_it_wrong( __METHOD__, 'The $page parameter must be a positive, non-zero integer.', '7.5.0' );
 			$page = 1;
 		}
 
 		if ( $limit < -1 ) {
-			wc_doing_it_wrong( __METHOD__, 'The $limit parameter must be an integer, and must have a value of -1 or higher.', '7.4.0' );
+			wc_doing_it_wrong( __METHOD__, 'The $limit parameter must be an integer, and must have a value of -1 or higher.', '7.5.0' );
 			$limit = 10;
 		}
 

--- a/includes/class-wc-subscription.php
+++ b/includes/class-wc-subscription.php
@@ -2142,6 +2142,62 @@ class WC_Subscription extends WC_Order {
 	}
 
 	/**
+	 * Offers a means of fetching paginated sets of related orders.
+	 *
+	 * @since 7.4.0
+	 *
+	 * @param string       $return_fields The columns to return, either 'all' or 'ids'
+	 * @param array|string $order_types   Can include 'any', 'parent', 'renewal', 'resubscribe' and/or 'switch'. Custom types possible via the 'woocommerce_subscription_related_orders' filter. Defaults to array( 'parent', 'renewal', 'switch' ).
+	 * @param int          $page          Optional. Can be used to specify which page of results is desired.
+	 * @param int          $limit         Optional. Can be used to specify how many results are desired per page. Defaults to -1, which is treated as meaning 'unlimited'.
+	 *
+	 * @return array {
+	 *     array: orders,
+	 *     int:   total,
+	 *     int:   max_num_pages
+	 * }
+	 */
+	public function get_paginated_related_orders( string $return_fields = 'ids', $order_types = array( 'parent', 'renewal', 'switch' ), int $page = 1, int $limit = 10 ): array {
+		$order_types    = ! is_array( $order_types ) ? (array) $order_types : $order_types;
+		$related_orders = [];
+
+		if ( ! in_array( $return_fields, array( 'all', 'ids' ), true ) ) {
+			wc_doing_it_wrong( __METHOD__, 'The $return_fields parameter must be either "all" or "ids".', '7.4.0' );
+			$return_fields = 'ids';
+		}
+
+		if ( $page < 1 ) {
+			wc_doing_it_wrong( __METHOD__, 'The $page parameter must be a positive, non-zero integer.', '7.4.0' );
+			$page = 1;
+		}
+
+		if ( $limit < -1 ) {
+			wc_doing_it_wrong( __METHOD__, 'The $limit parameter must be an integer, and must have a value of -1 or higher.', '7.4.0' );
+			$limit = 10;
+		}
+
+		$order_ids     = array_unique( $this->get_related_order_ids( $order_types, 'flat' ) );
+		$total         = count( $order_ids );
+		$max_num_pages = (int) ceil( $total / $limit );
+		rsort( $order_ids );
+
+		if ( $limit >= 0 && $page > 0 ) {
+			$offset    = ( $page - 1 ) * $limit;
+			$order_ids = array_slice( $order_ids, $offset, $limit );
+		}
+
+		foreach ( $order_ids as $id ) {
+			$related_orders[ $id ] = 'all' === $return_fields ? wc_get_order( $id ) : $id;
+		}
+
+		return array(
+			'orders'        => $related_orders,
+			'total'         => $total,
+			'max_num_pages' => $max_num_pages,
+		);
+	}
+
+	/**
 	 * Get the related order IDs for a subscription based on an order type.
 	 *
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.3.0

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -968,8 +968,8 @@ class WC_Subscriptions_Order {
 	 * Introduced to support pagination of the related orders list (within the My Account > View Subscription
 	 * screen).
 	 *
-     * @since 7.5.0 Updated to support pagination of the related orders list.
-     *
+	 * @since 7.5.0 Updated to support pagination of the related orders list.
+	 *
 	 * @param WC_Subscription $subscription        The subscription whose related orders we are interested in.
 	 * @param int[]|null      $subscription_orders IDs of the related orders.
 	 * @param int|null        $page                The current page number.

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -933,7 +933,7 @@ class WC_Subscriptions_Order {
 	 * Loads the related orders table on the view subscription page
 	 *
 	 * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.0.
-	 * @since 7.4.0 Updated to support pagination of the related orders list.
+	 * @since 7.5.0 Updated to support pagination of the related orders list.
 	 *
 	 * @param WC_Subscription $subscription The subscription whose related orders we are interested in.
 	 */

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -61,7 +61,8 @@ class WC_Subscriptions_Order {
 
 		add_action( 'woocommerce_order_details_after_order_table', __CLASS__ . '::add_subscriptions_to_view_order_templates', 10, 1 );
 
-		add_action( 'woocommerce_subscription_details_after_subscription_table', __CLASS__ . '::get_related_orders_template', 10, 1 );
+		add_action( 'woocommerce_subscription_details_after_subscription_table', __CLASS__ . '::get_related_orders_template' );
+		add_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', __CLASS__ . '::get_related_orders_pagination_template', 5, 4 );
 
 		add_filter( 'woocommerce_my_account_my_orders_actions', __CLASS__ . '::maybe_remove_pay_action', 10, 2 );
 
@@ -933,7 +934,6 @@ class WC_Subscriptions_Order {
 	 * Loads the related orders table on the view subscription page
 	 *
 	 * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.0.
-	 * @since 7.5.0 Updated to support pagination of the related orders list.
 	 *
 	 * @param WC_Subscription $subscription The subscription whose related orders we are interested in.
 	 */
@@ -962,6 +962,34 @@ class WC_Subscriptions_Order {
 				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
 			);
 		}
+	}
+
+	/**
+	 * Introduced to support pagination of the related orders list (within the My Account > View Subscription
+	 * screen).
+	 *
+	 * @param WC_Subscription $subscription        The subscription whose related orders we are interested in.
+	 * @param int[]|null      $subscription_orders IDs of the related orders.
+	 * @param int|null        $page                The current page number.
+	 * @param int|null        $max_num_pages       The maximum number of pages in the set.
+	 *
+	 * @since 7.5.0 Updated to support pagination of the related orders list.
+	 *
+	 */
+	public static function get_related_orders_pagination_template( WC_Subscription $subscription, ?array $subscription_orders = null, ?int $page = null, ?int $max_num_pages = null ) {
+		if ( null === $page || null === $max_num_pages ) {
+			return;
+		}
+
+		wc_get_template(
+			'myaccount/related-orders-pagination.php',
+			array(
+				'page'          => $page,
+				'max_num_pages' => $max_num_pages,
+			),
+			'',
+			WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )
+		);
 	}
 
 	/**

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -968,13 +968,14 @@ class WC_Subscriptions_Order {
 	 * Introduced to support pagination of the related orders list (within the My Account > View Subscription
 	 * screen).
 	 *
+     * @since 7.5.0 Updated to support pagination of the related orders list.
+     *
 	 * @param WC_Subscription $subscription        The subscription whose related orders we are interested in.
 	 * @param int[]|null      $subscription_orders IDs of the related orders.
 	 * @param int|null        $page                The current page number.
 	 * @param int|null        $max_num_pages       The maximum number of pages in the set.
 	 *
-	 * @since 7.5.0 Updated to support pagination of the related orders list.
-	 *
+	 * @return void
 	 */
 	public static function get_related_orders_pagination_template( WC_Subscription $subscription, ?array $subscription_orders = null, ?int $page = null, ?int $max_num_pages = null ) {
 		if ( null === $page || null === $max_num_pages ) {

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -932,14 +932,22 @@ class WC_Subscriptions_Order {
 	/**
 	 * Loads the related orders table on the view subscription page
 	 *
-	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
+	 * @since 1.0.0 Migrated from WooCommerce Subscriptions v2.0.
+	 * @since 7.4.0 Updated to support pagination of the related orders list.
+	 *
+	 * @param WC_Subscription $subscription The subscription whose related orders we are interested in.
 	 */
 	public static function get_related_orders_template( $subscription ) {
-        // phpcs:disable 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$page  = (int) ( $_GET['related_orders_page'] ?? 1 );
 		$limit = (int) ( $_GET['related_orders_limit'] ?? 10 );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitiz ed
 
-		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, $limit);
+		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, $limit );
 		$subscription_orders = $related_orders['orders'];
 
 		if ( 0 !== count( $subscription_orders ) ) {

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -935,8 +935,12 @@ class WC_Subscriptions_Order {
 	 * @since 1.0.0 - Migrated from WooCommerce Subscriptions v2.0
 	 */
 	public static function get_related_orders_template( $subscription ) {
+        // phpcs:disable 
+		$page  = (int) ( $_GET['related_orders_page'] ?? 1 );
+		$limit = (int) ( $_GET['related_orders_limit'] ?? 10 );
 
-		$subscription_orders = $subscription->get_related_orders();
+		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, $limit);
+		$subscription_orders = $related_orders['orders'];
 
 		if ( 0 !== count( $subscription_orders ) ) {
 			wc_get_template(
@@ -944,6 +948,8 @@ class WC_Subscriptions_Order {
 				array(
 					'subscription_orders' => $subscription_orders,
 					'subscription'        => $subscription,
+					'page'                => $page,
+					'max_num_pages'       => $related_orders['max_num_pages'],
 				),
 				'',
 				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -945,7 +945,7 @@ class WC_Subscriptions_Order {
 		$limit = (int) ( $_GET['related_orders_limit'] ?? 10 );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitiz ed
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, $limit );
 		$subscription_orders = $related_orders->orders;

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -948,7 +948,7 @@ class WC_Subscriptions_Order {
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitiz ed
 
 		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, $limit );
-		$subscription_orders = $related_orders['orders'];
+		$subscription_orders = $related_orders->orders;
 
 		if ( 0 !== count( $subscription_orders ) ) {
 			wc_get_template(
@@ -957,7 +957,7 @@ class WC_Subscriptions_Order {
 					'subscription_orders' => $subscription_orders,
 					'subscription'        => $subscription,
 					'page'                => $page,
-					'max_num_pages'       => $related_orders['max_num_pages'],
+					'max_num_pages'       => $related_orders->max_num_pages,
 				),
 				'',
 				WC_Subscriptions_Core_Plugin::instance()->get_subscriptions_core_directory( 'templates/' )

--- a/includes/class-wc-subscriptions-order.php
+++ b/includes/class-wc-subscriptions-order.php
@@ -941,13 +941,12 @@ class WC_Subscriptions_Order {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$page  = (int) ( $_GET['related_orders_page'] ?? 1 );
-		$limit = (int) ( $_GET['related_orders_limit'] ?? 10 );
+		$page = (int) ( $_GET['related_orders_page'] ?? 1 );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, $limit );
+		$related_orders      = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), $page, 10 );
 		$subscription_orders = $related_orders->orders;
 
 		if ( 0 !== count( $subscription_orders ) ) {

--- a/templates/myaccount/related-orders-pagination.php
+++ b/templates/myaccount/related-orders-pagination.php
@@ -24,11 +24,12 @@ $page_link = static function( int $page, string $type, string $label, string $al
 	$base_classes = 'button woocommerce-button wp-element-button';
 	$classes      = esc_attr( $base_classes . ' woocommerce-button--' . $type . ( $enabled ? '' : ' disabled' ) );
 	$url          = esc_url( add_query_arg( 'related_orders_page', $page, '#woocommerce-subscriptions-related-orders-table' ) );
+	$href         = $enabled ? "href='$url'" : '';
 	$label        = esc_html( $label );
 	$aria_label   = esc_attr( $label );
 	$alt_symbol   = esc_html( $alt_symbol );
 
-	return "<a href='$url' class='$classes' aria-label='$aria_label'><span class='label'>$label</span><span class='symbol'>$alt_symbol</span></a>";
+	return "<a $href class='$classes' aria-label='$aria_label'><span class='label'>$label</span><span class='symbol'>$alt_symbol</span></a>";
 };
 
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Our helper function takes care of escaping.

--- a/templates/myaccount/related-orders-pagination.php
+++ b/templates/myaccount/related-orders-pagination.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Pagination controls in support of the related orders list found on the My Account > View Subscription page.
  *

--- a/templates/myaccount/related-orders-pagination.php
+++ b/templates/myaccount/related-orders-pagination.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Pagination controls in support of the related orders list found on the My Account > View Subscription page.
+ *
+ * @category WooCommerce Subscriptions/Templates
+ * @version  7.5.0
+ *
+ * @var int $max_num_pages
+ * @var int $page
+ * @var WC_Subscription $subscription
+ * @var int[] $subscription_orders
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( 1 === $max_num_pages && 1 === $page ) {
+	return;
+}
+
+$prev_page = max( 1, $page - 1 );
+$next_page = min( $max_num_pages, $page + 1 );
+
+$page_link = static function( int $page, string $type, string $label, string $alt_symbol, bool $enabled = true ): string {
+	$base_classes = 'button woocommerce-button wp-element-button';
+	$classes      = esc_attr( $base_classes . ' woocommerce-button--' . $type . ( $enabled ? '' : ' disabled' ) );
+	$url          = esc_url( add_query_arg( 'related_orders_page', $page, '#woocommerce-subscriptions-related-orders-table' ) );
+	$label        = esc_html( $label );
+	$aria_label   = esc_attr( $label );
+	$alt_symbol   = esc_html( $alt_symbol );
+
+	return "<a href='$url' class='$classes' aria-label='$aria_label'><span class='label'>$label</span><span class='symbol'>$alt_symbol</span></a>";
+};
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Our helper function takes care of escaping.
+?>
+	<div class="woocommerce-subscriptions-related-orders-pagination-links woocommerce-pagination">
+		<div class="pagination-links">
+			<?php echo $page_link( 1, 'first', _x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ), '«', 1 !== $page ); ?>
+			<?php echo $page_link( $prev_page, 'prev', _x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ), '‹', 1 !== $page ); ?>
+		</div>
+
+		<div class="pagination-links">
+			<?php echo $page_link( $next_page, 'next', _x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ), '›', $page < $max_num_pages ); ?>
+			<?php echo $page_link( $max_num_pages, 'last', _x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ), '»', $page < $max_num_pages ); ?>
+		</div>
+	</div>
+<?php // phpcs:enable ?>

--- a/templates/myaccount/related-orders-pagination.php
+++ b/templates/myaccount/related-orders-pagination.php
@@ -7,8 +7,6 @@
  *
  * @var int $max_num_pages
  * @var int $page
- * @var WC_Subscription $subscription
- * @var int[] $subscription_orders
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -108,26 +108,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 	$prev_page = max( 1, $page - 1 );
 	$next_page = min( $max_num_pages, $page + 1 );
 
-	$first = '?related_orders_page=1#woocommerce-subscriptions-related-orders-table';
-	$prev  = '?related_orders_page=' . $prev_page . '#woocommerce-subscriptions-related-orders-table';
-	$next  = '?related_orders_page=' . $next_page . '#woocommerce-subscriptions-related-orders-table';
-	$last  = '?related_orders_page=' . $max_num_pages . '#woocommerce-subscriptions-related-orders-table';
+	$page_link = static function( int $page, string $type, string $label, bool $enabled = true ): string {
+		$base_classes = 'button woocommerce-button wp-element-button';
+		$classes      = esc_attr( $base_classes . ' woocommerce-button--' . $type . ( $enabled ? '' : ' disabled' ) );
+		$url          = esc_url( add_query_arg( 'related_orders_page', $page, '#woocommerce-subscriptions-related-orders-table' ) );
 
-	$base_classes  = 'woocommerce-button woocommerce-Button woocommerce-Button--first button wp-element-button';
-	$first_classes = $base_classes . ' woocommerce-button--first' . ( 1 === $page ? ' disabled' : '' );
-	$prev_classes  = $base_classes . ' woocommerce-button--prev' . ( 1 === $page ? ' disabled' : '' );
-	$next_classes  = $base_classes . ' woocommerce-button--next' . ( $page === $max_num_pages ? ' disabled' : '' );
-	$last_classes  = $base_classes . ' woocommerce-button--last' . ( $page === $max_num_pages ? ' disabled' : '' );
+		return "<a href='$url' class='$classes'>$label</a>";
+	};
+
+    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Our helper function takes care of escaping.
 	?>
 	<div class="pagination-links">
-		<a class="<?php echo esc_attr( $first_classes ); ?>" href="<?php echo esc_attr( $first ); ?>"><?php echo esc_html_x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
-		<a class="<?php echo esc_attr( $prev_classes ); ?>" href="<?php echo esc_attr( $prev ); ?>"><?php echo esc_html_x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
+		<?php echo $page_link( 1, 'first', _x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ), 1 !== $page ); ?>
+		<?php echo $page_link( $prev_page, 'prev', _x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ), 1 !== $page ); ?>
 	</div>
 
 	<div class="pagination-links">
-		<a class="<?php echo esc_attr( $next_classes ); ?>" href="<?php echo esc_attr( $next ); ?>"><?php echo esc_html_x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
-		<a class="<?php echo esc_attr( $last_classes ); ?>" href="<?php echo esc_attr( $last ); ?>"><?php echo esc_html_x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
+		<?php echo $page_link( $next_page, 'next', _x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ), $page < $max_num_pages ); ?>
+		<?php echo $page_link( $max_num_pages, 'last', _x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ), $page < $max_num_pages ); ?>
 	</div>
+	<?php // phpcs:enable ?>
 </div>
 
 <?php do_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', $subscription ); ?>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -104,38 +104,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 </table>
 
 <?php
-$prev_page = max( 1, $page - 1 );
-$next_page = min( $max_num_pages, $page + 1 );
-
-$page_link = static function( int $page, string $type, string $label, string $alt_symbol, bool $enabled = true ): string {
-	$base_classes = 'button woocommerce-button wp-element-button';
-	$classes      = esc_attr( $base_classes . ' woocommerce-button--' . $type . ( $enabled ? '' : ' disabled' ) );
-	$url          = esc_url( add_query_arg( 'related_orders_page', $page, '#woocommerce-subscriptions-related-orders-table' ) );
-	$label        = esc_html( $label );
-	$aria_label   = esc_attr( $label );
-	$alt_symbol   = esc_html( $alt_symbol );
-
-	return "<a href='$url' class='$classes' aria-label='$aria_label'><span class='label'>$label</span><span class='symbol'>$alt_symbol</span></a>";
-};
-
-if ( $max_num_pages > 1 || ( 1 === $max_num_pages && 1 !== $page ) ) :
-
-	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Our helper function takes care of escaping.
-	?>
-		<div class="woocommerce-subscriptions-related-orders-pagination-links woocommerce-pagination">
-			<div class="pagination-links">
-				<?php echo $page_link( 1, 'first', _x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ), '«', 1 !== $page ); ?>
-				<?php echo $page_link( $prev_page, 'prev', _x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ), '‹', 1 !== $page ); ?>
-			</div>
-
-			<div class="pagination-links">
-				<?php echo $page_link( $next_page, 'next', _x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ), '›', $page < $max_num_pages ); ?>
-				<?php echo $page_link( $max_num_pages, 'last', _x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ), '»', $page < $max_num_pages ); ?>
-			</div>
-		</div>
-	<?php
-	// phpcs:enable
-endif;
-
-do_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', $subscription );
+/**
+ * Allows additional content to be added following the related orders table.
+ *
+ * @since 2.0.0 Hook added.
+ * @since 7.5.0 Additional params $subscription_orders, $page and $max_num_pages added.
+ *
+ * @param WC_Subscription $subscription
+ * @param int[]           $subscription_orders
+ * @param int             $page
+ * @param int             $max_num_pages
+ */
+do_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', $subscription, $subscription_orders, $page, $max_num_pages );
 ?>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -3,7 +3,7 @@
  * Related Orders table on the View Subscription page.
  *
  * @category WooCommerce Subscriptions/Templates
- * @version  7.4.0
+ * @version  7.5.0
  *
  * @var int             $max_num_pages
  * @var int             $page

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -103,31 +103,39 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tbody>
 </table>
 
-<div class="woocommerce-subscriptions-related-orders-pagination-links woocommerce-pagination">
-	<?php
-	$prev_page = max( 1, $page - 1 );
-	$next_page = min( $max_num_pages, $page + 1 );
+<?php
+$prev_page = max( 1, $page - 1 );
+$next_page = min( $max_num_pages, $page + 1 );
 
-	$page_link = static function( int $page, string $type, string $label, bool $enabled = true ): string {
-		$base_classes = 'button woocommerce-button wp-element-button';
-		$classes      = esc_attr( $base_classes . ' woocommerce-button--' . $type . ( $enabled ? '' : ' disabled' ) );
-		$url          = esc_url( add_query_arg( 'related_orders_page', $page, '#woocommerce-subscriptions-related-orders-table' ) );
+$page_link = static function( int $page, string $type, string $label, string $alt_symbol, bool $enabled = true ): string {
+	$base_classes = 'button woocommerce-button wp-element-button';
+	$classes      = esc_attr( $base_classes . ' woocommerce-button--' . $type . ( $enabled ? '' : ' disabled' ) );
+	$url          = esc_url( add_query_arg( 'related_orders_page', $page, '#woocommerce-subscriptions-related-orders-table' ) );
+	$label        = esc_html( $label );
+	$aria_label   = esc_attr( $label );
+	$alt_symbol   = esc_html( $alt_symbol );
 
-		return "<a href='$url' class='$classes'>$label</a>";
-	};
+	return "<a href='$url' class='$classes' aria-label='$aria_label'><span class='label'>$label</span><span class='symbol'>$alt_symbol</span></a>";
+};
 
-    // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Our helper function takes care of escaping.
+if ( $max_num_pages > 1 || ( 1 === $max_num_pages && 1 !== $page ) ) :
+
+	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Our helper function takes care of escaping.
 	?>
-	<div class="pagination-links">
-		<?php echo $page_link( 1, 'first', _x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ), 1 !== $page ); ?>
-		<?php echo $page_link( $prev_page, 'prev', _x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ), 1 !== $page ); ?>
-	</div>
+		<div class="woocommerce-subscriptions-related-orders-pagination-links woocommerce-pagination">
+			<div class="pagination-links">
+				<?php echo $page_link( 1, 'first', _x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ), '«', 1 !== $page ); ?>
+				<?php echo $page_link( $prev_page, 'prev', _x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ), '‹', 1 !== $page ); ?>
+			</div>
 
-	<div class="pagination-links">
-		<?php echo $page_link( $next_page, 'next', _x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ), $page < $max_num_pages ); ?>
-		<?php echo $page_link( $max_num_pages, 'last', _x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ), $page < $max_num_pages ); ?>
-	</div>
-	<?php // phpcs:enable ?>
-</div>
+			<div class="pagination-links">
+				<?php echo $page_link( $next_page, 'next', _x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ), '›', $page < $max_num_pages ); ?>
+				<?php echo $page_link( $max_num_pages, 'last', _x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ), '»', $page < $max_num_pages ); ?>
+			</div>
+		</div>
+	<?php
+	// phpcs:enable
+endif;
 
-<?php do_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', $subscription ); ?>
+do_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', $subscription );
+?>

--- a/templates/myaccount/related-orders.php
+++ b/templates/myaccount/related-orders.php
@@ -1,10 +1,14 @@
 <?php
 /**
- * Related Orders table on the View Subscription page
+ * Related Orders table on the View Subscription page.
  *
- * @author   Prospress
  * @category WooCommerce Subscriptions/Templates
- * @version  7.3.0 - Migrated from WooCommerce Subscriptions v2.6.2
+ * @version  7.4.0
+ *
+ * @var int             $max_num_pages
+ * @var int             $page
+ * @var WC_Subscription $subscription
+ * @var int[]           $subscription_orders
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<h2><?php esc_html_e( 'Related orders', 'woocommerce-subscriptions' ); ?></h2>
 </header>
 
-<table class="shop_table shop_table_responsive my_account_orders woocommerce-orders-table woocommerce-MyAccount-orders woocommerce-orders-table--orders">
+<table id="woocommerce-subscriptions-related-orders-table" class="shop_table shop_table_responsive my_account_orders woocommerce-orders-table woocommerce-MyAccount-orders woocommerce-orders-table--orders">
 
 	<thead>
 		<tr>
@@ -98,5 +102,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endforeach; ?>
 	</tbody>
 </table>
+
+<div class="woocommerce-subscriptions-related-orders-pagination-links woocommerce-pagination">
+	<?php
+	$prev_page = max( 1, $page - 1 );
+	$next_page = min( $max_num_pages, $page + 1 );
+
+	$first = '?related_orders_page=1#woocommerce-subscriptions-related-orders-table';
+	$prev  = '?related_orders_page=' . $prev_page . '#woocommerce-subscriptions-related-orders-table';
+	$next  = '?related_orders_page=' . $next_page . '#woocommerce-subscriptions-related-orders-table';
+	$last  = '?related_orders_page=' . $max_num_pages . '#woocommerce-subscriptions-related-orders-table';
+
+	$base_classes  = 'woocommerce-button woocommerce-Button woocommerce-Button--first button wp-element-button';
+	$first_classes = $base_classes . ' woocommerce-button--first' . ( 1 === $page ? ' disabled' : '' );
+	$prev_classes  = $base_classes . ' woocommerce-button--prev' . ( 1 === $page ? ' disabled' : '' );
+	$next_classes  = $base_classes . ' woocommerce-button--next' . ( $page === $max_num_pages ? ' disabled' : '' );
+	$last_classes  = $base_classes . ' woocommerce-button--last' . ( $page === $max_num_pages ? ' disabled' : '' );
+	?>
+	<div class="pagination-links">
+		<a class="<?php echo esc_attr( $first_classes ); ?>" href="<?php echo esc_attr( $first ); ?>"><?php echo esc_html_x( 'First', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
+		<a class="<?php echo esc_attr( $prev_classes ); ?>" href="<?php echo esc_attr( $prev ); ?>"><?php echo esc_html_x( 'Previous', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
+	</div>
+
+	<div class="pagination-links">
+		<a class="<?php echo esc_attr( $next_classes ); ?>" href="<?php echo esc_attr( $next ); ?>"><?php echo esc_html_x( 'Next', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
+		<a class="<?php echo esc_attr( $last_classes ); ?>" href="<?php echo esc_attr( $last ); ?>"><?php echo esc_html_x( 'Last', 'Related orders pagination', 'woocommerce-subscriptions' ); ?></a>
+	</div>
+</div>
 
 <?php do_action( 'woocommerce_subscription_details_after_subscription_related_orders_table', $subscription ); ?>

--- a/tests/unit/test-class-wc-subscription.php
+++ b/tests/unit/test-class-wc-subscription.php
@@ -46,4 +46,43 @@ class WC_Subscription_Test extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	public function test_get_paginated_related_orders(): void {
+		$subscription = WCS_Helper_Subscription::create_subscription(
+			array(
+				'status'                  => 'active',
+				'requires_manual_renewal' => true,
+			)
+		);
+
+		// We create a mix of renewal and switch orders partly to provide a more authentic test, and also because these
+		// are cached separately from one another (and we want to ensure we are fetching from both in our tests).
+		for ( $i = 0; $i < 7; $i++ ) {
+			$i % 2
+				? WCS_Helper_Subscription::create_renewal_order( $subscription )
+				: WCS_Helper_Subscription::create_switch_order( $subscription );
+		}
+
+		$all_related_orders        = $subscription->get_related_orders();
+		$zero_related_orders       = $subscription->get_paginated_related_orders( 'ids', array( 'renewal', 'switch' ), 1, 0 )->orders;
+		$all_orders_page_1_limit_4 = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), 1, 4 )->orders;
+		$all_orders_page_2_limit_4 = $subscription->get_paginated_related_orders( 'ids', array( 'parent', 'renewal', 'switch' ), 2, 4 )->orders;
+		$renewal_orders_only       = $subscription->get_paginated_related_orders( 'ids', 'renewal' )->orders;
+
+		$this->assertCount( 0, $zero_related_orders, 'No orders were returned when requesting page 1 of 0 related orders.' );
+		$this->assertCount( 7, $all_related_orders, 'A total of 7 orders exist in relation to the test subscription.' );
+		$this->assertCount( 4, $all_orders_page_1_limit_4, 'First 4 related orders successfully retrieved (page 1).' );
+		$this->assertCount( 3, $all_orders_page_2_limit_4, 'Final 3 related orders successfully retrieved (page 2).' );
+		$this->assertCount( 3, $renewal_orders_only, 'All 3 renewal orders were successfully fetched.' );
+	}
+
+	public function test_get_paginated_related_orders_with_invalid_page_number(): void {
+		$this->setExpectedIncorrectUsage( WC_Subscription::class . '::get_paginated_related_orders' );
+		WCS_Helper_Subscription::create_subscription()->get_paginated_related_orders( 'ids', array( 'switch' ), 0 );
+	}
+
+	public function test_get_paginated_related_orders_with_invalid_limit(): void {
+		$this->setExpectedIncorrectUsage( WC_Subscription::class . '::get_paginated_related_orders' );
+		WCS_Helper_Subscription::create_subscription()->get_paginated_related_orders( 'ids', array( 'switch' ), 1, -2 );
+	}
 }


### PR DESCRIPTION
Subscribers can visit **My Account ‣ Subscriptions ‣ View Subscription** and, amongst other things, they will be presented with a list of related orders. However, there is currently no limit on how many orders are listed. Imagine a subscription that renews daily: if this runs for a few years, we'll have hundreds (and eventually *thousands)* of related orders. 

- This presents a usability issue:
    - A massive table of hundreds (/thousands) of rows is not easy to consume.
    - It pushes other information out of sight (by default, billing and shipping addresses).
- It presents a performance issue:
    - Our default caching strategy (see [WCS_Related_Order_Store_Cached_CPT](https://github.com/Automattic/woocommerce-subscriptions-core/blob/8.1.1/includes/data-stores/class-wcs-related-order-store-cached-cpt.php)) seems to scale really quite well, by storing several lists of related order IDs for each subscription, and I have not touched this. *If we **do** feel a need to adapt this, or supplement the current caching strategy with something else, it should probably be a project of its own.*
    - The cost of fetching the raw IDs, then, isn't part of what we address here. Hydration of the order objects is.

With that context in mind, in this PR we introduce a new method to the `WC_Subscription` class, making it possible to fetch individual pages of related orders, and we add pagination controls to the frontend related orders list.

<div align="center"><img width="650" alt="" src="https://github.com/user-attachments/assets/087294b7-79a3-46cc-a16b-a4ef843c7e38" /></div>

Fixes WOOSUBS-162 | https://github.com/woocommerce/woocommerce-subscriptions/issues/4751

## Further notes

From a local test using a subscription with 339 related orders, I observed the following results (measured using Query Monitor):

| Branch | Object cache | Peak memory (MB) | Total DB queries |
| --- | --- | --- | --- |
| Trunk | off | 198 | 5381 |
| Trunk | on (+primed) | 147 | 3241 |
| PR | off | 131 | 3124 |
| PR | on (+primed) | 85 | 1159 |

💡 Be aware that if you test with enough orders, and with Query Monitor activated, you may run out of memory. So be ready to adjust that `php.ini` file and bump `memory_limit` accordingly (or else reduce the size of the test data set).

**How can this code break?**

Before this change, we passed an array of *all* related order IDs into the `related-orders.php` template whereas, with this change, a maximum of 10 IDs will be passed in. It's possible that, in some cases, our users will have implemented their own pagination (or have some other custom feature that depends on having access to the full range of IDs for some other reason).

I suspect this would be the exception rather than the rule, and if it surfaces we could initially guide them toward restoring the previous behaviour: for example, they could unhook `WC_Subscriptions_Order::get_related_orders_template()` from the `woocommerce_subscription_details_after_subscription_table` action, and replace it with a custom callback that follows the earlier strategy.

Additionally, it was previously the case that the [`woocommerce_subscription_related_orders`](https://github.com/Automattic/woocommerce-subscriptions-core/blob/8.1.1/includes/class-wc-subscription.php#L2116) filter hook would be invoked one or more times (once for each related order type, ie 'renewal', 'switch', etc) whereas with this change, that will no longer happen. Once again, this *could* cause issues in some cases, and the mitigation would be similar to what I described earlier.

## How to test this PR

If you want to look at performance characteristics, I'd recommend using Query Monitor. However, if, like me, you test using a 'real' customer account instead of the main admin account, Query Monitor output won't be available. You can fix this with a small snippet like this:

```php
/**
 * Make Query Monitor available to all users.
 * 
 * ⚠️ Remove after testing!
 */
add_action( 'init', function() {
	$user = wp_get_current_user();

	if ( is_object( $user ) ) {
		$user->add_cap( 'view_query_monitor' );
	}
} );
```

To functionally test pagination, you may also wish to generate a large-ish number of renewal orders. You can do this manually, via the subscription editor, by repeatedly running the *create pending renewal* order action. That could get a little tiresome, though, depending on how many orders you want to generate and so, though not perfect, you could also consider leveraging a bit of code like this:

```php
/**
 * This script can be used to quickly add a stack of renewals
 * to an existing subscription. Can be useful when testing
 * scalability concerns for WooCommerce Subscriptions.
 */
function generate_renewal_order_for_subscription( $subscription_id ) {
	$subscription = new WC_Subscription( $subscription_id );

	// We can't successfully trigger creation of a renewal unless the subscription
	// is active, which may not initially be the case.
	if ( 'active' !== $subscription->get_status() ) {
		$subscription->update_status( 'active' );
	}

	// Try triggering a renewal. This also often sets the subscription to on-hold,
	// so we again change the status.
	WC_Subscriptions_Manager::prepare_renewal( $subscription_id );
	$subscription->update_status( 'active' );
}

// Generate 100 renewals for the subscription (adjust the sub ID as needed).
for ( $i = 1; $i <= 100; $i++ ) {
	generate_renewal_order_for_subscription( 12345 ); // ⚠️ Supply actual subscription ID.
	print '.' . ( ( $i % 10 ) ? '' : PHP_EOL );       // Optional CLI progress dots :-)
}
```

For the testing itself, navigate to a suitable subscription on the frontend: **My Account  Subscriptions ‣ View Subscription**:

1. A maximum of 10 related orders will be rendered.
2. "First", "Previous", "Next" and "Last" pagination links will appear below the table.
3. If they are not useful (for instance, "First" or "Previous" are not useful if we are looking at page 1 of the results) then they still appear, and are still functional, but are styled a little differently by applying the `disabled` class.
4. No ajax magic here. However, the links take advantage of an anchor/ID to keep the customer in broadly the same part of the screen whenever they use the pagination controls.

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [x] Will this PR affect WooCommerce Subscriptions? **Yes → WOOSUBS-162**
- [x] Will this PR affect WooCommerce Payments? **No**
- [x] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0) **None*
