### PR TITLE
Replaced {blogname} with {site_title} in email templates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 8.3.0 - 2025-xx-xx =
 * Fix - Manual discounts on pay for order flow
+* Fix - Replace blogname with site_title in email templates
 
 
 = 8.2.0 - 2025-04-14 =

--- a/includes/emails/class-wcs-email-cancelled-subscription.php
+++ b/includes/emails/class-wcs-email-cancelled-subscription.php
@@ -27,8 +27,8 @@ class WCS_Email_Cancelled_Subscription extends WC_Email {
 		$this->description = __( 'Cancelled Subscription emails are sent when a customer\'s subscription is cancelled (either by a store manager, or the customer).', 'woocommerce-subscriptions' );
 
 		$this->heading     = __( 'Subscription Cancelled', 'woocommerce-subscriptions' );
-		// translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
-		$this->subject     = sprintf( _x( '[%s] Subscription Cancelled', 'default email subject for cancelled emails sent to the admin', 'woocommerce-subscriptions' ), '{blogname}' );
+		// translators: placeholder is {site_title}, a variable that will be substituted when email is sent out
+		$this->subject     = sprintf( _x( '[%s] Subscription Cancelled', 'default email subject for cancelled emails sent to the admin', 'woocommerce-subscriptions' ), '{site_title}' );
 
 		$this->template_html  = 'emails/cancelled-subscription.php';
 		$this->template_plain = 'emails/plain/cancelled-subscription.php';

--- a/includes/emails/class-wcs-email-completed-renewal-order.php
+++ b/includes/emails/class-wcs-email-completed-renewal-order.php
@@ -27,8 +27,8 @@ class WCS_Email_Completed_Renewal_Order extends WC_Email_Customer_Completed_Orde
 		$this->customer_email = true;
 
 		$this->heading        = _x( 'Your renewal order is complete', 'Default email heading for email to customer on completed renewal order', 'woocommerce-subscriptions' );
-		// translators: $1: {blogname}, $2: {order_date}, variables that will be substituted when email is sent out
-		$this->subject        = sprintf( _x( 'Your %1$s renewal order from %2$s is complete', 'Default email subject for email to customer on completed renewal order', 'woocommerce-subscriptions' ), '{blogname}', '{order_date}' );
+		// translators: $1: {site_title}, $2: {order_date}, variables that will be substituted when email is sent out
+		$this->subject        = sprintf( _x( 'Your %1$s renewal order from %2$s is complete', 'Default email subject for email to customer on completed renewal order', 'woocommerce-subscriptions' ), '{site_title}', '{order_date}' );
 
 		$this->template_html  = 'emails/customer-completed-renewal-order.php';
 		$this->template_plain = 'emails/plain/customer-completed-renewal-order.php';
@@ -178,8 +178,8 @@ class WCS_Email_Completed_Renewal_Order extends WC_Email_Customer_Completed_Orde
 
 		} elseif ( 'subject_downloadable' === $key ) {
 			wcs_deprecated_argument( __CLASS__ . '::$' . $key, '5.6.0', 'The subject_downloadabl property used for emails with downloadable files was removed in WooCommerce 3.1. Use the subject property instead.' );
-			// translators: $1: {blogname}, $2: {order_date}, variables will be substituted when email is sent out
-			return $this->get_option( 'subject_downloadable', sprintf( _x( 'Your %1$s subscription renewal order from %2$s is complete - download your files', 'Default email subject for email with downloadable files in it', 'woocommerce-subscriptions' ), '{blogname}', '{order_date}' ) );
+			// translators: $1: {site_title}, $2: {order_date}, variables will be substituted when email is sent out
+			return $this->get_option( 'subject_downloadable', sprintf( _x( 'Your %1$s subscription renewal order from %2$s is complete - download your files', 'Default email subject for email with downloadable files in it', 'woocommerce-subscriptions' ), '{site_title}', '{order_date}' ) );
 
 		} else {
 			return;

--- a/includes/emails/class-wcs-email-completed-switch-order.php
+++ b/includes/emails/class-wcs-email-completed-switch-order.php
@@ -33,7 +33,7 @@ class WCS_Email_Completed_Switch_Order extends WC_Email_Customer_Completed_Order
 		$this->customer_email = true;
 
 		$this->heading        = __( 'Your subscription change is complete', 'woocommerce-subscriptions' );
-		$this->subject        = __( 'Your {blogname} subscription change from {order_date} is complete', 'woocommerce-subscriptions' );
+		$this->subject        = __( 'Your {site_title} subscription change from {order_date} is complete', 'woocommerce-subscriptions' );
 
 		$this->template_html  = 'emails/customer-completed-switch-order.php';
 		$this->template_plain = 'emails/plain/customer-completed-switch-order.php';
@@ -187,7 +187,7 @@ class WCS_Email_Completed_Switch_Order extends WC_Email_Customer_Completed_Order
 
 		} elseif ( 'subject_downloadable' === $key ) {
 			wcs_deprecated_argument( __CLASS__ . '::$' . $key, '5.6.0', 'The subject_downloadable property used for emails with downloadable files was removed in WooCommerce 3.1. Use the subject property instead.' );
-			return $this->get_option( 'subject_downloadable', __( 'Your {blogname} subscription change from {order_date} is complete - download your files', 'woocommerce-subscriptions' ) );
+			return $this->get_option( 'subject_downloadable', __( 'Your {site_title} subscription change from {order_date} is complete - download your files', 'woocommerce-subscriptions' ) );
 
 		} else {
 			return;

--- a/includes/emails/class-wcs-email-customer-on-hold-renewal-order.php
+++ b/includes/emails/class-wcs-email-customer-on-hold-renewal-order.php
@@ -22,7 +22,7 @@ class WCS_Email_Customer_On_Hold_Renewal_Order extends WC_Email_Customer_On_Hold
 		$this->customer_email = true;
 		$this->title          = __( 'On-hold Renewal Order', 'woocommerce-subscriptions' );
 		$this->description    = __( 'This is an order notification sent to customers containing order details after a renewal order is placed on-hold.', 'woocommerce-subscriptions' );
-		$this->subject        = __( 'Your {blogname} renewal order has been received!', 'woocommerce-subscriptions' );
+		$this->subject        = __( 'Your {site_title} renewal order has been received!', 'woocommerce-subscriptions' );
 		$this->heading        = __( 'Thank you for your renewal order', 'woocommerce-subscriptions' );
 		$this->template_html  = 'emails/customer-on-hold-renewal-order.php';
 		$this->template_plain = 'emails/plain/customer-on-hold-renewal-order.php';

--- a/includes/emails/class-wcs-email-expired-subscription.php
+++ b/includes/emails/class-wcs-email-expired-subscription.php
@@ -27,8 +27,8 @@ class WCS_Email_Expired_Subscription extends WC_Email {
 		$this->description = __( 'Expired Subscription emails are sent when a customer\'s subscription expires.', 'woocommerce-subscriptions' );
 
 		$this->heading     = __( 'Subscription Expired', 'woocommerce-subscriptions' );
-		// translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
-		$this->subject     = sprintf( _x( '[%s] Subscription Expired', 'default email subject for expired emails sent to the admin', 'woocommerce-subscriptions' ), '{blogname}' );
+		// translators: placeholder is {site_title}, a variable that will be substituted when email is sent out
+		$this->subject     = sprintf( _x( '[%s] Subscription Expired', 'default email subject for expired emails sent to the admin', 'woocommerce-subscriptions' ), '{site_title}' );
 
 		$this->template_html  = 'emails/expired-subscription.php';
 		$this->template_plain = 'emails/plain/expired-subscription.php';

--- a/includes/emails/class-wcs-email-new-renewal-order.php
+++ b/includes/emails/class-wcs-email-new-renewal-order.php
@@ -23,7 +23,7 @@ class WCS_Email_New_Renewal_Order extends WC_Email_New_Order {
 		$this->description    = __( 'New renewal order emails are sent when a subscription renewal payment is processed.', 'woocommerce-subscriptions' );
 
 		$this->heading        = __( 'New subscription renewal order', 'woocommerce-subscriptions' );
-		$this->subject        = __( '[{blogname}] New subscription renewal order ({order_number}) - {order_date}', 'woocommerce-subscriptions' );
+		$this->subject        = __( '[{site_title}] New subscription renewal order ({order_number}) - {order_date}', 'woocommerce-subscriptions' );
 
 		$this->template_html  = 'emails/admin-new-renewal-order.php';
 		$this->template_plain = 'emails/plain/admin-new-renewal-order.php';

--- a/includes/emails/class-wcs-email-new-switch-order.php
+++ b/includes/emails/class-wcs-email-new-switch-order.php
@@ -28,7 +28,7 @@ class WCS_Email_New_Switch_Order extends WC_Email_New_Order {
 		$this->description    = __( 'Subscription switched emails are sent when a customer switches a subscription.', 'woocommerce-subscriptions' );
 
 		$this->heading        = __( 'Subscription Switched', 'woocommerce-subscriptions' );
-		$this->subject        = __( '[{blogname}] Subscription Switched ({order_number}) - {order_date}', 'woocommerce-subscriptions' );
+		$this->subject        = __( '[{site_title}] Subscription Switched ({order_number}) - {order_date}', 'woocommerce-subscriptions' );
 
 		$this->template_html  = 'emails/admin-new-switch-order.php';
 		$this->template_plain = 'emails/plain/admin-new-switch-order.php';

--- a/includes/emails/class-wcs-email-on-hold-subscription.php
+++ b/includes/emails/class-wcs-email-on-hold-subscription.php
@@ -27,8 +27,8 @@ class WCS_Email_On_Hold_Subscription extends WC_Email {
 		$this->description = __( 'Suspended Subscription emails are sent when a customer manually suspends their subscription.', 'woocommerce-subscriptions' );
 
 		$this->heading     = __( 'Subscription Suspended', 'woocommerce-subscriptions' );
-		// translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
-		$this->subject     = sprintf( _x( '[%s] Subscription Suspended', 'default email subject for suspended emails sent to the admin', 'woocommerce-subscriptions' ), '{blogname}' );
+		// translators: placeholder is {site_title}, a variable that will be substituted when email is sent out
+		$this->subject     = sprintf( _x( '[%s] Subscription Suspended', 'default email subject for suspended emails sent to the admin', 'woocommerce-subscriptions' ), '{site_title}' );
 
 		$this->template_html  = 'emails/on-hold-subscription.php';
 		$this->template_plain = 'emails/plain/on-hold-subscription.php';

--- a/includes/emails/class-wcs-email-processing-renewal-order.php
+++ b/includes/emails/class-wcs-email-processing-renewal-order.php
@@ -26,7 +26,7 @@ class WCS_Email_Processing_Renewal_Order extends WC_Email_Customer_Processing_Or
 		$this->customer_email = true;
 
 		$this->heading        = __( 'Thank you for your order', 'woocommerce-subscriptions' );
-		$this->subject        = __( 'Your {blogname} renewal order receipt from {order_date}', 'woocommerce-subscriptions' );
+		$this->subject        = __( 'Your {site_title} renewal order receipt from {order_date}', 'woocommerce-subscriptions' );
 
 		$this->template_html  = 'emails/customer-processing-renewal-order.php';
 		$this->template_plain = 'emails/plain/customer-processing-renewal-order.php';

--- a/languages/woocommerce-subscriptions-fr.po
+++ b/languages/woocommerce-subscriptions-fr.po
@@ -317,8 +317,8 @@ msgid "Thank you for your renewal order"
 msgstr "Merci pour votre commande de renouvellement"
 
 #: includes/emails/class-wcs-email-customer-on-hold-renewal-order.php:25
-msgid "Your {blogname} renewal order has been received!"
-msgstr "Votre commande de renouvellement de {blogname} a été reçue !"
+msgid "Your {site_title} renewal order has been received!"
+msgstr "Votre commande de renouvellement de {site_title} a été reçue !"
 
 #: includes/emails/class-wcs-email-customer-on-hold-renewal-order.php:24
 msgid ""
@@ -2021,14 +2021,14 @@ msgctxt "item name sent to paypal"
 msgid "Subscription %1$s - %2$s"
 msgstr "Abonnement %1$s - %2$s"
 
-#. translators: placeholder is {blogname}, a variable that will be substituted
+#. translators: placeholder is {site_title}, a variable that will be substituted
 #. when email is sent out
 #: includes/emails/class-wcs-email-on-hold-subscription.php:31
 msgctxt "default email subject for suspended emails sent to the admin"
 msgid "[%s] Subscription Suspended"
 msgstr "[%s] Abonnement suspendu"
 
-#. translators: placeholder is {blogname}, a variable that will be substituted
+#. translators: placeholder is {site_title}, a variable that will be substituted
 #. when email is sent out
 #: includes/emails/class-wcs-email-expired-subscription.php:31
 msgctxt "default email subject for expired emails sent to the admin"
@@ -4216,7 +4216,7 @@ msgctxt ""
 msgid "#"
 msgstr "n°"
 
-#. translators: $1: {blogname}, $2: {order_date}, variables will be substituted
+#. translators: $1: {site_title}, $2: {order_date}, variables will be substituted
 #. when email is sent out
 #: includes/emails/class-wcs-email-completed-renewal-order.php:40
 msgctxt "Default email subject for email with downloadable files in it"
@@ -4234,7 +4234,7 @@ msgstr ""
 "Votre commande de renouvellement d’abonnement est terminée, téléchargez vos "
 "fichiers"
 
-#. translators: $1: {blogname}, $2: {order_date}, variables that will be
+#. translators: $1: {site_title}, $2: {order_date}, variables that will be
 #. substituted when email is sent out
 #: includes/emails/class-wcs-email-completed-renewal-order.php:31
 msgctxt ""
@@ -4264,7 +4264,7 @@ msgctxt ""
 msgid "Email Heading"
 msgstr "En-tête de l’e-mail"
 
-#. translators: placeholder is {blogname}, a variable that will be substituted
+#. translators: placeholder is {site_title}, a variable that will be substituted
 #. when email is sent out
 #: includes/emails/class-wcs-email-cancelled-subscription.php:31
 msgctxt "default email subject for cancelled emails sent to the admin"
@@ -5999,8 +5999,8 @@ msgstr ""
 "désirez mettre en place une alternative."
 
 #: includes/emails/class-wcs-email-new-switch-order.php:26
-msgid "[{blogname}] Subscription Switched ({order_number}) - {order_date}"
-msgstr "[{blogname}] Abonnement changé ({order_number}) - {order_date}"
+msgid "[{site_title}] Subscription Switched ({order_number}) - {order_date}"
+msgstr "[{site_title}] Abonnement changé ({order_number}) - {order_date}"
 
 #: includes/emails/class-wcs-email-new-switch-order.php:23
 msgid ""
@@ -6017,9 +6017,9 @@ msgstr "Abonnement changé"
 
 #: includes/emails/class-wcs-email-new-renewal-order.php:26
 msgid ""
-"[{blogname}] New subscription renewal order ({order_number}) - {order_date}"
+"[{site_title}] New subscription renewal order ({order_number}) - {order_date}"
 msgstr ""
-"[{blogname}] Nouvelle commande de renouvellement d’abonnement ({order_number}"
+"[{site_title}] Nouvelle commande de renouvellement d’abonnement ({order_number}"
 ") - {order_date}"
 
 #: includes/emails/class-wcs-email-new-renewal-order.php:25
@@ -6052,8 +6052,8 @@ msgid "Customer Renewal Invoice"
 msgstr "Facture de renouvellement client"
 
 #: includes/emails/class-wcs-email-processing-renewal-order.php:29
-msgid "Your {blogname} renewal order receipt from {order_date}"
-msgstr "Votre reçu de commande de renouvellement de {blogname} du {order_date}"
+msgid "Your {site_title} renewal order receipt from {order_date}"
+msgstr "Votre reçu de commande de renouvellement de {site_title} du {order_date}"
 
 #: includes/emails/class-wcs-email-processing-renewal-order.php:28
 msgid "Thank you for your order"
@@ -6075,10 +6075,10 @@ msgstr "Traitement de la commande de renouvellement"
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:39
 msgid ""
-"Your {blogname} subscription change from {order_date} is complete - download "
+"Your {site_title} subscription change from {order_date} is complete - download "
 "your files"
 msgstr ""
-"Votre changement d’abonnement de {blogname} du {order_date} est terminé, "
+"Votre changement d’abonnement de {site_title} du {order_date} est terminé, "
 "téléchargez vos fichiers"
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:38
@@ -6086,9 +6086,9 @@ msgid "Your subscription change is complete - download your files"
 msgstr "Votre changement d’abonnement est terminé, téléchargez vos fichiers"
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:31
-msgid "Your {blogname} subscription change from {order_date} is complete"
+msgid "Your {site_title} subscription change from {order_date} is complete"
 msgstr ""
-"Votre changement d’abonnement de {blogname} du {order_date} est terminé"
+"Votre changement d’abonnement de {site_title} du {order_date} est terminé"
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:30
 msgid "Your subscription change is complete"

--- a/languages/woocommerce-subscriptions.pot
+++ b/languages/woocommerce-subscriptions.pot
@@ -4038,7 +4038,7 @@ msgstr ""
 msgid "Subscription Cancelled"
 msgstr ""
 
-#. translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
+#. translators: placeholder is {site_title}, a variable that will be substituted when email is sent out
 #: includes/emails/class-wcs-email-cancelled-subscription.php:31
 msgctxt "default email subject for cancelled emails sent to the admin"
 msgid "[%s] Subscription Cancelled"
@@ -4146,7 +4146,7 @@ msgctxt "Default email heading for email to customer on completed renewal order"
 msgid "Your renewal order is complete"
 msgstr ""
 
-#. translators: $1: {blogname}, $2: {order_date}, variables that will be substituted when email is sent out
+#. translators: $1: {site_title}, $2: {order_date}, variables that will be substituted when email is sent out
 #: includes/emails/class-wcs-email-completed-renewal-order.php:31
 msgctxt "Default email subject for email to customer on completed renewal order"
 msgid "Your %1$s renewal order from %2$s is complete"
@@ -4157,7 +4157,7 @@ msgctxt "Default email heading for email with downloadable files in it"
 msgid "Your subscription renewal order is complete - download your files"
 msgstr ""
 
-#. translators: $1: {blogname}, $2: {order_date}, variables will be substituted when email is sent out
+#. translators: $1: {site_title}, $2: {order_date}, variables will be substituted when email is sent out
 #: includes/emails/class-wcs-email-completed-renewal-order.php:40
 msgctxt "Default email subject for email with downloadable files in it"
 msgid "Your %1$s subscription renewal order from %2$s is complete - download your files"
@@ -4176,7 +4176,7 @@ msgid "Your subscription change is complete"
 msgstr ""
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:31
-msgid "Your {blogname} subscription change from {order_date} is complete"
+msgid "Your {site_title} subscription change from {order_date} is complete"
 msgstr ""
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:38
@@ -4184,7 +4184,7 @@ msgid "Your subscription change is complete - download your files"
 msgstr ""
 
 #: includes/emails/class-wcs-email-completed-switch-order.php:39
-msgid "Your {blogname} subscription change from {order_date} is complete - download your files"
+msgid "Your {site_title} subscription change from {order_date} is complete - download your files"
 msgstr ""
 
 #: includes/emails/class-wcs-email-customer-on-hold-renewal-order.php:23
@@ -4196,7 +4196,7 @@ msgid "This is an order notification sent to customers containing order details 
 msgstr ""
 
 #: includes/emails/class-wcs-email-customer-on-hold-renewal-order.php:25
-msgid "Your {blogname} renewal order has been received!"
+msgid "Your {site_title} renewal order has been received!"
 msgstr ""
 
 #: includes/emails/class-wcs-email-customer-on-hold-renewal-order.php:26
@@ -4247,7 +4247,7 @@ msgstr ""
 msgid "Subscription Expired"
 msgstr ""
 
-#. translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
+#. translators: placeholder is {site_title}, a variable that will be substituted when email is sent out
 #: includes/emails/class-wcs-email-expired-subscription.php:31
 msgctxt "default email subject for expired emails sent to the admin"
 msgid "[%s] Subscription Expired"
@@ -4277,7 +4277,7 @@ msgid "New subscription renewal order"
 msgstr ""
 
 #: includes/emails/class-wcs-email-new-renewal-order.php:26
-msgid "[{blogname}] New subscription renewal order ({order_number}) - {order_date}"
+msgid "[{site_title}] New subscription renewal order ({order_number}) - {order_date}"
 msgstr ""
 
 #: includes/emails/class-wcs-email-new-switch-order.php:22
@@ -4290,7 +4290,7 @@ msgid "Subscription switched emails are sent when a customer switches a subscrip
 msgstr ""
 
 #: includes/emails/class-wcs-email-new-switch-order.php:26
-msgid "[{blogname}] Subscription Switched ({order_number}) - {order_date}"
+msgid "[{site_title}] Subscription Switched ({order_number}) - {order_date}"
 msgstr ""
 
 #: includes/emails/class-wcs-email-on-hold-subscription.php:26
@@ -4305,7 +4305,7 @@ msgstr ""
 msgid "Subscription Suspended"
 msgstr ""
 
-#. translators: placeholder is {blogname}, a variable that will be substituted when email is sent out
+#. translators: placeholder is {site_title}, a variable that will be substituted when email is sent out
 #: includes/emails/class-wcs-email-on-hold-subscription.php:31
 msgctxt "default email subject for suspended emails sent to the admin"
 msgid "[%s] Subscription Suspended"
@@ -4340,7 +4340,7 @@ msgid "Thank you for your order"
 msgstr ""
 
 #: includes/emails/class-wcs-email-processing-renewal-order.php:29
-msgid "Your {blogname} renewal order receipt from {order_date}"
+msgid "Your {site_title} renewal order receipt from {order_date}"
 msgstr ""
 
 #. translators: 1-2: opening/closing tags - link to documentation.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-subscriptions/issues/4411

## Description

This PR replaces {blogname} with {site_title}. blogname has been deprecated in Woo core 3.2 and a patch re-added to Woo core 3.3 but when a plugin/theme hooks into `woocommerce_email_format_string_replace` or `woocommerce_email_format_string_find` a bug prevents blogname from being replaced with the actual blogname.

More details [here](https://github.com/woocommerce/woocommerce/issues/57574#issuecomment-2845769279)

## How to test this PR
- Checkout to this branch
- Go to /wp-admin > Settings > Emails > Subscription Switch Completed
- Make sure the {site_title} gets replaced with the actual site_title
- Add this code to your functions.php file or to the plugin main file
```
 add_filter( 'woocommerce_email_format_string_find',
	function( $legacy_find, $that ) {
		return $legacy_find;
	},
	20,
	2
);
```
- Reload the admin page and make sure the {site_title} got replaced


## Product impact
<!-- What products will this PR ship in? -->

- [x] Added changelog entry (or does not apply)
- [ ] Will this PR affect WooCommerce Subscriptions? yes/no/tbc, add issue ref
- [ ] Will this PR affect WooCommerce Payments? yes/no/tbc, add issue ref
- [ ] <!-- 🚨 Deprecations 🚨 --> Added deprecated functions, hooks or classes to the [spreadsheet](https://docs.google.com/spreadsheets/d/1xw9xszcPMnWsp4C8OKZMsLzZob7tOmWT7qMqmEIq314/edit#gid=0)
