### PR TITLE
Fixed manual discounts on pay for order flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Subscriptions Core Changelog ***
 
+= 8.3.0 - 2025-xx-xx =
+* Fix - Manual discounts on pay for order flow
+
+
 = 8.2.0 - 2025-04-14 =
 * Update - Increase the number of args accepted by wcs_get_subscriptions(), to bring about parity with wc_get_orders().
 * Dev - Update wcs_maybe_prefix_key() and wcs_maybe_unprefix_key() to support an array of keys.

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1414,7 +1414,7 @@ class WCS_Cart_Renewal {
 
 		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.
 		if ( $order_discount !== $total_coupon_discount && $order_discount > $total_coupon_discount ) {
-			// If there is a manually applied discount, we need to add a pseudo coupon for the difference.
+			// If there is a manually applied discount, we need to add a coupon for the difference.
 			$coupons[] = $this->create_manual_discount_coupon( $order_discount - $total_coupon_discount );
 		}
 

--- a/includes/class-wcs-cart-renewal.php
+++ b/includes/class-wcs-cart-renewal.php
@@ -1407,26 +1407,15 @@ class WCS_Cart_Renewal {
 			$total_coupon_discount += floatval( array_sum( wc_list_pluck( $coupon_items, 'get_discount_tax' ) ) );
 		}
 
-		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.
-		$order_has_manual_discount = $order_discount !== $total_coupon_discount;
-
 		// Get all coupon line items as coupon objects.
 		if ( ! empty( $coupon_items ) ) {
 			$coupons = $this->get_line_item_coupons( $coupon_items );
 		}
 
-		if ( $order_has_manual_discount ) {
-			// Remove any coupon line items which don't grant free shipping.
-			foreach ( $coupons as $index => $coupon ) {
-				if ( ! $coupon->get_free_shipping() ) {
-					unset( $coupons[ $index ] );
-				}
-
-				// We're going to apply a coupon for the full order discount so make sure free shipping coupons don't apply any discount.
-				$coupon->set_amount( 0 );
-			}
-
-			$coupons[] = $this->get_pseudo_coupon( $order_discount );
+		// If the order total discount is different from the discount applied from coupons we have a manually applied discount.
+		if ( $order_discount !== $total_coupon_discount && $order_discount > $total_coupon_discount ) {
+			// If there is a manually applied discount, we need to add a pseudo coupon for the difference.
+			$coupons[] = $this->create_manual_discount_coupon( $order_discount - $total_coupon_discount );
 		}
 
 		foreach ( $coupons as $coupon ) {
@@ -1453,7 +1442,7 @@ class WCS_Cart_Renewal {
 					continue;
 				}
 
-				$coupon = $this->get_pseudo_coupon( $coupon_item->get_discount() );
+				$coupon = $this->create_manual_discount_coupon( $coupon_item->get_discount() );
 				$coupon->set_code( $coupon_item->get_code() );
 			} elseif ( 'subscription_renewal' === $this->cart_item_key ) {
 				$coupon_type = $coupon->get_discount_type();
@@ -1471,12 +1460,12 @@ class WCS_Cart_Renewal {
 	}
 
 	/**
-	 * Apply a pseudo coupon to the cart for a specific discount amount.
+	 * Apply a coupon to the cart for a specific discount amount.
 	 *
 	 * @param float $discount The discount amount.
 	 * @return WC_Coupon
 	 */
-	protected function get_pseudo_coupon( $discount ) {
+	protected function create_manual_discount_coupon( $discount ) {
 		$cart_types = array(
 			'subscription_initial_payment' => 'initial',
 			'subscription_renewal'         => 'renewal',
@@ -1486,9 +1475,7 @@ class WCS_Cart_Renewal {
 
 		// Generate a unique coupon code from the cart type.
 		$coupon = new WC_Coupon( "discount_{$cart_type}" );
-
-		// Apply our cart style pseudo coupon type and the set the amount.
-		$coupon->set_discount_type( "{$cart_type}_cart" );
+		$coupon->set_discount_type( 'fixed_cart' );
 		$coupon->set_amount( $discount );
 
 		return $coupon;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4233

## Description
This PR fixes a bug that when manually editing cost of one sub product ended up applying the discount to all sub products on the order

<!--
Write a brief summary about this PR. 
- Why is this change needed? 
- What does this change do? 
- Were there other solutions you considered? 
- Why did you choose to pursue this solution? 
- Describe any trade-offs you might have had to make.
-->

<!--
Questions for PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos as appropriate.
-->

## How to test this PR
**Setup**
- Checkout to this branch
- Create 2 subscription products with the same cadence
- Create a product discount coupon code (non-recurring) that only applies to one of the products you created
- Enable Check payment method
- Enable /wp-admin > WooCommerce > Settings > Subscriptions > Accept Manual Renewals

**Single use coupon**
- As a customer create an order with two subscription products with the same cadence
- Pay with Check
- As an admin edit the parent order created
- Add the discount coupon
- Give a manual discount to the other product
- Set the order status to `Pending Payment`
- Save the changes
- Copy the `Customer Payment Page` link
- As a customer open the link
- Make sure both the manual discount and the coupon discount showed up and are correct

**Recurring coupon**
- As a customer create an order with two subscription products with the same cadence
- Pay with Check
- As an admin edit the subscription
- Give a manual discount to one of the products
- Add the discount coupon
- Set the order status to `Pending Payment`
- Save the changes
- Delete the coupon
- Create a renewal order
- Copy the `Customer Payment Page` link from the renewal order
- As a customer open the link
- Make sure both the manual discount and the coupon discount showed up and are correct

## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
