### PR TITLE
Add PHP coverage checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 		"phpunit/phpunit": "9.5.14",
 		"woocommerce/woocommerce-sniffs": "0.1.0",
 		"dave-liddament/sarb": "^1.1",
-		"yoast/phpunit-polyfills": "1.1.0"
+		"yoast/phpunit-polyfills": "1.1.0",
+		"rregeer/phpunit-coverage-check": "^0.3.1"
 	},
 	"scripts": {
 		"phpcs": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cd4c7d25ece957ea841b92cb1646a67",
+    "content-hash": "f8dcea64b8fdf48fc7a4775baf049d9b",
     "packages": [
         {
             "name": "composer/installers",
@@ -1460,6 +1460,52 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
             "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "rregeer/phpunit-coverage-check",
+            "version": "0.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/richardregeer/phpunit-coverage-check.git",
+                "reference": "9618fa74477fbc448c1b0599bef5153d170094bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/richardregeer/phpunit-coverage-check/zipball/9618fa74477fbc448c1b0599bef5153d170094bd",
+                "reference": "9618fa74477fbc448c1b0599bef5153d170094bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "bin": [
+                "bin/coverage-check"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Richard Regeer",
+                    "email": "rich2309@gmail.com"
+                }
+            ],
+            "description": "Check the code coverage using the clover report of phpunit",
+            "keywords": [
+                "ci",
+                "code coverage",
+                "php",
+                "phpunit",
+                "testing",
+                "unittest"
+            ],
+            "support": {
+                "issues": "https://github.com/richardregeer/phpunit-coverage-check/issues",
+                "source": "https://github.com/richardregeer/phpunit-coverage-check/tree/0.3.1"
+            },
+            "time": "2019-10-14T07:04:13+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4070,15 +4116,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
 	"main": "Gruntfile.js",
 	"config": {
 		"translate": true,
-		"version_replace_paths": ["includes/"]
+		"version_replace_paths": [
+			"includes/"
+		]
 	},
 	"repository": {
 		"type": "git",
@@ -39,6 +41,8 @@
 		"start": "wp-scripts start assets/src/js/index.js",
 		"test:unit": "wp-scripts test-unit-js",
 		"test:php": "./vendor/bin/phpunit",
+		"test:php-coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit",
+		"test:php-check-coverage": "./vendor/bin/coverage-check ./coverage/clover.xml 50 --only-percentage",
 		"makepot": "wp i18n make-pot . languages/woocommerce-subscriptions.pot",
 		"prearchive": "rm -rf woocommerce-subscriptions-core && rm -rf woocommerce-subscriptions-core.zip",
 		"postarchive": "unzip woocommerce-subscriptions-core.zip -d woocommerce-subscriptions-core && rm woocommerce-subscriptions-core.zip && zip -r woocommerce-subscriptions-core.zip woocommerce-subscriptions-core && rm -rf woocommerce-subscriptions-core"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,4 +13,27 @@
 		</testsuite>
 	</testsuites>
 
+	<coverage processUncoveredFiles="false">
+		<include>
+			<directory suffix=".php">includes/</directory>
+			<file>wcs-functions.php</file>
+			<file>woocommerce-subscriptions-core.php</file>
+		</include>
+
+		<exclude>
+			<directory suffix=".php">includes/admin/debug-tools</directory>
+			<directory suffix=".php">includes/admin/meta-boxes/views/</directory>
+			<directory suffix=".php">includes/deprecated</directory>
+			<directory suffix=".php">includes/gateways/paypal/includes/deprecated</directory>
+			<directory suffix=".php">includes/gateways/paypal/includes/templates</directory>
+			<directory suffix=".php">includes/interfaces/</directory>
+			<directory suffix=".php">includes/legacy/</directory>
+			<directory suffix=".php">includes/upgrades/templates/</directory>
+		</exclude>
+
+		<report>
+			<clover outputFile="coverage/clover.xml" />
+			<html outputDirectory="coverage" />
+		</report>
+	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,6 @@
 		<include>
 			<directory suffix=".php">includes/</directory>
 			<file>wcs-functions.php</file>
-			<file>woocommerce-subscriptions-core.php</file>
 		</include>
 
 		<exclude>

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,10 +18,26 @@ $ bin/install-wp-tests.sh <db-name> <db-user> <db-password> [db-host]
 
 Tip: try using `127.0.0.1` for the DB host if the default `localhost` isn't working.
 
-3. Run the tests from the plugin root directory using
+## Running tests
+
+Run the tests from the plugin root directory using
 
 ```
-$ ./vendor/bin/phpunit
+$ npm run test:php
+```
+
+For running tests with PHP code coverage report. Note you'll need to have [XDebug](https://xdebug.org/docs/install) installed and configured.
+
+```
+$ npm run test:php-coverage
+```
+
+Report files will be created in `coverage/` folder. Open index.html for inspecting HTML report.
+
+For getting overal coverage stats:
+
+```
+npm run test:php-check-coverage
 ```
 
 ### Tips
@@ -34,6 +50,6 @@ If you have MySQL installed via a socket (like with Local), your install command
 bin/install-wp-tests.sh <db-name> <db-user> <db-password> "localhost:/Users/{username}/Library/ApplicationSupport/Local/run/Qm1DpkUyd/mysql/mysqld.sock"
 ```
 
-You can find the socket location in your Local database settings. 
+You can find the socket location in your Local database settings.
 
 <img width="500" alt="Screenshot 2024-04-12 at 10 29 07 am" src="https://github.com/Automattic/woocommerce-subscriptions-core/assets/8490476/fbd62f4e-de0f-4c20-b44c-c10365a1343f">


### PR DESCRIPTION
## Description

Add scripts for generating coverage reports and checking overall coverage.

For now I've excluded a few things:

- views (templates)
- legacy and deprecated code
- php interfaces

## How to test this PR

Testing scripts:

1. Follow setup instructions in tests/README.md
2. Run tests with coverage report
3. Check overal coverage and html report locally.

Testing config:

1. Review coverage config in phpunit.xml.dist
2. Inspect excluded folders and files list.
3. Check if anything else is missing or should not be in that list.

## Product impact

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
